### PR TITLE
fix: add direct JWT verification fallback for CLI/MCP OAuth tokens

### DIFF
--- a/src/app/api/auth/cli-token/route.ts
+++ b/src/app/api/auth/cli-token/route.ts
@@ -198,9 +198,9 @@ export async function POST(request: NextRequest) {
 
   } catch (err) {
     console.error('[CLI-Token] Unhandled error:', err);
-    const message = err instanceof Error ? err.message : String(err);
+    const detail = err instanceof Error ? err.message : String(err);
     return NextResponse.json(
-      { status: 'error', message: `Internal error: ${message}` },
+      { status: 'error', message: 'Internal server error', detail },
       { status: 500 }
     );
   }

--- a/src/app/api/auth/cli-token/route.ts
+++ b/src/app/api/auth/cli-token/route.ts
@@ -58,46 +58,46 @@ async function verifyClerkJwtDirect(token: string): Promise<{ userId: string; cl
 }
 
 export async function POST(request: NextRequest) {
-  // --- Auth: verify Clerk OAuth token ---
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return NextResponse.json(
-      { status: 'error', message: 'Missing Authorization header' },
-      { status: 401 }
-    );
-  }
-
-  const bearerToken = authHeader.slice(7);
-  let userId: string | undefined;
-  let clientId: string | undefined;
-
-  // Strategy 1: Try Clerk's built-in auth() + verifyClerkToken
   try {
-    const clerkAuth = await auth({ acceptsToken: 'oauth_token' });
-    const authInfo = verifyClerkToken(clerkAuth, bearerToken);
-    userId = authInfo?.extra?.userId as string | undefined;
-    clientId = (authInfo as unknown as Record<string, unknown>)?.clientId as string | undefined;
-  } catch (err) {
-    console.warn('[CLI-Token] Clerk auth() failed, will try direct JWT:', err);
-  }
+    // --- Auth: verify Clerk OAuth token ---
+    const authHeader = request.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json(
+        { status: 'error', message: 'Missing Authorization header' },
+        { status: 401 }
+      );
+    }
 
-  // Strategy 2: Direct JWT verification (fallback for CLI/non-browser contexts)
-  if (!userId || !clientId) {
-    console.log('[CLI-Token] Falling back to direct JWT verification');
+    const bearerToken = authHeader.slice(7);
+    let userId: string | undefined;
+    let clientId: string | undefined;
+
+    // Strategy 1: Direct JWT verification (most reliable for CLI/non-browser OAuth tokens)
     const direct = await verifyClerkJwtDirect(bearerToken);
     if (direct) {
       userId = direct.userId;
       clientId = direct.clientId;
       console.log(`[CLI-Token] Direct JWT verified: userId=${userId} clientId=${clientId}`);
     }
-  }
 
-  if (!userId || !clientId) {
-    return NextResponse.json(
-      { status: 'error', message: 'Invalid or expired token. Re-run: node auth.js --action login' },
-      { status: 401 }
-    );
-  }
+    // Strategy 2: Clerk auth() + verifyClerkToken (fallback for browser/session contexts)
+    if (!userId || !clientId) {
+      try {
+        const clerkAuth = await auth({ acceptsToken: 'oauth_token' });
+        const authInfo = verifyClerkToken(clerkAuth, bearerToken);
+        userId = authInfo?.extra?.userId as string | undefined;
+        clientId = (authInfo as unknown as Record<string, unknown>)?.clientId as string | undefined;
+      } catch (err) {
+        console.warn('[CLI-Token] Clerk auth() also failed:', err);
+      }
+    }
+
+    if (!userId || !clientId) {
+      return NextResponse.json(
+        { status: 'error', message: 'Invalid or expired token. Re-run: node auth.js --action login' },
+        { status: 401 }
+      );
+    }
 
 
   // --- Resolve user ---
@@ -195,6 +195,14 @@ export async function POST(request: NextRequest) {
     emails: emailAccess.map((e) => e.targetEmail),
     proxy_endpoint: DASHBOARD_URL.replace('://fgac.ai', '://gmail.fgac.ai').replace('://localhost:3000', '://localhost:3000'),
   });
+
+  } catch (err) {
+    console.error('[CLI-Token] Unhandled error:', err);
+    return NextResponse.json(
+      { status: 'error', message: 'Internal server error. Check logs.' },
+      { status: 500 }
+    );
+  }
 }
 
 export async function GET() {

--- a/src/app/api/auth/cli-token/route.ts
+++ b/src/app/api/auth/cli-token/route.ts
@@ -15,6 +15,7 @@
  */
 import { verifyClerkToken } from '@clerk/mcp-tools/next';
 import { auth } from '@clerk/nextjs/server';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { db } from '@/db';
 import {
   agentConnections, users, proxyKeys, keyEmailAccess,
@@ -23,6 +24,38 @@ import { eq, and } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 const DASHBOARD_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+
+/**
+ * Decode and verify a Clerk OAuth JWT directly against the Clerk JWKS endpoint.
+ * This is the fallback when auth()+verifyClerkToken fails (common in CLI/non-browser contexts
+ * where Clerk middleware doesn't intercept the request).
+ */
+async function verifyClerkJwtDirect(token: string): Promise<{ userId: string; clientId: string } | null> {
+  try {
+    // Decode the payload without verification first to get the issuer
+    const [, payloadB64] = token.split('.');
+    if (!payloadB64) return null;
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+    const issuer = payload.iss;
+    if (!issuer) return null;
+
+    // Verify signature against Clerk's JWKS
+    const JWKS = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
+    const { payload: verified } = await jwtVerify(token, JWKS, {
+      issuer,
+      clockTolerance: 30,
+    });
+
+    const sub = verified.sub;
+    const cid = (verified as Record<string, unknown>).client_id as string | undefined;
+
+    if (!sub || !cid) return null;
+    return { userId: sub, clientId: cid };
+  } catch (err) {
+    console.error('[CLI-Token] JWT direct verification failed:', err);
+    return null;
+  }
+}
 
 export async function POST(request: NextRequest) {
   // --- Auth: verify Clerk OAuth token ---
@@ -38,31 +71,34 @@ export async function POST(request: NextRequest) {
   let userId: string | undefined;
   let clientId: string | undefined;
 
+  // Strategy 1: Try Clerk's built-in auth() + verifyClerkToken
   try {
     const clerkAuth = await auth({ acceptsToken: 'oauth_token' });
     const authInfo = verifyClerkToken(clerkAuth, bearerToken);
     userId = authInfo?.extra?.userId as string | undefined;
     clientId = (authInfo as unknown as Record<string, unknown>)?.clientId as string | undefined;
-  } catch {
+  } catch (err) {
+    console.warn('[CLI-Token] Clerk auth() failed, will try direct JWT:', err);
+  }
+
+  // Strategy 2: Direct JWT verification (fallback for CLI/non-browser contexts)
+  if (!userId || !clientId) {
+    console.log('[CLI-Token] Falling back to direct JWT verification');
+    const direct = await verifyClerkJwtDirect(bearerToken);
+    if (direct) {
+      userId = direct.userId;
+      clientId = direct.clientId;
+      console.log(`[CLI-Token] Direct JWT verified: userId=${userId} clientId=${clientId}`);
+    }
+  }
+
+  if (!userId || !clientId) {
     return NextResponse.json(
-      { status: 'error', message: 'Invalid or expired token. Re-run auth.' },
+      { status: 'error', message: 'Invalid or expired token. Re-run: node auth.js --action login' },
       { status: 401 }
     );
   }
 
-  if (!userId) {
-    return NextResponse.json(
-      { status: 'error', message: 'Token missing userId claim' },
-      { status: 401 }
-    );
-  }
-
-  if (!clientId) {
-    return NextResponse.json(
-      { status: 'error', message: 'Token missing clientId claim. Use DCR OAuth.' },
-      { status: 400 }
-    );
-  }
 
   // --- Resolve user ---
   const user = await db.query.users.findFirst({

--- a/src/app/api/auth/cli-token/route.ts
+++ b/src/app/api/auth/cli-token/route.ts
@@ -198,8 +198,9 @@ export async function POST(request: NextRequest) {
 
   } catch (err) {
     console.error('[CLI-Token] Unhandled error:', err);
+    const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json(
-      { status: 'error', message: 'Internal server error. Check logs.' },
+      { status: 'error', message: `Internal error: ${message}` },
       { status: 500 }
     );
   }

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -459,17 +459,56 @@ const handler = createMcpHandler(
   }
 );
 
+/**
+ * Direct JWT verification fallback for CLI/non-browser OAuth tokens.
+ * Used when Clerk's auth()+verifyClerkToken fails to extract userId/clientId.
+ */
+async function verifyClerkJwtDirect(token: string) {
+  try {
+    const { createRemoteJWKSet, jwtVerify } = await import('jose');
+    const [, payloadB64] = token.split('.');
+    if (!payloadB64) return undefined;
+    const rawPayload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+    const issuer = rawPayload.iss;
+    if (!issuer) return undefined;
+
+    const JWKS = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
+    const { payload: verified } = await jwtVerify(token, JWKS, { issuer, clockTolerance: 30 });
+    const sub = verified.sub;
+    const cid = (verified as Record<string, unknown>).client_id as string | undefined;
+    if (!sub || !cid) return undefined;
+
+    return {
+      token,
+      scopes: ((verified as Record<string, unknown>).scope as string || '').split(' '),
+      clientId: cid,
+      extra: { userId: sub },
+    };
+  } catch (err) {
+    console.error('[MCP] Direct JWT verification failed:', err);
+    return undefined;
+  }
+}
+
 export const POST = experimental_withMcpAuth(
   handler,
   async (_req, bearerToken) => {
+    // Strategy 1: Try Clerk's built-in auth() + verifyClerkToken
     try {
       const clerkAuth = await auth({ acceptsToken: 'oauth_token' });
       const authInfo = verifyClerkToken(clerkAuth, bearerToken);
-      return authInfo;
+      if (authInfo?.extra?.userId) return authInfo;
     } catch (error) {
-      console.error('[MCP] Token verification error:', error);
-      return undefined;
+      console.warn('[MCP] Clerk auth() failed, will try direct JWT:', error);
     }
+
+    // Strategy 2: Direct JWT verification (fallback for CLI/non-browser contexts)
+    if (bearerToken) {
+      console.log('[MCP] Falling back to direct JWT verification');
+      return await verifyClerkJwtDirect(bearerToken);
+    }
+
+    return undefined;
   },
   {
     required: true,


### PR DESCRIPTION
## Problem
The `/api/auth/cli-token` endpoint returns HTTP 500 (empty body) when called from CLI scripts during the DCR+PKCE OAuth onboarding flow. The `auth({ acceptsToken: 'oauth_token' })` from `@clerk/nextjs/server` doesn't properly extract `userId`/`clientId` from OAuth access tokens in non-browser contexts.

## Root Cause
Clerk middleware doesn't intercept API route requests from CLI scripts (no cookies, no session). When `auth()` is called, it returns an unauthenticated state, causing `verifyClerkToken()` to return `undefined`. The code then hits the `!userId` check and returns 401.

In production, the `auth()` call itself was throwing (HTTP 500 with empty body) before even reaching the error handling.

## Fix
Added a **direct JWT verification fallback** using the `jose` library (already a dependency):
1. First tries the Clerk `auth() + verifyClerkToken` chain (works for browser/session contexts)
2. If that fails, decodes the JWT, extracts the `iss` (issuer), fetches the JWKS from `{issuer}/.well-known/jwks.json`, and verifies the signature
3. Extracts `sub` → userId and `client_id` → clientId from the verified payload

Applied to both:
- `/api/auth/cli-token` (CLI onboarding)
- `/api/mcp` (MCP server auth handler)