### PR TITLE
fix/implement stepup reverification

### DIFF
--- a/docs/implementation_plans/fix-investigate-clerk-no-gmail_v8.md
+++ b/docs/implementation_plans/fix-investigate-clerk-no-gmail_v8.md
@@ -1,0 +1,41 @@
+# Fixing the Google Connect Button Logic (V8)
+
+## Goal Description
+The Google Connect button fails when clicked by a user whose Google account is in an `unverified` (disconnected) state. This happens because the component attempts to call `.reauthorize()` on the existing but disconnected `ExternalAccountResource`. The `.reauthorize()` method expects the account to be fully verified and is strictly meant for stepping up scopes. For unverified or disconnected accounts, it fails silently or throws.
+
+We need to update the client component so that it only calls `.reauthorize()` if the account is actively verified, and falls back to `.createExternalAccount()` for unverified/disconnected accounts.
+
+## Proposed Changes
+
+### 1. Update Connection Logic
+#### [MODIFY] src/app/dashboard/ConnectGoogleWarning.tsx
+- Change the `handleConnect` conditional logic:
+```tsx
+  const existingGoogleAccount = user.externalAccounts.find(acc => 
+    acc.provider === 'google' || (acc.provider as any) === 'oauth_google'
+  );
+  
+  let verificationUrl: string | undefined;
+
+  if (existingGoogleAccount && existingGoogleAccount.verification?.status === 'verified') {
+    // If they have an active account but missing scopes, FORCE reauthorization
+    const response = await existingGoogleAccount.reauthorize({ 
+      additionalScopes: ['https://www.googleapis.com/auth/gmail.modify'],
+      redirectUrl: window.location.href 
+    });
+    verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
+  } else {
+    // If they never linked Google OR if it was disconnected (unverified)
+    const response = await user.createExternalAccount({
+      strategy: "oauth_google",
+      redirectUrl: window.location.href,
+    });
+    verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
+  }
+```
+
+## Verification Plan
+Manual Testing:
+1. Ensure the user's dashboard is yellow with a missing Google connection alert.
+2. Click the 'Sign in with Google' button.
+3. Verify that the browser is successfully redirected to Google's OAuth consent screen instead of hanging.

--- a/docs/implementation_plans/fix-investigate-clerk-no-gmail_v9.md
+++ b/docs/implementation_plans/fix-investigate-clerk-no-gmail_v9.md
@@ -1,0 +1,40 @@
+# Handling Clerk Step-Up Authentication (V9)
+
+## Goal Description
+When attempting to connect or reconnect a Google account, Clerk often requires "Step-Up Authentication" (reverification) to ensure a malicious actor hasn't hijacked an active session to link their own external accounts. The programmatic `.createExternalAccount()` and `.destroy()` SDK methods do not bypass this; instead, they halt and throw a "You need to provide additional verification to perform this operation" error.
+
+To robustly handle this, we will implement Clerk's native `useReverification()` hook. This hook acts as a wrapper around any sensitive async action: if the action throws a reverification error, the hook intercepts it, automatically pops up the beautiful native Clerk User Profile modal asking them to verify their password/passkey/email, and upon success, automatically re-executes our original connection logic!
+
+## Proposed Changes
+
+### 1. Robust Client-Side Connection and Hook Integration
+#### [MODIFY] src/app/dashboard/ConnectGoogleWarning.tsx
+- Import `useReverification` from `@clerk/nextjs`.
+- Extract the core connection logic (destroying existing unverified accounts, creating new accounts, or reauthorizing existing verified accounts) into a distinct async `connectAction` function.
+- Wrap `connectAction` with the hook: `const enhancedConnectAction = useReverification(connectAction);`
+- Update the `handleConnect` onClick handler to simply `await enhancedConnectAction()`.
+
+```tsx
+// Example Logic:
+const connectAction = async () => {
+  /* ... destroy if unverified, reauthorize if verified, create if new ... */
+}
+const enhancedConnectAction = useReverification(connectAction);
+
+const handleConnect = async () => {
+  setIsLoading(true);
+  try {
+    await enhancedConnectAction();
+  } catch (error) {
+    setIsLoading(false);
+  }
+}
+```
+
+## Verification Plan
+1. Let the browser subagent log in and navigate to the dashboard.
+2. In the Clerk UI, disconnect the Google account to enter the "unverified" state.
+3. Refresh the dashboard and click "Sign in with Google".
+4. The Clerk Step-Up Authentication modal will pop up natively requesting a password or code.
+5. Have the subagent complete the challenge.
+6. Verify the browser instantly proceeds to the Google OAuth consent screen.

--- a/src/app/dashboard/ConnectGoogleWarning.tsx
+++ b/src/app/dashboard/ConnectGoogleWarning.tsx
@@ -24,6 +24,12 @@ export function ConnectGoogleWarning() {
         verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
       } else {
         // If they never linked Google OR if it was disconnected (unverified), create a new connection
+        if (existingGoogleAccount) {
+          // Clean up the disconnected/unverified account before creating a new one
+          // Otherwise Clerk throws an error because the strategy already exists on their profile
+          await existingGoogleAccount.destroy();
+        }
+        
         const response = await user.createExternalAccount({
           strategy: "oauth_google",
           redirectUrl: window.location.href,

--- a/src/app/dashboard/ConnectGoogleWarning.tsx
+++ b/src/app/dashboard/ConnectGoogleWarning.tsx
@@ -15,21 +15,15 @@ export function ConnectGoogleWarning() {
       
       let verificationUrl: string | undefined;
 
-      if (existingGoogleAccount && existingGoogleAccount.verification?.status === 'verified') {
-        // If they have an active account but missing scopes, FORCE reauthorization with explicit additional scopes
+      if (existingGoogleAccount) {
+        // If they have an active or unverified account but missing scopes, FORCE reauthorization with explicit additional scopes
         const response = await existingGoogleAccount.reauthorize({ 
           additionalScopes: ['https://www.googleapis.com/auth/gmail.modify'],
           redirectUrl: window.location.href 
         });
         verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
       } else {
-        // If they never linked Google OR if it was disconnected (unverified), create a new connection
-        if (existingGoogleAccount) {
-          // Clean up the disconnected/unverified account before creating a new one
-          // Otherwise Clerk throws an error because the strategy already exists on their profile
-          await existingGoogleAccount.destroy();
-        }
-        
+        // If they never linked Google, create a new connection
         const response = await user.createExternalAccount({
           strategy: "oauth_google",
           redirectUrl: window.location.href,

--- a/src/app/dashboard/ConnectGoogleWarning.tsx
+++ b/src/app/dashboard/ConnectGoogleWarning.tsx
@@ -1,43 +1,55 @@
 "use client";
 
-import { useUser } from "@clerk/nextjs";
+import { useUser, useReverification } from "@clerk/nextjs";
 import { useState } from "react";
+import { isReverificationCancelledError } from "@clerk/nextjs/errors";
 
 export function ConnectGoogleWarning() {
   const { user } = useUser();
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleConnect = async () => {
+  const connectAction = async () => {
     if (!user) return;
+    const existingGoogleAccount = user.externalAccounts.find(acc => acc.provider === 'google' || acc.provider === 'oauth_google' as any);
+      
+    let verificationUrl: string | undefined;
+
+    if (existingGoogleAccount && existingGoogleAccount.verification?.status === 'verified') {
+      const response = await existingGoogleAccount.reauthorize({ 
+        additionalScopes: ['https://www.googleapis.com/auth/gmail.modify'],
+        redirectUrl: window.location.href 
+      });
+      verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
+    } else {
+      if (existingGoogleAccount) {
+        await existingGoogleAccount.destroy();
+      }
+      const response = await user.createExternalAccount({
+        strategy: "oauth_google",
+        redirectUrl: window.location.href,
+      });
+      verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
+    }
+
+    if (verificationUrl) {
+      window.location.href = verificationUrl;
+    } else {
+      setIsLoading(false); // In case it returns without a URL
+    }
+  };
+
+  const enhancedConnectAction = useReverification(connectAction);
+
+  const handleConnect = async () => {
     setIsLoading(true);
     try {
-      const existingGoogleAccount = user.externalAccounts.find(acc => acc.provider === 'google' || acc.provider === 'oauth_google' as any);
-      
-      let verificationUrl: string | undefined;
-
-      if (existingGoogleAccount) {
-        // If they have an active or unverified account but missing scopes, FORCE reauthorization with explicit additional scopes
-        const response = await existingGoogleAccount.reauthorize({ 
-          additionalScopes: ['https://www.googleapis.com/auth/gmail.modify'],
-          redirectUrl: window.location.href 
-        });
-        verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
-      } else {
-        // If they never linked Google, create a new connection
-        const response = await user.createExternalAccount({
-          strategy: "oauth_google",
-          redirectUrl: window.location.href,
-        });
-        verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
-      }
-
-      if (verificationUrl) {
-        window.location.href = verificationUrl;
-      } else {
-        setIsLoading(false); // In case it returns without a URL
-      }
+      await enhancedConnectAction();
     } catch (error) {
-      console.error("Failed to connect Google:", error);
+      if (isReverificationCancelledError(error)) {
+        console.log("User cancelled reverification modal");
+      } else {
+        console.error("Failed to connect Google:", error);
+      }
       setIsLoading(false);
     }
   };

--- a/src/app/dashboard/ConnectGoogleWarning.tsx
+++ b/src/app/dashboard/ConnectGoogleWarning.tsx
@@ -15,15 +15,15 @@ export function ConnectGoogleWarning() {
       
       let verificationUrl: string | undefined;
 
-      if (existingGoogleAccount) {
-        // If they have an account but missing scopes, FORCE reauthorization with explicit additional scopes
+      if (existingGoogleAccount && existingGoogleAccount.verification?.status === 'verified') {
+        // If they have an active account but missing scopes, FORCE reauthorization with explicit additional scopes
         const response = await existingGoogleAccount.reauthorize({ 
           additionalScopes: ['https://www.googleapis.com/auth/gmail.modify'],
           redirectUrl: window.location.href 
         });
         verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
       } else {
-        // If they never linked Google, create a new connection
+        // If they never linked Google OR if it was disconnected (unverified), create a new connection
         const response = await user.createExternalAccount({
           strategy: "oauth_google",
           redirectUrl: window.location.href,


### PR DESCRIPTION
- **fix(auth): fallback to createExternalAccount for unverified accounts**
- **fix(auth): destroy unverified external account before recreating**
- **fix(auth): revert createExternalAccount fallback for unverified accounts to prevent step-up auth error**
- **feat(auth): natively wrap external account connection with reverification challenge hook**
