### PR TITLE
feat: Google Sheets FGAC + Antigravity agent config port (combined deploy)

### DIFF
--- a/.claude/commands/browser-agent.md
+++ b/.claude/commands/browser-agent.md
@@ -1,91 +1,104 @@
 ---
-description: Drive the user's real Chrome via Playwright CLI over CDP, preserving Google sign-in sessions
+description: Analyze or test the UI in a browser — built-in browser tools by default, CDP-attached Chrome when a logged-in session is required
 argument-hint: [url]
-allowed-tools: Bash(curl:*), Bash(npx @playwright/cli:*), Bash(playwright-cli:*), Read
+allowed-tools: Bash(curl:*), Bash(npx @playwright/cli:*), Read
 ---
 
 # Browser Agent Workflow
 
-Drives the user's real Chrome browser via `@playwright/cli attach --cdp`, preserving all
-Google sign-in sessions and cookies. Target URL: `$1` (if empty, ask the user what to open).
+Target URL: `$1` (if empty, ask the user what to open).
 
-See `.claude/skills/playwright-cli/SKILL.md` for the full CLI command reference.
+Two paths. **Default to Path A.** Path B exists only for tests that need the user's real
+Google sign-in session.
 
-## Prerequisites
+---
 
-Chrome must be running with remote debugging enabled using the **project testing profile**:
+## Path A — Built-in browser tools (default in Claude Code)
 
-macOS:
-```bash
-"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --user-data-dir="$CLAUDE_PROJECT_DIR/.playwright_user_data" --remote-debugging-port=9222
-```
+Use the `mcp__Claude_Browser__*` tools. No setup, no external process, and console/network
+inspection is far better than screenshot-scraping.
 
-Linux:
-```bash
-google-chrome --user-data-dir="$CLAUDE_PROJECT_DIR/.playwright_user_data" --remote-debugging-port=9222
-```
+1. **Open the pane** at the target URL:
+   `preview_start` with `{url: "$1"}`
 
-> **CRITICAL**: Always use the project `.playwright_user_data` profile — it holds the Google
-> sign-in sessions and cookies the tests need. Do NOT launch Chrome without `--user-data-dir`,
-> do NOT use a different profile path, and do NOT run `pkill chrome` (that kills the user's
-> real browser session). To clean up only test Chrome instances, use
-> `pkill -f 'chrome.*playwright_user_data'`. If Chrome isn't listening on 9222, STOP and ask
-> the user to start it with the command above.
+2. **Read the page.** Prefer text and the accessibility tree over screenshots — they are
+   cheaper and more precise:
+   - `get_page_text` — visible copy
+   - `read_page` with `filter: "interactive"` — elements tagged `ref_N` for clicking
+   - `computer` with `action: "screenshot"` — only when you need to judge *visual* layout
 
-## Execution Steps
+3. **Interact** via `computer` (`left_click`, `type`, `scroll`) using `ref` from `read_page`,
+   or `form_input` for form fields.
 
-1. **Check the Chrome debugging port**
+4. **Check for runtime errors** — this is the highest-signal step for validating a deploy:
+   - `read_console_messages` with `{onlyErrors: true}`
+   - `read_network_requests` — confirm assets and API calls return expected status codes.
+     Cancelled RSC prefetches show as `ERR_ABORTED` and are normal in Next.js.
 
+5. **Verify responsive behavior** with `resize_window` (`mobile` / `tablet` / `desktop`).
+
+### Limits of Path A
+
+This browser has **no Google or Clerk session**. Anything behind `/dashboard` redirects to
+sign-in. Do NOT attempt to sign in — entering credentials is off-limits. You can still validate
+a great deal without auth:
+
+- Public pages render, and copy/layout is correct
+- No console errors, all chunks load
+- Auth gates actually gate (a redirect to Clerk is a *passing* result)
+- API endpoints return sane codes unauthenticated — e.g. `/api/mcp` `tools/list` returning
+  **401 rather than 500** proves new tool code loads without crashing the handler
+
+---
+
+## Path B — CDP-attached real Chrome (only when auth is required)
+
+Needed only to exercise signed-in flows (dashboard, rules, Google Picker, per-file access).
+
+> **Prerequisite that is easy to miss**: the profile directory must already exist *and* be
+> signed in to Google. It is gitignored, so it does NOT travel with the repo — a fresh clone or
+> a different machine has no profile and therefore no session. Creating it is a one-time
+> interactive sign-in by the user.
+
+1. **Check the debugging port**:
    ```bash
    curl -s http://localhost:9222/json/version
    ```
-   - Returns JSON → proceed to step 2.
-   - Connection refused → STOP and ask the user to launch Chrome with the command above.
+   Connection refused → STOP and ask the user to launch Chrome:
 
-2. **Attach to the running browser**
+   macOS:
+   ```bash
+   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --user-data-dir="$CLAUDE_PROJECT_DIR/.playwright_user_data" --remote-debugging-port=9222
+   ```
+   Linux:
+   ```bash
+   google-chrome --user-data-dir="$CLAUDE_PROJECT_DIR/.playwright_user_data" --remote-debugging-port=9222
+   ```
 
+2. **Attach**:
    ```bash
    npx @playwright/cli attach --cdp=http://localhost:9222 -s=fgac_ui
    ```
-   This connects the CLI session to the user's real Chrome with cookies and auth state intact.
-   If the attach fails, STOP and report it — do not silently fall back to a fresh browser.
+   If attach fails, STOP and report — never silently fall back to a fresh browser, which
+   would produce a green result against an unauthenticated session.
 
-3. **Navigate to the target URL**
-
+3. **Drive it**, filtering snapshots to keep context small:
    ```bash
    npx @playwright/cli -s=fgac_ui goto $1
-   ```
-
-4. **Snapshot the page structure**, filtered to keep context small:
-
-   ```bash
-   npx @playwright/cli -s=fgac_ui snapshot 2>&1 | grep -E "heading|button|link|textbox|Agent|Approve" | head -30
-   ```
-   Read the YAML output to identify element refs (e.g. `e15`, `e23`). Widen the grep only if
-   you can't find the element you need.
-
-5. **Interact using refs from the snapshot**
-
-   ```bash
+   npx @playwright/cli -s=fgac_ui snapshot 2>&1 | grep -E "heading|button|link|Approve" | head -30
    npx @playwright/cli -s=fgac_ui click e15
-   npx @playwright/cli -s=fgac_ui fill e12 "some text"
-   npx @playwright/cli -s=fgac_ui select e8 "option_value"
-   ```
-
-6. **Capture proof screenshots** into the gitignored QA directory, never the project root:
-
-   ```bash
    npx @playwright/cli -s=fgac_ui screenshot .playwright/qa_proof.png
-   ```
-
-7. **Close the session when done** (does NOT close the user's browser)
-
-   ```bash
    npx @playwright/cli -s=fgac_ui close
    ```
 
-## Rules
+> **NEVER run `pkill chrome`** — it kills the user's real browser. To clean up only test
+> instances: `pkill -f 'chrome.*playwright_user_data'`.
 
-- Never write ad-hoc Node.js Playwright scripts — use this CLI flow.
-- Never perform QA state changes by writing to the database. Drive the UI as a real user would.
-- Report attach/navigation failures immediately instead of continuing with unverified state.
+---
+
+## Rules for both paths
+
+- Never write ad-hoc Node.js Playwright scripts.
+- Never make QA state changes by writing to the database — drive the UI as a real user would.
+- Screenshots go to gitignored paths (`.playwright/`), never the project root.
+- Report attach/navigation failures immediately rather than continuing with unverified state.

--- a/.claude/commands/browser-agent.md
+++ b/.claude/commands/browser-agent.md
@@ -1,0 +1,91 @@
+---
+description: Drive the user's real Chrome via Playwright CLI over CDP, preserving Google sign-in sessions
+argument-hint: [url]
+allowed-tools: Bash(curl:*), Bash(npx @playwright/cli:*), Bash(playwright-cli:*), Read
+---
+
+# Browser Agent Workflow
+
+Drives the user's real Chrome browser via `@playwright/cli attach --cdp`, preserving all
+Google sign-in sessions and cookies. Target URL: `$1` (if empty, ask the user what to open).
+
+See `.claude/skills/playwright-cli/SKILL.md` for the full CLI command reference.
+
+## Prerequisites
+
+Chrome must be running with remote debugging enabled using the **project testing profile**:
+
+macOS:
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --user-data-dir="$CLAUDE_PROJECT_DIR/.playwright_user_data" --remote-debugging-port=9222
+```
+
+Linux:
+```bash
+google-chrome --user-data-dir="$CLAUDE_PROJECT_DIR/.playwright_user_data" --remote-debugging-port=9222
+```
+
+> **CRITICAL**: Always use the project `.playwright_user_data` profile — it holds the Google
+> sign-in sessions and cookies the tests need. Do NOT launch Chrome without `--user-data-dir`,
+> do NOT use a different profile path, and do NOT run `pkill chrome` (that kills the user's
+> real browser session). To clean up only test Chrome instances, use
+> `pkill -f 'chrome.*playwright_user_data'`. If Chrome isn't listening on 9222, STOP and ask
+> the user to start it with the command above.
+
+## Execution Steps
+
+1. **Check the Chrome debugging port**
+
+   ```bash
+   curl -s http://localhost:9222/json/version
+   ```
+   - Returns JSON → proceed to step 2.
+   - Connection refused → STOP and ask the user to launch Chrome with the command above.
+
+2. **Attach to the running browser**
+
+   ```bash
+   npx @playwright/cli attach --cdp=http://localhost:9222 -s=fgac_ui
+   ```
+   This connects the CLI session to the user's real Chrome with cookies and auth state intact.
+   If the attach fails, STOP and report it — do not silently fall back to a fresh browser.
+
+3. **Navigate to the target URL**
+
+   ```bash
+   npx @playwright/cli -s=fgac_ui goto $1
+   ```
+
+4. **Snapshot the page structure**, filtered to keep context small:
+
+   ```bash
+   npx @playwright/cli -s=fgac_ui snapshot 2>&1 | grep -E "heading|button|link|textbox|Agent|Approve" | head -30
+   ```
+   Read the YAML output to identify element refs (e.g. `e15`, `e23`). Widen the grep only if
+   you can't find the element you need.
+
+5. **Interact using refs from the snapshot**
+
+   ```bash
+   npx @playwright/cli -s=fgac_ui click e15
+   npx @playwright/cli -s=fgac_ui fill e12 "some text"
+   npx @playwright/cli -s=fgac_ui select e8 "option_value"
+   ```
+
+6. **Capture proof screenshots** into the gitignored QA directory, never the project root:
+
+   ```bash
+   npx @playwright/cli -s=fgac_ui screenshot .playwright/qa_proof.png
+   ```
+
+7. **Close the session when done** (does NOT close the user's browser)
+
+   ```bash
+   npx @playwright/cli -s=fgac_ui close
+   ```
+
+## Rules
+
+- Never write ad-hoc Node.js Playwright scripts — use this CLI flow.
+- Never perform QA state changes by writing to the database. Drive the UI as a real user would.
+- Report attach/navigation failures immediately instead of continuing with unverified state.

--- a/.claude/commands/deploy-pr-preview.md
+++ b/.claude/commands/deploy-pr-preview.md
@@ -1,0 +1,99 @@
+---
+description: Push the branch to a PR, wait for the Vercel Preview build, validate the live UI with the browser agent, and return both URLs
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(npm run db:generate), Bash(ls:*), Bash(npx vercel ls:*), Bash(npx vercel inspect:*), Bash(curl:*), Bash(jq:*), Read
+---
+
+# Deploy PR Preview
+
+Current branch: !`git branch --show-current`
+
+1. **Merge latest main** so the preview is up to date:
+
+   ```bash
+   git fetch origin main && git merge origin/main
+   ```
+
+2. **If you made schema/data model changes**, generate the migration file *before* pushing.
+   `migrate.ts` dynamically loads all `.sql` files from `src/db/migrations/` — verify your new
+   file exists there and follows the `NNNN_*.sql` naming convention.
+
+   ```bash
+   npm run db:generate && ls -la src/db/migrations/
+   ```
+
+3. **Push the branch**:
+
+   ```bash
+   git push origin HEAD
+   ```
+
+4. **Ensure a PR exists**:
+
+   ```bash
+   gh pr view || gh pr create --fill
+   ```
+
+5. **Cancel stale builds** for older commits on this branch, so you don't wait on outdated
+   builds. Identify deployments in `Building` or `Queued` state older than your push:
+
+   ```bash
+   npx vercel ls googleapis-fine-grain-access-control
+   ```
+   Then cancel each (this modifies state — confirm with the user if it isn't obviously yours):
+   ```bash
+   npx vercel cancel <deployment-url>
+   ```
+
+6. **Wait for the Preview deployment** and extract the live alias URL:
+
+   ```bash
+   npx vercel ls googleapis-fine-grain-access-control | grep -w "Ready" | grep -w "Preview" | head -n 1 | awk '{print $2}'
+   ```
+
+7. **If the deployment fails with `● Error`**, you MUST read the build logs BEFORE taking any
+   corrective action. Do NOT blindly delete Neon branches or retry without diagnosing.
+
+   a. Fetch the build logs:
+   ```bash
+   VERCEL_TOKEN=$(cat ~/.local/share/com.vercel.cli/auth.json | jq -r '.token')
+   npx vercel inspect <deployment-url>
+   curl -s "https://api.vercel.com/v2/deployments/<deployment-id>/events" \
+     -H "Authorization: Bearer $VERCEL_TOKEN" | jq -r '.[].payload.text'
+   ```
+
+   b. Diagnose from the logs. Common failures:
+   - **Migration SQL errors** (e.g. `cannot insert multiple commands into a prepared statement`) — fix the migration file or the `splitStatements` parser in `migrate.ts`.
+   - **Neon branch limit exceeded** — only THEN run `npx tsx scripts/cleanup-neon-branches.ts`.
+   - **TypeScript/build errors** — fix the code.
+   - **Missing environment variables** — check Vercel project settings.
+
+   c. Fix the root cause, push again, and return to step 5.
+
+   > **CRITICAL**: Never delete Neon branches as a first response to a build error. Always read
+   > the logs first. Deleting branches is destructive and only appropriate when the logs
+   > explicitly indicate a branch limit error.
+
+8. **Validate the frontend yourself** once the Preview URL is `Ready`, by running the
+   `/browser-agent` workflow:
+   - Attach to Chrome and navigate to the specific Vercel Preview URL.
+   - Log in with a test user context if necessary.
+   - Wait for full load, then snapshot/screenshot to confirm the features you built are
+     visible and functional.
+
+9. **Only AFTER browser validation succeeds**, report to the user:
+   - If you hit errors accessing the URL or interacting with the page, STOP and say so immediately.
+   - Fetch the PR URL explicitly so you have it in context:
+     ```bash
+     gh pr view --json url -q .url
+     ```
+   - Give the user BOTH the **GitHub PR URL** and the **Vercel Preview URL**.
+   - Summarize the validation you performed.
+   - Ask the user to manually verify the application state using the Preview URL.
+
+> **Failure Reflection**: Past runs failed by giving only the Vercel URL and hiding the PR URL,
+> and by skipping `/browser-agent` entirely or ignoring Playwright CLI attach errors, producing
+> a silent failure. Always verify you attached, loaded the page, and captured visual proof —
+> and always provide both URLs.
+
+> **CRITICAL RULE**: Do not invoke `/deploy-prod` at the end of this workflow. Only the user
+> merges to production, after they are satisfied with the Preview URL.

--- a/.claude/commands/deploy-prod.md
+++ b/.claude/commands/deploy-prod.md
@@ -1,0 +1,50 @@
+---
+description: USER-ONLY — merge the PR to main, wait for the production deployment, and validate it
+allowed-tools: Bash(gh:*), Bash(npx vercel ls:*), Bash(npx vercel inspect:*), Bash(npx vercel logs:*), Bash(curl:*), Bash(sleep:*)
+---
+
+# Deploy to Production
+
+> **CRITICAL AGENT RULE**: Do NOT invoke or automate this command on your own. You are NEVER
+> allowed to run it as part of another workflow or on your own initiative — it is strictly for
+> the user to execute after they have verified the preview branch. If you believe your task is
+> complete, give the user the working Preview URL to review instead.
+>
+> If you are reading this because the user typed `/deploy-prod` themselves, proceed.
+
+1. **Merge the current PR to main**:
+
+   ```bash
+   gh pr merge --auto --merge
+   ```
+
+2. **Wait for the production deployment** (~5 minutes):
+
+   ```bash
+   sleep 300
+   ```
+
+3. **Validate the deployment**:
+
+   ```bash
+   npx vercel ls googleapis-fine-grain-access-control --prod --limit 1
+   ```
+   Optional precise status check if you have the deployment URL:
+   ```bash
+   npx vercel inspect <deployment-url>
+   ```
+   Health check:
+   ```bash
+   curl -I https://fgac.ai/
+   ```
+
+4. **If successful** (status `READY` and the health check passes), report success to the user.
+
+5. **If there are issues**:
+   - Flag the deployment issues explicitly.
+   - Check logs:
+     ```bash
+     npx vercel logs googleapis-fine-grain-access-control --prod
+     ```
+   - Propose fixes. Do NOT attempt a production redeploy yourself — `vercel --prod`,
+     `vercel promote`, and `vercel alias` are banned and denied in `.claude/settings.json`.

--- a/.claude/commands/qa-claude-code-cli.md
+++ b/.claude/commands/qa-claude-code-cli.md
@@ -1,0 +1,96 @@
+---
+description: Run all capability tests through Claude Code CLI local scripts (headless `claude -p` evals)
+argument-hint: [--filter A1]
+allowed-tools: Bash(bash test/qa-envs/cc-cli/reset.sh), Bash(node test/qa-envs/cc-cli/:*), Bash(bash evals/run_evals.sh:*), Bash(cat:*), Bash(jq:*), Bash(tmux:*), Read, Glob
+---
+
+# Claude Code CLI QA
+
+Requires: `/qa-setup` completed, dev server running. Optional filter: `$ARGUMENTS`
+
+## Two-Phase Hybrid Testing Model
+
+### Phase 1: Auth Setup (interactive, one-time)
+
+The OAuth DCR + PKCE flow needs interactive browser consent. Do this once before headless testing:
+
+1. **Reset**:
+   ```bash
+   bash test/qa-envs/cc-cli/reset.sh
+   ```
+2. **Authenticate**:
+   ```bash
+   FGAC_ROOT_URL=http://localhost:3000 node test/qa-envs/cc-cli/.claude/skills/gmail-fgac/scripts/auth.js --action login
+   ```
+3. **Approve** the connection in the dashboard via `/browser-agent`.
+4. **Verify** credentials are stored:
+   ```bash
+   cat ~/.openclaw/gmail-fgac/fgac-credentials.json | jq '.proxy_key, .key_label'
+   ```
+
+### Phase 2: Headless Capability Eval (`claude -p`)
+
+With auth pre-seeded, ALL capability assertions run headlessly:
+
+```bash
+cd test/qa-envs/cc-cli && bash evals/run_evals.sh
+```
+
+Single test:
+```bash
+cd test/qa-envs/cc-cli && bash evals/run_evals.sh --filter A1
+```
+
+The runner uses `claude -p` (print/headless mode) with:
+- `--output-format json` — structured, parseable results
+- `--allowedTools "Bash(node:*)"` — restricted to skill scripts
+- `--max-turns 5` — prevents runaway execution
+- `--dangerously-skip-permissions` — unattended execution
+
+> **Why not tmux?** The earlier tmux approach was fragile (alternate screen buffer issues,
+> timing, usage throttling). `claude -p` is deterministic, fast (10–15s per test), and CI/CD
+> compatible.
+
+## Coverage Report (Required)
+
+The eval suite emits a pass/fail report automatically. Cross-reference it against
+`docs/QA_Acceptance_Test/capabilities/` for full coverage:
+
+```
+| Cap | Assertion | Status | Duration | Notes |
+|-----|-----------|--------|----------|-------|
+| 01  | A1        | ✅/❌/⏭️ | 10s      |       |
+| 01  | A2        | ✅/❌/⏭️ | 15s      |       |
+...
+```
+
+All assertions must be accounted for. Any ⏭️ (skipped) must include a reason. Report failures
+with the actual output — never mark a test passing on an assumption.
+
+## Adding New Test Cases
+
+Add entries to `test/qa-envs/cc-cli/evals/test_cases.json`:
+
+```json
+{
+  "id": "A5",
+  "capability": "02_read_blacklist",
+  "name": "Read blocked competitor email",
+  "prompt": "Using gmail-fgac, search for emails from spy@competitor.com",
+  "assert_pattern": "blocked|filtered|no results",
+  "expect_exit": 0,
+  "max_turns": 5
+}
+```
+
+## Fallback: Interactive TUI Testing
+
+If headless testing is insufficient (e.g. testing slash command UI or the skill discovery
+banner), use the tmux fallback:
+
+```bash
+tmux new-session -d -s fgac-cli-qa -x 200 -y 50 "cd test/qa-envs/cc-cli && claude --dangerously-skip-permissions"
+tmux send-keys -t fgac-cli-qa "What skills do you have available?" Enter
+```
+
+This should be rare — most capability assertions work via `claude -p`.

--- a/.claude/commands/qa-claude-code.md
+++ b/.claude/commands/qa-claude-code.md
@@ -1,0 +1,30 @@
+---
+description: Run all capability tests through Claude Code MCP via tmux
+allowed-tools: Bash(tmux:*), Bash(npx @playwright/cli:*), Bash(curl:*), Bash(jq:*), Bash(ls:*), Read, Glob
+---
+
+# Claude Code MCP QA
+
+Requires: `/qa-setup` completed, dev server running, tmux + Playwright available.
+
+Read and execute: `docs/QA_Acceptance_Test/agents/02_claude_code_mcp.md`
+
+That doc runs ALL capabilities via tmux + Playwright. Capability assertions are defined in
+`docs/QA_Acceptance_Test/capabilities/`. If new capability files have been added there, the
+agent doc must be updated to cover them.
+
+## Coverage Report (Required)
+
+After running all capabilities, generate a coverage matrix in the QA report. Cross-reference
+every assertion in `docs/QA_Acceptance_Test/capabilities/` against actual results:
+
+```
+| Cap | Assertion | Status | Notes |
+|-----|-----------|--------|-------|
+| 01  | A1        | ✅/❌/⏭️ |       |
+| 01  | A2        | ✅/❌/⏭️ |       |
+...
+```
+
+All 48 assertions must be accounted for. Any ⏭️ (skipped) must include a reason
+(e.g. "Setup 02 not run"). Report failures honestly with the actual output.

--- a/.claude/commands/qa-hosted-mcp.md
+++ b/.claude/commands/qa-hosted-mcp.md
@@ -1,0 +1,31 @@
+---
+description: Run all capability tests through the Hosted MCP interface
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(ls:*), Read, Glob
+---
+
+# Hosted MCP QA
+
+Requires: `/qa-setup` completed, dev server running.
+
+Read and execute: `docs/QA_Acceptance_Test/agents/01_hosted_mcp.md`
+
+That doc runs ALL capabilities via curl against the MCP endpoint. Capability assertions are
+defined in `docs/QA_Acceptance_Test/capabilities/`. If new capability files have been added
+there, the agent doc must be updated to cover them.
+
+## Coverage Report (Required)
+
+After running all capabilities, generate a coverage matrix in the QA report. Cross-reference
+every assertion in `docs/QA_Acceptance_Test/capabilities/` against actual results:
+
+```
+| Cap | Assertion | Status | Notes |
+|-----|-----------|--------|-------|
+| 01  | A1        | ✅/❌/⏭️ |       |
+| 01  | A2        | ✅/❌/⏭️ |       |
+...
+```
+
+All 48 assertions must be accounted for. Any ⏭️ (skipped) must include a reason
+(e.g. "Setup 02 not run"). Report failures honestly with the actual output — never mark a test
+passing on the basis of an assumption.

--- a/.claude/commands/qa-openclaw.md
+++ b/.claude/commands/qa-openclaw.md
@@ -1,0 +1,31 @@
+---
+description: Run all capability tests through a genuine OpenClaw Docker instance
+allowed-tools: Bash(docker:*), Bash(curl:*), Bash(jq:*), Bash(ls:*), Read, Glob
+---
+
+# OpenClaw QA
+
+Requires: `/qa-setup` completed, dev server running, Docker available.
+
+Read and execute: `docs/QA_Acceptance_Test/agents/04_openclaw.md`
+
+That doc starts a real OpenClaw container and runs ALL capabilities through the gateway API —
+not standalone scripts. Capability assertions are defined in
+`docs/QA_Acceptance_Test/capabilities/`. If new capability files have been added there, the
+agent doc must be updated to cover them.
+
+## Coverage Report (Required)
+
+After running all capabilities, generate a coverage matrix in the QA report. Cross-reference
+every assertion in `docs/QA_Acceptance_Test/capabilities/` against actual results:
+
+```
+| Cap | Assertion | Status | Notes |
+|-----|-----------|--------|-------|
+| 01  | A1        | ✅/❌/⏭️ |       |
+| 01  | A2        | ✅/❌/⏭️ |       |
+...
+```
+
+All 48 assertions must be accounted for. Any ⏭️ (skipped) must include a reason
+(e.g. "Setup 02 not run"). Report failures honestly with the actual output.

--- a/.claude/commands/qa-production.md
+++ b/.claude/commands/qa-production.md
@@ -1,0 +1,24 @@
+---
+description: Validate production via real distribution channels (all 4 agents)
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(ls:*), Bash(docker:*), Bash(npx:*), Read, Glob
+---
+
+# Production QA
+
+Requires: production deployment live at fgac.ai.
+
+Discover and execute ALL production docs in order:
+
+```bash
+ls docs/QA_Acceptance_Test/production/*.md | sort
+```
+
+For each file, read it and follow its instructions. The `00_` file is the smoke test; `01_`–`04_`
+are the per-agent channel tests. Each agent doc installs from the real distribution channel,
+then runs ALL capabilities against production URLs.
+
+> **Read-only against production.** This workflow validates a deployment that already exists.
+> Never trigger a production deploy from here — `vercel --prod`, `vercel promote`, and
+> `vercel alias` are banned. Deployments are the user's call via `/deploy-prod`.
+
+Report failures honestly with the actual output, and account for every assertion.

--- a/.claude/commands/qa-setup.md
+++ b/.claude/commands/qa-setup.md
@@ -1,0 +1,56 @@
+---
+description: Bootstrap the QA environment (secrets, dev server, setup docs) via the browser agent
+allowed-tools: Bash(bash scripts/qa-secrets.sh), Bash(npm run dev:qa), Bash(curl:*), Bash(ls:*), Bash(cat .qa_test_emails.json), Bash(jq:*), Read, Glob
+---
+
+# QA Setup
+
+Prepares the environment every other `/qa-*` workflow depends on.
+
+## Steps
+
+1. **Pull secrets**:
+   ```bash
+   bash scripts/qa-secrets.sh
+   ```
+
+2. **Read `.qa_test_emails.json`** for `USER_A` and `USER_B`.
+
+3. **Start the QA dev server** (clears the `.next/dev` cache, uses Webpack rather than
+   Turbopack to avoid memory leaks, 8GB heap). Run it in the background so it keeps running
+   across the rest of the QA:
+   ```bash
+   npm run dev:qa
+   ```
+
+4. **Verify the dev server is up**:
+   ```bash
+   curl -sf http://localhost:3000
+   ```
+
+5. **Discover and execute ALL setup docs in order**:
+   ```bash
+   ls docs/QA_Acceptance_Test/setup/*.md | sort
+   ```
+   Read each file and follow its instructions using `/browser-agent`.
+
+   > **CRITICAL**: Do NOT skip any setup doc. Setup 02 (multi-account linking) establishes
+   > USER_B, delegation, and multi-key creation — without it, capabilities 03, 04, 05, and 07
+   > are untestable.
+
+   > **CRITICAL**: Do NOT shortcut setup by writing to the database. All state changes go
+   > through the Web UI, exactly as a real user would (see CLAUDE.md, Database Rule 7).
+
+6. **Screenshot the final dashboard state** as proof, into the gitignored directory:
+   `.playwright/qa_proof_setup.png`
+
+7. **Coverage Checkpoint** — verify ALL prerequisites before proceeding:
+   - [ ] USER_A signed up and Google account connected
+   - [ ] USER_B signed up as a separate FGAC user
+   - [ ] USER_B delegated their email to USER_A
+   - [ ] Three proxy keys created: QA-Agent-A, QA-Agent-B, QA-Power-Agent
+   - [ ] Quick-add 2FA block rules applied (exactly once — the button should read "✓ 2FA Block Applied")
+   - [ ] Send whitelist rule created
+   - [ ] Key-specific read blacklist rule created (assigned to QA-Agent-B only)
+
+   If any item is unchecked, **STOP** — re-run the relevant setup doc before running agent tests.

--- a/.claude/commands/recover-session.md
+++ b/.claude/commands/recover-session.md
@@ -1,0 +1,129 @@
+---
+description: Rebuild context after a crashed or interrupted session from compact artifacts and git state, without loading a full transcript
+argument-hint: [branch-name|latest]
+allowed-tools: Bash(git:*), Bash(ls:*), Bash(head:*), Bash(tail:*), Bash(cat:*), Bash(jq:*), Bash(node:*), Read, Glob, Grep
+---
+
+# Recover Session
+
+**Purpose:** Extract the minimum viable context from an interrupted session so work can
+continue in a fresh conversation WITHOUT exhausting the context window.
+
+Target: `$1` (a branch name, or `latest` / empty for the most recent work).
+
+> [!CAUTION]
+> **NEVER read a full session transcript (`~/.claude/projects/*/[uuid].jsonl`).** Those files
+> run to hundreds of KB and will consume most of your context budget, dooming the recovery to
+> the same fate. Use the targeted extraction below.
+>
+> If the previous session is still resumable, `claude --resume` is cheaper than this workflow.
+> Use this command when resume isn't available or the transcript is too large to reload.
+
+## Execution Steps
+
+### Step 1: Git state is the ground truth
+
+The git log is the most reliable record of what was actually completed.
+
+```bash
+echo "=== Branch ===" && git branch --show-current && \
+echo "\n=== Recent commits ===" && git log --oneline -10 && \
+echo "\n=== Uncommitted changes ===" && git status --short && \
+echo "\n=== Diff stats vs main ===" && git diff --stat main...HEAD 2>/dev/null | tail -5
+```
+
+### Step 2: Read the implementation plan for this branch
+
+This project saves versioned plans per branch (see CLAUDE.md). Find the highest revision and
+read only its head:
+
+```bash
+BR=$(git branch --show-current) && \
+ls -1 docs/implementation_plans/ | grep -F "$BR" | sort -V | tail -1
+```
+
+Then read the first ~60 lines of that file with `Read` (`limit: 60`) — enough for the goal and
+approach. Read further only if you actually need the detail.
+
+### Step 3: Check project memory
+
+```bash
+cat ~/.claude/projects/-Users-kyesh-GitRepos-fine-grain-access-control/memory/MEMORY.md 2>/dev/null
+```
+Read individual memory files only if the index line looks relevant.
+
+### Step 4: Check QA results (if the interruption happened during QA)
+
+```bash
+cat docs/QA_Acceptance_Test/qa-results.json 2>/dev/null | node -e "
+const r = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+console.log('Last QA run:', r.run_id);
+console.log('Summary:', r.summary.pass + '/' + r.summary.total, 'pass,', r.summary.fail, 'fail');
+r.tests.filter(t => t.status !== 'pass').forEach(t => console.log(' ', t.status.toUpperCase() + ':', t.id, '-', t.name));
+" 2>/dev/null || echo "No QA results file found"
+```
+
+### Step 5: Locate the stop point (LAST FEW LINES ONLY)
+
+Only if steps 1–4 left you unsure where work stopped. Read the tail of the most recent
+transcript — never the whole file:
+
+```bash
+LOG=$(ls -t ~/.claude/projects/-Users-kyesh-GitRepos-fine-grain-access-control/*.jsonl 2>/dev/null | head -1) && \
+echo "Transcript: $LOG" && tail -5 "$LOG" | node -e "
+let buf=''; process.stdin.on('data',d=>buf+=d).on('end',()=>{
+  for (const line of buf.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const d = JSON.parse(line);
+      const c = d.message?.content;
+      const text = typeof c === 'string' ? c : Array.isArray(c) ? c.map(b => b.text || b.name || b.type).join(' ') : '';
+      console.log((d.type || '?') + ': ' + String(text).slice(0, 200));
+    } catch {}
+  }
+});" 2>/dev/null || echo "No transcript found"
+```
+
+### Step 6: Check the environment is clean before resuming
+
+```bash
+echo "Untracked files: $(git status --short | grep '^??' | wc -l)  (should be < 20)" && \
+pgrep -fl 'chrome.*playwright_user_data' | head -3 || echo "No stale test-Chrome processes"
+```
+
+Kill stale test browsers with `pkill -f 'chrome.*playwright_user_data'` — never plain
+`pkill chrome`.
+
+### Step 7: Write the recovery brief
+
+Produce a compact summary and use it as the task list for this conversation:
+
+```markdown
+# Recovery Brief
+
+## Branch: [branch-name]
+
+### What's Done
+- [Completed items from the git log and plan]
+
+### What's In Progress
+- [Uncommitted changes, unfinished plan steps]
+
+### Stop Point
+- [Where the session stopped, from Step 5]
+
+### Next Action
+- [The specific next thing to do]
+```
+
+Register these as tasks, then proceed with the work.
+
+> [!IMPORTANT]
+> **Total context budget for recovery: ~5,000 tokens.** Git state ~300, implementation plan
+> head ~500, memory index ~200, QA summary ~200, transcript tail ~200. That leaves the rest of
+> the window for actual work.
+
+### Step 8: Proceed
+
+**Do NOT go back and read more of the old transcript.** If you need a specific implementation
+decision, check the code itself (`Grep`, targeted `Read`) rather than the conversation log.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Bash(vercel --prod:*)",
+      "Bash(vercel deploy --prod:*)",
+      "Bash(npx vercel --prod:*)",
+      "Bash(npx vercel deploy --prod:*)",
+      "Bash(vercel promote:*)",
+      "Bash(npx vercel promote:*)",
+      "Bash(vercel alias:*)",
+      "Bash(npx vercel alias:*)",
+      "Bash(git push origin main:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Read(./.env)",
+      "Read(./.env.local)",
+      "Read(./.env.production)",
+      "Read(./.qa_test_emails.json)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(vercel env add:*)",
+      "Bash(vercel env rm:*)",
+      "Bash(npx vercel env add:*)",
+      "Bash(npx vercel env rm:*)",
+      "Bash(npx vercel cancel:*)",
+      "Bash(git commit --no-verify:*)",
+      "Bash(npx tsx scripts/cleanup-neon-branches.ts:*)"
+    ],
+    "allow": [
+      "Bash(git pull:*)",
+      "Bash(git fetch:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git branch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(npm run lint:*)",
+      "Bash(npm run build:*)",
+      "Bash(npm run db:branch:*)",
+      "Bash(npm run db:generate:*)",
+      "Bash(npx vercel ls:*)",
+      "Bash(npx vercel inspect:*)",
+      "Bash(npx vercel logs:*)",
+      "Bash(npx vercel env ls:*)",
+      "Bash(npx vercel env pull:*)",
+      "Bash(npx @playwright/cli:*)",
+      "Bash(curl -s http://localhost:9222/json/version)",
+      "Bash(curl -sf http://localhost:3000:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 4. Review the `docs/` folder and update the docs and data model to match your changes.
 5. Commit frequently as you work through the problem.
 6. **Validation**: Validate changes locally, then in the preview branch via `/deploy-pr-preview`, running the applicable `docs/QA_Acceptance_Test` suites before handing back to the user.
-7. **Browser Automation**: NEVER call raw Playwright screenshot tools or write ad-hoc Node.js browser scripts. To analyze or test the UI interactively you MUST use `/browser-agent`, which attaches to the user's real Chrome over CDP so Google sign-in sessions and cookies are preserved.
+7. **Browser Automation**: In Claude Code, use the **built-in browser tools** (`mcp__Claude_Browser__*`) to analyze or test the UI — `preview_start`, `navigate`, `get_page_text`, `read_page`, `read_console_messages`, `read_network_requests`, `computer`. NEVER write ad-hoc Node.js browser scripts. The Playwright CLI path described in `.agent/workflows/browser-agent.md` is the Antigravity equivalent and is not the default here; reach for it only when a test genuinely needs the user's logged-in Chrome profile over CDP. See `/browser-agent` for both paths and their trade-offs.
 
 ## Database Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# FGAC.ai — Project Rules
+
+> These rules are the Claude Code port of `.agent/rules/` (Antigravity). Both trees are
+> kept in sync; if you change a rule here, mirror it in `.agent/rules/` and vice versa.
+> Workflows live in `.claude/commands/` (mirror of `.agent/workflows/`).
+
+## General Workflow
+
+1. **Branching**: Always pull the latest changes from main and create a new branch when starting new work.
+2. **Database Changes**: Follow the Database Rules below. Always run `npm run db:branch` BEFORE schema changes to enforce Neon branching.
+3. **Implementation Plans**: Document implementation plans as you normally would, but save a copy of each revision to `docs/implementation_plans/[branch_name]_v[revision].md`. If the file already exists, increment the revision number instead of editing it. This keeps a reviewable history of how plans evolved for QA and validation work.
+4. Review the `docs/` folder and update the docs and data model to match your changes.
+5. Commit frequently as you work through the problem.
+6. **Validation**: Validate changes locally, then in the preview branch via `/deploy-pr-preview`, running the applicable `docs/QA_Acceptance_Test` suites before handing back to the user.
+7. **Browser Automation**: NEVER call raw Playwright screenshot tools or write ad-hoc Node.js browser scripts. To analyze or test the UI interactively you MUST use `/browser-agent`, which attaches to the user's real Chrome over CDP so Google sign-in sessions and cookies are preserved.
+
+## Database Rules
+
+1. **Isolation First**: BEFORE creating any migration or pushing schema changes, ALWAYS run `npm run db:branch` so Drizzle-Kit executes against an isolated development branch.
+2. **Verify Connection**: Use the output of `db:branch` to confirm you are NOT connected to the production database branch (unless explicitly instructed for a hotfix, which requires extreme caution).
+3. **No Manual Prod Migrations**: NEVER run `drizzle-kit push` or `migrate` manually against a production connection string. Production changes happen via CI/CD.
+4. **Schema Changes**: Modifying `src/db/schema.ts` requires a subsequent `npm run db:push` to your local branch to verify correctness.
+5. **Drizzle/Migration Safety**: `drizzle.config.ts` and `src/db/migrate.ts` carry environment safety guards. On a feature branch (not `main`) they crash rather than implicitly falling back to production parameters (e.g. `DATABASE_URL`). Do not bypass this. If it halts, ensure your branch was populated via `npm run db:branch`.
+6. **Environment Variables**: NEVER commit `.env` or `.env.local` files containing database credentials.
+7. **No Direct DB Writes During QA**: NEVER write ad-hoc scripts (`psql`, `npx tsx`, raw SQL, Drizzle ORM scripts) that INSERT, UPDATE, or DELETE application data to simulate user actions during QA. QA exists to validate the real user flow. All state changes (approving connections, creating keys, configuring rules) MUST go through the Web UI via `/browser-agent` or the application's own API endpoints — exactly as a real user would. Direct DB manipulation bypasses the authorization checks the tests are meant to validate and can create invalid cross-user data bindings. Read-only queries for debugging are fine.
+8. **Migration File Verification**: After `drizzle-kit generate`, ALWAYS verify (a) the new `.sql` file exists in `src/db/migrations/`, (b) `migrate.ts` will pick it up (it uses a dynamic `readdirSync` — confirm the `.sql` extension and `NNNN_*.sql` naming convention), and (c) `npm run db:migrate` succeeds locally against your dev branch. NEVER assume a generated migration will be discovered without verification.
+
+## Security, Safety, and Workflow Best Practices
+
+- **Strict UI Policy**: Put debug information exclusively in server logs. NEVER render debug identifiers, developer tokens, or internal error objects into the HTML/UI.
+- **Git Hook Restrictions**: NEVER bypass Git hooks (`--no-verify`) without explicit user approval. Stop and investigate failures such as secret scanning to prevent compromised credentials.
+- **Never Push to Main**: NEVER push directly or merge automatically to `main`. Always open a PR, use `/deploy-pr-preview` for validation, and leave `/deploy-prod` to the user.
+- **Never Deploy to Production**: NEVER run `npx vercel --prod`, `vercel --prod`, `vercel deploy --prod`, or ANY command that triggers a production deployment, regardless of how small the change appears. Production deployments are done ONLY by the user via `/deploy-prod`. If a production redeploy is needed (e.g. after env var changes), tell the user and let them trigger it.
+
+### Vercel CLI Safety
+
+Safe, no approval needed:
+- `vercel env ls` — list environment variables
+- `vercel env pull` — pull env vars to local files
+- `vercel inspect` — inspect deployments
+- `vercel ls` / `vercel logs` — list and read deployments
+
+State-modifying, require user approval (but NOT production deployments):
+- `vercel env add` / `vercel env rm` — add or remove environment variables
+- `vercel cancel` — cancel a queued or building deployment
+
+**BANNED** — never run:
+- `vercel --prod` / `vercel deploy --prod` — deploys to production
+- `vercel promote` — promotes a deployment to production
+- `vercel alias` — aliases a deployment to a production domain
+
+These bans are additionally enforced as `deny` rules in `.claude/settings.json`.
+
+## Context Efficiency & Session Hygiene
+
+Ported from `.agent/rules/session-stability.md`. The Antigravity-specific parts (ptyHost
+crash pacing, `waitForPreviousTools`, `command_status` polling) do not apply to Claude Code
+and have been dropped; what remains are the rules that still hold here.
+
+1. **Batch related shell checks into one command.** Instead of five separate `curl` calls, run one command with `curl ... && curl ... && curl ...`. Independent commands may be issued in parallel in a single response.
+2. **Playwright snapshots**: ALWAYS pipe through `grep` to extract only relevant elements.
+   - Bad: `npx @playwright/cli -s=foo snapshot`
+   - Good: `npx @playwright/cli -s=foo snapshot 2>&1 | grep -E "heading|button|Agent|Approve" | head -10`
+3. **Command output**: pipe long output through `head`/`tail`/`grep` rather than dumping it whole.
+4. **File reads**: use `Read` with `offset`/`limit` when you know which section you need.
+5. **NEVER leave binary files** (PNGs, PDFs) in the project root. Save QA screenshots to a gitignored directory or delete them after use.
+6. **NEVER create `node_modules`** outside the project root without adding it to `.gitignore`.
+7. **Before starting a QA session**, verify the workspace is clean: `git status --short | grep '^??' | wc -l` should be under 20.
+8. **Kill stale processes** from crashed sessions before restarting: `pkill -f 'chrome.*playwright_user_data'`. Never plain `pkill chrome` — that kills the user's real browser.
+9. **After an interrupted session**, use `/recover-session` to rebuild context from compact artifacts and git state rather than re-reading a long transcript.
+10. At natural phase boundaries, write a walkthrough artifact and update the task list for cross-session continuity.

--- a/docs/architecture_and_strategy.md
+++ b/docs/architecture_and_strategy.md
@@ -93,3 +93,16 @@ Each proxy key can access multiple email accounts (via `key_email_access`):
 | OpenClaw | Local scripts + REST proxy API | Code flexibility, full API surface |
 | CLI | `npx fgac auth login` (separate npm package) | Power users, headless flows |
 | Direct API | `Bearer sk_proxy_...` to `gmail.fgac.ai` | Custom integrations |
+
+### Google Sheets Per-File Access Control (`drive.file`)
+In addition to Gmail, FGAC natively supports Google Sheets using Google's **Per-File Access Scope (`https://www.googleapis.com/auth/drive.file`)**.
+
+#### Key Architecture Principles for Sheets:
+1. **Zero CASA Audit Overhead**: Utilizing `drive.file` scope avoids restricted scope audits, requiring only standard Google verification (3-7 days, $0 cost).
+2. **Google Picker Integration**: Users intentionally select specific spreadsheets via the native Google Picker UI. Google's servers bind file permissions directly to the app's scope grant on Google's authorization servers.
+3. **FGAC Per-File Rules**: For each exposed spreadsheet, users can configure per-file permissions in the dashboard:
+   - **`sheet_read` (Read Only)**: Agents can fetch structure and read range data (`GET`), but mutating operations (`POST`, `PUT`, `PATCH`, `DELETE`) return `403 Forbidden`.
+   - **`sheet_read_write` (Read & Write)**: Agents can read cell ranges, update cell values, and append rows.
+   - **`sheet_block` (Blocked)**: Explicitly denies all agent operations for that file ID.
+4. **MCP Tools**: Exposes `sheets_get_spreadsheet`, `sheets_read_range`, `sheets_update_range`, and `sheets_append_rows` tools for MCP clients.
+

--- a/docs/implementation_plans/feature-google-drive-sheets-fgac_v1.md
+++ b/docs/implementation_plans/feature-google-drive-sheets-fgac_v1.md
@@ -1,0 +1,149 @@
+# Fine-Grained Access Control (FGAC) Expansion: Google Drive & Google Sheets
+
+Expand the Fine-Grained Access Control (FGAC) paradigm beyond Gmail to natively support **Google Drive** and **Google Sheets** APIs. This includes adding new OAuth scope configurations, extending database schemas and rule action types, adding REST proxy endpoint handlers, creating MCP tools for Drive & Sheets, and updating the dashboard UI and developer documentation.
+
+---
+
+## Architecture & Data Flow Overview
+
+```
+Agent (Claude / Custom SDK / REST / MCP)
+         │
+         ▼
+┌────────────────────────────────────────────────────────┐
+│               FGAC Proxy / MCP Server                  │
+│                                                        │
+│  1. Authenticate Proxy Key                             │
+│  2. Map target user & email                            │
+│  3. Evaluate Access Rules (Gmail | Drive | Sheets)     │
+│  4. Retrieve Real OAuth Token via Clerk                │
+└────────────────────────┬───────────────────────────────┘
+                         │
+        ┌────────────────┼────────────────┐
+        ▼                ▼                ▼
+   Gmail API         Drive API        Sheets API
+ (gmail.v1.users) (drive.v3.files) (v4.spreadsheets)
+```
+
+---
+
+## User Review Required
+
+> [!IMPORTANT]
+> **Google OAuth Scope Requirements**:
+> Expanding to Drive and Sheets requires adding the following OAuth scopes to your Clerk Dashboard Google Connection settings:
+> - **Google Drive**: `https://www.googleapis.com/auth/drive.readonly` and/or `https://www.googleapis.com/auth/drive.file` (or `https://www.googleapis.com/auth/drive`)
+> - **Google Sheets**: `https://www.googleapis.com/auth/spreadsheets.readonly` and/or `https://www.googleapis.com/auth/spreadsheets`
+> 
+> *Note:* Adding restricted scopes will require updating your Google Cloud OAuth consent screen settings and may trigger a Google CASA security re-review if moving to production.
+
+---
+
+## Open Questions
+
+> [!QUESTION]
+> **1. Scope Granularities**: Should default OAuth scope requests in Clerk request full Drive/Sheets access (`drive`, `spreadsheets`) or read-only/file-scoped access (`drive.readonly`, `spreadsheets.readonly`)?
+>
+> **2. Folder Path Resolution**: For Drive rules filtering by folder hierarchy (e.g. "Only allow files in Folder X"), should we resolve folder parent lineages dynamically via Drive API metadata calls on each request, or rely on explicit target folder IDs / file ID patterns?
+>
+> **3. Sheet Cell Content Redaction vs Block**: For Sheets access rules, should blocked read access reject the whole API call (403 Forbidden), or mask/redact sensitive columns/cells in the returned JSON? (Rejecting with 403 matches the current Gmail payload blocking pattern).
+
+---
+
+## Proposed Changes
+
+### Database & Schema Layer
+
+#### [MODIFY] [schema.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/db/schema.ts)
+- Update `accessRules.service` type comments and validator to include `'drive'` and `'sheets'`.
+- Expand supported `actionType` values:
+  - **Gmail**: `send_whitelist`, `read_blacklist`, `label_whitelist`, `label_blacklist`, `delete_whitelist`
+  - **Drive**: `drive_read_blacklist`, `drive_read_whitelist`, `drive_write_blacklist`, `drive_delete_blacklist`, `drive_share_blacklist`, `drive_folder_scope`
+  - **Sheets**: `sheets_read_blacklist`, `sheets_read_whitelist`, `sheets_edit_blacklist`, `sheets_export_blacklist`
+
+---
+
+### REST API Proxy Layer
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/proxy/[...path]/route.ts)
+- Extend `handleProxyRequest` to handle non-Gmail paths:
+  - Match Google Drive paths: `drive/v3/files/...`, `drive/v2/files/...`, `upload/drive/v3/files/...`
+  - Match Google Sheets paths: `v4/spreadsheets/...`
+- Implement rule evaluation logic for Drive:
+  - **Delete blocking**: Intercept `DELETE` requests to `drive/v3/files/{fileId}` or `POST` requests to `files/{fileId}/trash`.
+  - **Folder/File Whitelisting & Blacklisting**: Validate target `fileId` or file name regex against active `drive_read_blacklist` / `drive_read_whitelist` rules.
+  - **Share Blocking**: Block `POST` requests to `files/{fileId}/permissions` if `drive_share_blacklist` rules apply.
+- Implement rule evaluation logic for Sheets:
+  - **Spreadsheet/Tab Blacklisting**: Inspect URL parameters and body for `spreadsheetId` and sheet tab names (e.g., `'Salary'!A1:D10`), evaluating against `sheets_read_blacklist` and `sheets_edit_blacklist`.
+
+---
+
+### MCP Server Layer
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/mcp/route.ts)
+- Add new helper functions for Google Drive & Sheets APIs: `driveFetch(...)`, `sheetsFetch(...)`.
+- Implement new MCP Tools in the tool registry:
+  - **Drive Tools**:
+    - `drive_list_files`: Search & list Drive files with optional folder filtering.
+    - `drive_read_file`: Get file metadata and read text/document contents.
+    - `drive_create_file`: Upload/create a document or file in Drive.
+    - `drive_delete_file`: Delete or trash a file in Drive.
+    - `drive_share_file`: Manage file sharing permissions.
+  - **Sheets Tools**:
+    - `sheets_get_spreadsheet`: Fetch spreadsheet structure and tab metadata.
+    - `sheets_read_range`: Read cell values from a specified tab and range.
+    - `sheets_update_range`: Write/update cell values in a range.
+    - `sheets_append_rows`: Append data rows to an existing spreadsheet tab.
+    - `sheets_create`: Create a new Google Spreadsheet.
+- Wire all tools to enforce proxy key permission validation and apply service-specific rules (`drive` and `sheets`) prior to execution.
+
+---
+
+### Dashboard & UI Layer
+
+#### [MODIFY] [RuleControls.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/RuleControls.tsx)
+- Add `<option value="drive">Google Drive</option>` and `<option value="sheets">Google Sheets</option>` to the service selection dropdown.
+- Render dynamic rule action types and contextual help text based on the selected service (e.g., Regex for File/Folder ID or Sheet Tab Name).
+
+#### [MODIFY] [EditRuleButton.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/EditRuleButton.tsx)
+- Include `drive` and `sheets` options and form fields for rule editing.
+
+#### [MODIFY] [KeyControls.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/KeyControls.tsx)
+- Update code snippet modal and instructions to provide example SDK setup code for Google Drive and Google Sheets in Python (`api_endpoint`) and Node.js (`rootUrl`).
+
+#### [MODIFY] [ConnectGoogleWarning.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/ConnectGoogleWarning.tsx)
+- Update scope guidance and warnings to notify users when connecting accounts for Drive and Sheets functionality.
+
+---
+
+### Documentation Layer
+
+#### [MODIFY] [architecture_and_strategy.md](file:///home/kyesh/GitRepos/fine_grain_access_control/docs/architecture_and_strategy.md)
+- Document the expanded multi-service architecture (Gmail, Google Drive, Google Sheets).
+
+#### [MODIFY] [tech_stack.md](file:///home/kyesh/GitRepos/fine_grain_access_control/docs/tech_stack.md)
+- Update technical scope references and token vault examples to cover Drive and Sheets.
+
+#### [MODIFY] [user_guide.md](file:///home/kyesh/GitRepos/fine_grain_access_control/docs/user_guide.md)
+- Add end-user guides on setting up fine-grained rules for Google Drive folders and Google Sheets ranges.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+1. **Type Checking & Build Validation**:
+   - Run `npm run build` to verify no TypeScript compilation errors exist across new routes, schemas, and components.
+2. **Migration & DB Verification**:
+   - Validate schema updates and run `npm run db:push` / `npm run db:migrate` against local dev branch.
+3. **MCP & Proxy Route Testing**:
+   - Run unit and API route tests for proxy routing and rule evaluation on Gmail, Drive, and Sheets endpoints.
+
+### Manual Verification
+1. **Dashboard Rule Creation**:
+   - Create access rules for Drive (`drive_read_blacklist` for confidential folder IDs) and Sheets (`sheets_edit_blacklist` for Sensitive tab names).
+2. **MCP Tool Testing**:
+   - Connect MCP client (e.g. Claude Code or OpenClaw) and execute `drive_list_files`, `drive_read_file`, `sheets_read_range`, and `sheets_update_range`.
+   - Verify that blocked requests fail with clean `403 Forbidden` errors containing the rule violation explanation.
+3. **REST Proxy SDK Integration**:
+   - Test standard Google Python SDK (`google-api-python-client`) with `api_endpoint` set to proxy route for Drive (`/drive/v3`) and Sheets (`/v4/spreadsheets`).

--- a/docs/implementation_plans/feature-google-drive-sheets-fgac_v2.md
+++ b/docs/implementation_plans/feature-google-drive-sheets-fgac_v2.md
@@ -1,0 +1,136 @@
+# Fine-Grained Access Control (FGAC) Expansion: Google Drive & Sheets (v2)
+
+Expand the Fine-Grained Access Control (FGAC) paradigm to support **Google Drive** and **Google Sheets**, focusing on a **guarded, incremental opt-in flow for beta test users** and **single-spreadsheet document-level access control (Read vs Read/Write)** for V1.
+
+---
+
+## 1. Google OAuth Policies & Guarding Strategy
+
+### Google OAuth Verification & 100 Test User Policy
+- **Testing Status & Test Users**: In Google Cloud Console, any OAuth client in "Testing" mode allows up to **100 designated test user emails**.
+- **Scope Expansion Behavior**: When adding new restricted/sensitive scopes (`spreadsheets`, `drive.readonly`) to an existing OAuth app:
+  - Users listed on the **100 Test Users** list can grant the new scopes by acknowledging the standard Google "Unverified App" warning.
+  - General users outside the test list will be blocked by Google until formal CASA Tier 2 / OAuth verification is completed.
+
+### Feature Flagging & Selective Scope Requesting
+To protect general users from seeing unverified scope prompts or breaking existing Gmail functionality:
+1. **Default Scope Isolation**: General sign-up and login via Clerk will continue requesting **ONLY base Gmail scopes** (`gmail.modify`). No Drive or Sheets scopes are requested during standard user onboarding.
+2. **Dashboard Beta Guard**: Introduce a **"Google Drive & Sheets Integration (Beta)"** toggle / section in the dashboard UI.
+3. **Incremental Scope Upgrade Flow**: Only when an authorized user clicks **"Opt-in to Google Sheets Access"**, we trigger Clerk's incremental reauthorization flow:
+   ```ts
+   await existingGoogleAccount.reauthorize({
+     additionalScopes: [
+       'https://www.googleapis.com/auth/spreadsheets',
+       'https://www.googleapis.com/auth/drive.readonly'
+     ],
+     redirectUrl: window.location.href,
+     oidcPrompt: 'consent'
+   });
+   ```
+4. **Backend Scope Detection**: Before executing Drive or Sheets proxy/MCP calls, the backend checks if the stored token contains the required scopes. If missing, it returns a clean prompt instructing the user to enable the beta integration in their dashboard.
+
+---
+
+## 2. Document Access Control Model: Single Sheet Exposure (V1)
+
+### Comparison: Manual Spreadsheet ID Entry vs Google Picker API (`drive.file` scope)
+
+| Metric / Dimension | Option A: Manual Entry of Spreadsheet ID / URL (Selected for V1) | Option B: Google Picker API with `drive.file` Scope |
+| :--- | :--- | :--- |
+| **How it Works** | User pastes Google Sheet URL or ID (e.g., `https://docs.google.com/spreadsheets/d/1BxiM.../edit`) into the FGAC rule creator. System extracts `spreadsheetId` (`1BxiM...`). | User clicks "Select Sheet", Google Picker iframe pops up in browser. User picks 1 file. Token gets `drive.file` scope. |
+| **OAuth Scope Required** | Requires `spreadsheets` or `spreadsheets.readonly` scope on user's token. | Requires `https://www.googleapis.com/auth/drive.file` scope. |
+| **Enforcement Mechanism** | **FGAC Proxy Enforcement**: Proxy inspects every API call and rejects requests if `spreadsheetId` != an authorized `spreadsheetId` in `access_rules`. | **Google OAuth + FGAC Proxy**: Dual enforcement at Google token level and FGAC proxy level. |
+| **UX & Ergonomics** | Copy-paste Sheet URL/ID from browser bar (extremely simple and explicit). | Native file chooser popup modal. |
+| **Clerk Integration** | **100% Native & Seamless**: Token fetched via standard `clerkClient.users.getUserOauthAccessToken()`. | Requires passing raw OAuth access token directly into frontend JS (`gapi.load('picker')`), requiring a custom endpoint to expose token to UI. |
+| **Implementation Risk** | **Zero Risk**: Standard React text input + URL parser. | **Moderate**: External Google Picker SDK dependency and cross-origin iframe handling. |
+
+> **Decision for V1**: Use **Option A (Manual Entry with URL Auto-Parsing)**. It integrates seamlessly with Clerk, provides complete auditability in FGAC, and eliminates frontend SDK dependencies.
+
+---
+
+## 3. Simplified V1 Rule Architecture (Read vs Read & Write)
+
+Rather than implementing complex protected cells or range-level redaction in V1, the system will enforce **whole-document access control** per Google Spreadsheet ID:
+
+### Supported Rule Action Types for Sheets (V1)
+1. **`sheet_read`**: Allow **Read-Only** access (`GET` requests / read tools) to the specified Spreadsheet ID (`1BxiM...`). Block all `POST`, `PUT`, `PATCH`, `DELETE` operations.
+2. **`sheet_read_write`**: Allow **Read & Write** access (`GET`, `POST`, `PUT`, `PATCH`) to the specified Spreadsheet ID.
+3. **`sheet_block`**: Explicitly **Block All Access** to the specified Spreadsheet ID.
+
+---
+
+## Proposed Changes
+
+### Database & Schema Layer
+
+#### [MODIFY] [schema.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/db/schema.ts)
+- Update `accessRules.service` type definitions to include `'sheets'` (and `'drive'`).
+- Add V1 Sheets action types: `'sheet_read'`, `'sheet_read_write'`, `'sheet_block'`.
+- Store the target `spreadsheetId` in `accessRules.regexPattern` (or `targetResourceId`).
+
+---
+
+### Dashboard & UI Layer
+
+#### [NEW] [BetaFeatureToggle.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/BetaFeatureToggle.tsx)
+- Component rendering the "Google Drive & Sheets Integration (Beta)" card for test users.
+- Connects to Clerk's `account.reauthorize({ additionalScopes: [...] })` flow to request incremental scopes dynamically on user request.
+
+#### [MODIFY] [RuleControls.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/RuleControls.tsx)
+- Add "Google Sheets" option to service selector dropdown when beta feature is enabled.
+- Add input field for Spreadsheet URL/ID with auto-extraction logic (e.g., parsing `https://docs.google.com/spreadsheets/d/{spreadsheetId}/edit`).
+- Radio toggle for rule type: **Read Only** vs **Read & Write** vs **Block Access**.
+
+#### [MODIFY] [EditRuleButton.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/EditRuleButton.tsx)
+- Support editing existing single-sheet access rules.
+
+#### [MODIFY] [KeyControls.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/KeyControls.tsx)
+- Update code snippet modal with example Google Sheets API proxy calls in Python and Node.js using `rootUrl: 'https://sheets.fgac.ai/'`.
+
+---
+
+### REST API Proxy Layer
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/proxy/[...path]/route.ts)
+- Add route matcher for Google Sheets REST API endpoints (`/v4/spreadsheets/{spreadsheetId}/...`).
+- Extract target `spreadsheetId` from API path.
+- Evaluate proxy key rules for `service = 'sheets'`:
+  - If no rule matches `spreadsheetId` -> Return `403 Forbidden` ("Spreadsheet not exposed via FGAC rules").
+  - If rule is `sheet_block` -> Return `403 Forbidden`.
+  - If request method is mutating (`POST`, `PUT`, `PATCH`, `DELETE`) and rule is `sheet_read` -> Return `403 Forbidden` ("Write access denied on this spreadsheet").
+  - If rule is `sheet_read_write` -> Allow request and forward with Clerk Google OAuth token.
+
+---
+
+### MCP Server Layer
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/mcp/route.ts)
+- Add `sheetsFetch(...)` helper function hitting `https://sheets.googleapis.com/v4/spreadsheets/...`.
+- Implement initial Sheets MCP Tools:
+  - **`sheets_get_spreadsheet`**: Get metadata and sheet/tab names for an allowed spreadsheet.
+  - **`sheets_read_range`**: Read values from a specific range in an allowed spreadsheet.
+  - **`sheets_update_range`**: Write/update values in a range (requires `sheet_read_write` rule).
+  - **`sheets_append_rows`**: Append rows to a table (requires `sheet_read_write` rule).
+- Wire all tools to enforce `sheet_read` vs `sheet_read_write` permissions prior to executing API calls.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+1. **Build & Type Check**:
+   - Run `npm run build` to verify no TypeScript compilation errors exist.
+2. **Schema & Migration Safety**:
+   - Run `npm run db:branch` and `npm run db:push` to test DB migration cleanly.
+
+### Manual Verification
+1. **Incremental Scope Upgrade Test**:
+   - Sign in as a test user. Verify default login asks ONLY for Gmail scopes.
+   - Click "Opt-in to Google Sheets Integration (Beta)" in dashboard. Verify Clerk triggers reauthorization modal for `spreadsheets` scope.
+2. **Single Sheet Rule Creation**:
+   - Paste a Google Sheet URL into the rule creator. Verify system auto-extracts `spreadsheetId`.
+   - Create a `sheet_read` (Read Only) rule for Proxy Key A.
+3. **MCP Tool Testing**:
+   - Call `sheets_read_range` with Proxy Key A on the allowed spreadsheet -> Succeeds.
+   - Call `sheets_update_range` with Proxy Key A on the allowed spreadsheet -> Fails with `403 Forbidden` (Read Only restriction enforced).
+   - Call `sheets_read_range` on an unlisted spreadsheet -> Fails with `403 Forbidden` (Default Deny enforced).

--- a/docs/implementation_plans/feature-google-drive-sheets-fgac_v3.md
+++ b/docs/implementation_plans/feature-google-drive-sheets-fgac_v3.md
@@ -1,0 +1,145 @@
+# Fine-Grained Access Control (FGAC) Expansion: Google Sheets (v3)
+
+Expand the Fine-Grained Access Control (FGAC) paradigm to support **Google Sheets**, focusing on backend-controlled user permissions, single-spreadsheet document-level access control (Read vs Read/Write), and clear scope approval pathways.
+
+> [!NOTE]
+> Google Drive support has been explicitly removed from this scope to focus purely on Google Sheets.
+
+---
+
+## 1. Google OAuth Policies for Published Apps
+
+### Published App Behavior for New Unapproved Scopes
+When an existing **Published App** (already live in production with verified Gmail scopes) requests new, unapproved Google OAuth scopes (such as `spreadsheets` or `drive.file`):
+
+1. **Existing Capabilities Retained**: The app remains fully published and operational for all previously verified scopes (e.g., Gmail). Existing users are not broken or logged out.
+2. **Unverified App Warning**: When requesting the new unapproved scope, users will see Google's **"Google hasn't verified this app"** warning screen.
+3. **100 Unverified User Cap**: Google enforces a hard cap of **100 total unverified users** for the new scope. Any user (up to 100) can click *"Advanced -> Go to App Name (unsafe)"* to authorize the new scope during beta testing. Once 100 users have authorized the unapproved scope, Google blocks subsequent authorization requests until verification is complete.
+
+---
+
+## 2. Google Verification & Approval Process Comparison
+
+Google categorizes scopes into **Restricted**, **Sensitive**, and **Non-Sensitive**. Below is the exact approval breakdown for the two architecture options:
+
+```
+                  ┌─────────────────────────────────────────┐
+                  │          Google OAuth Scopes            │
+                  └────────────────────┬────────────────────┘
+                                       │
+            ┌──────────────────────────┴──────────────────────────┐
+            ▼                                                     ▼
+Option A: Restricted Scope                             Option B: Per-File Scope
+https://www.googleapis.com/auth/spreadsheets           https://www.googleapis.com/auth/drive.file
+  • CASA Tier 2 Audit ($500-$3,000+)                     • No CASA Audit ($0)
+  • 4 to 8 Weeks Verification                            • 3 to 7 Days Verification
+  • Access to all Sheets (FGAC filters)                  • Access only to selected Sheet
+```
+
+### Detailed Comparison Matrix
+
+| Metric / Requirement | Option A: Full Sheets Scope (`spreadsheets`) | Option B: Per-File Scope (`drive.file`) |
+| :--- | :--- | :--- |
+| **Google Scope Category** | **Restricted Scope** | **Recommended / Sensitive Scope** |
+| **Security Audit (CASA)** | **Required** (CASA Tier 2 independent security lab audit) | **NOT Required** |
+| **Verification Timeline** | **4 to 8 Weeks** | **3 to 7 Business Days** |
+| **Verification Cost** | **$500 – $3,000+** | **$0** |
+| **Unverified Limit** | 100 users total | 100 users total |
+| **File Management** | Grants access to all user spreadsheets; **FGAC Proxy** enforces which single `spreadsheetId` an agent can access. | Google OAuth grants access **only to the file(s) selected by the user** in the Google Picker modal. |
+| **Read & Write Ability** | **Full Read & Write** across spreadsheets. | **Full Read & Write** on the specific selected file(s). |
+| **Clerk Integration** | **Seamless**: Standard `clerkClient.users.getUserOauthAccessToken()` works out of the box. | Requires a backend API endpoint to pass a short-lived token to `gapi.picker.PickerBuilder()`. |
+| **User Experience** | User pastes Google Sheet URL/ID into FGAC. | User clicks "Select Sheet" and picks file via Google Picker UI. |
+
+> **Recommendation**:
+> - **V1 Alpha / Immediate Testing**: Use **Option A** with manual URL entry for backend-approved test users (up to 100 users under Google's unverified app cap).
+> - **Production Scale**: Migrate to **Option B (`drive.file`)** or submit Option A for CASA Tier 2 verification before expanding past 100 users.
+
+---
+
+## 3. Backend User Guarding & Scope Upgrade Mechanics
+
+### Backend Data Guard (No Dashboard UI Needed)
+- No user-facing frontend beta toggles or public UI switches will be created.
+- Access to the Google Sheets integration is controlled strictly by backend database flags (e.g. `users.can_access_sheets_beta = true` or a backend whitelist).
+
+### Clerk Token Vault & Incremental Scope Upgrades
+- **Default Sign-up**: Standard user signup continues requesting **ONLY base Gmail scopes** (`gmail.modify`).
+- **Incremental Scope Upgrade**: For backend-enabled test users, when they connect Google Sheets capability, we call Clerk's `account.reauthorize({ additionalScopes: ['https://www.googleapis.com/auth/spreadsheets'] })`.
+- **Clerk Architecture**:
+  1. Clerk handles the OAuth 2.0 incremental authorization (`include_granted_scopes=true`).
+  2. Clerk stores the resulting refresh token in its SOC2-compliant vault.
+  3. When an agent calls the FGAC Proxy or MCP server, the backend calls `clerkClient.users.getUserOauthAccessToken(userId, 'oauth_google')` to fetch the valid access token.
+
+---
+
+## 4. Single-Sheet Access Control Model (V1)
+
+For V1, access control is enforced at the **whole spreadsheet level** (by `spreadsheetId`):
+
+### Supported Action Types
+1. **`sheet_read`**: Grants **Read-Only** access (`GET /v4/spreadsheets/{spreadsheetId}...`). Mutating calls (`POST`, `PUT`, `PATCH`, `DELETE`) are blocked with `403 Forbidden`.
+2. **`sheet_read_write`**: Grants **Read & Write** access (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`) to the specified spreadsheet.
+3. **`sheet_block`**: Explicitly **Blocks All Access** to the specified spreadsheet.
+
+---
+
+## Proposed Technical Changes
+
+### Database & Schema Layer
+
+#### [MODIFY] [schema.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/db/schema.ts)
+- Update `accessRules.service` comments to include `'sheets'`.
+- Add Sheets V1 action types: `'sheet_read'`, `'sheet_read_write'`, `'sheet_block'`.
+- Target `spreadsheetId` stored in `accessRules.regexPattern`.
+
+---
+
+### REST API Proxy Layer
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/proxy/[...path]/route.ts)
+- Add route handler for `/v4/spreadsheets/{spreadsheetId}/...`.
+- Extract target `spreadsheetId` from incoming API path.
+- Evaluate proxy key rules for `service = 'sheets'`:
+  - If no rule matches `spreadsheetId` -> Return `403 Forbidden` ("Spreadsheet not permitted").
+  - If rule is `sheet_block` -> Return `403 Forbidden`.
+  - If request is mutating (`POST`, `PUT`, `PATCH`, `DELETE`) and rule is `sheet_read` -> Return `403 Forbidden` ("Write access denied").
+  - If rule is `sheet_read_write` -> Forward request to `https://sheets.googleapis.com` using Clerk OAuth token.
+
+---
+
+### MCP Server Layer
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/mcp/route.ts)
+- Add helper `sheetsFetch(token, path, method, body)`.
+- Register Sheets MCP Tools:
+  - **`sheets_get_spreadsheet`**: Get metadata and sheet/tab names for an allowed spreadsheet.
+  - **`sheets_read_range`**: Read cell values from an allowed spreadsheet.
+  - **`sheets_update_range`**: Write/update cell values (requires `sheet_read_write` rule).
+  - **`sheets_append_rows`**: Append data rows (requires `sheet_read_write` rule).
+- Wire all tools to enforce proxy key permission validation before calling Sheets API.
+
+---
+
+### Documentation Layer
+
+#### [MODIFY] [architecture_and_strategy.md](file:///home/kyesh/GitRepos/fine_grain_access_control/docs/architecture_and_strategy.md)
+- Update strategy documentation to detail Gmail + Google Sheets fine-grained proxying.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+1. **Build & Type Check**:
+   - Run `npm run build` to verify clean TypeScript compilation.
+2. **Database Verification**:
+   - Verify schema updates against dev database.
+
+### Manual Verification
+1. **Backend User Permission Check**:
+   - Enable `can_access_sheets_beta` for a test user in DB.
+2. **Single Sheet Rule Validation**:
+   - Create a `sheet_read` rule for Proxy Key A on spreadsheet ID `1BxiM...`.
+   - Execute `sheets_read_range` via MCP tool -> Verify Success.
+   - Execute `sheets_update_range` via MCP tool -> Verify `403 Forbidden` (Read Only restriction enforced).
+   - Execute `sheets_read_range` on an unlisted spreadsheet -> Verify `403 Forbidden` (Default Deny enforced).

--- a/docs/implementation_plans/feature-google-drive-sheets-fgac_v4.md
+++ b/docs/implementation_plans/feature-google-drive-sheets-fgac_v4.md
@@ -1,0 +1,160 @@
+# Fine-Grained Access Control (FGAC) Expansion: Google Sheets via Per-File Scope (`drive.file`) (v4)
+
+Fully flushed-out implementation plan to expand FGAC to **Google Sheets** using Google's **Per-File Access Scope (`https://www.googleapis.com/auth/drive.file`)** and **Google Picker API**. 
+
+This design eliminates the need for expensive CASA Tier 2 security audits ($0 cost, 3-7 day verification), avoids unverified user caps or feature flag restrictions, and provides an **intentional user upgrade flow** with **per-file granular permission management (Read, Read/Write, Block)** directly in the FGAC dashboard.
+
+---
+
+## 1. Architecture & Security Flow
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────────┐
+│                                 1. Intentional Upgrade                                 │
+│ User clicks "Add Google Sheets" in FGAC Dashboard                                      │
+│   │                                                                                    │
+│   ▼                                                                                    │
+│ Clerk Incremental OAuth: reauthorize({ additionalScopes: ['drive.file'] })            │
+└──────────────────────────────────────────┬─────────────────────────────────────────────┘
+                                           │
+                                           ▼
+┌────────────────────────────────────────────────────────────────────────────────────────┐
+│                               2. Google Picker Modal                                   │
+│ Frontend fetches temp picker token from /api/auth/google-picker-token                  │
+│ Native Google Picker UI opens -> User picks 1 or more Google Sheets                    │
+│   │                                                                                    │
+│   ▼                                                                                    │
+│ Google grants drive.file scope access ONLY to selected spreadsheet IDs                 │
+└──────────────────────────────────────────┬─────────────────────────────────────────────┘
+                                           │
+                                           ▼
+┌────────────────────────────────────────────────────────────────────────────────────────┐
+│                          3. Per-File Rules & Management                                │
+│ FGAC stores access_rules per spreadsheet ID with user-configured permission:           │
+│   • Read Only (sheet_read)                                                             │
+│   • Read & Write (sheet_read_write)                                                    │
+│   • Blocked (sheet_block)                                                              │
+└──────────────────────────────────────────┬─────────────────────────────────────────────┘
+                                           │
+                                           ▼
+┌────────────────────────────────────────────────────────────────────────────────────────┐
+│                         4. Agent Proxy & MCP Execution                                 │
+│ Agent calls Proxy/MCP -> FGAC validates proxy key & per-file permission                │
+│ FGAC fetches OAuth token from Clerk Vault -> Forwards call to Google Sheets API        │
+└────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Why Per-File Scope (`drive.file`) is Superior
+
+1. **No CASA Tier 2 Security Audit**: `drive.file` is a Google-recommended narrow scope. It requires standard verification (3–7 days, $0 fee) vs full CASA Tier 2 audit (4–8 weeks, $500–$3,000+).
+2. **No Feature Flag or User Cap Needed**: Because `drive.file` is non-restricted, it works smoothly for all production users without unverified app warnings or 100-user caps.
+3. **Double-Layer Least Privilege**:
+   - **Google OAuth Level**: Google's API *physically restricts* the OAuth token from reading/writing any file the user did not explicitly select in Google Picker.
+   - **FGAC Proxy Level**: FGAC Proxy enforces fine-grained Read vs Read/Write vs Block rules per selected file per Proxy Key.
+
+---
+
+## 3. Detailed Component Architecture
+
+### A. Clerk & Google Picker Token Bridge
+
+Because Clerk intentionally keeps raw OAuth access tokens on the backend server for security, we build a lightweight, authenticated bridge for Google Picker:
+
+#### [NEW] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/auth/google-picker-token/route.ts)
+- Authenticated Next.js route (`auth()` via Clerk).
+- Fetches user's Google OAuth access token via `clerkClient.users.getUserOauthAccessToken(userId, 'oauth_google')`.
+- Returns `{ accessToken, clientId }` back to the authenticated dashboard frontend to initialize Google Picker.
+
+---
+
+### B. Google Picker Component & Intentional Upgrade Flow
+
+#### [NEW] [useGooglePicker.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/useGooglePicker.ts)
+- React hook to dynamically load Google Picker JS SDK (`https://apis.google.com/js/api.js`).
+- Handles checking if user has granted `drive.file` scope via Clerk:
+  - If missing: Triggers `user.externalAccounts[0].reauthorize({ additionalScopes: ['https://www.googleapis.com/auth/drive.file'] })`.
+  - Once scope is granted: Launches `google.picker.PickerBuilder()` configured for Google Spreadsheets (`google.picker.ViewId.SPREADSHEETS`).
+- Supports **Multi-File Selection**: User can select multiple spreadsheets in a single picker session or reopen picker anytime to add more files.
+- On file selection (`ACTION_PICKED`), receives document objects:
+  ```json
+  [
+    { "id": "1BxiMVs0...", "name": "Q3 Financials", "mimeType": "application/vnd.google-apps.spreadsheet" }
+  ]
+  ```
+- Submits selected files to FGAC backend route `/api/rules/grant-sheets-access`.
+
+---
+
+### C. Per-File Dashboard Management UI
+
+#### [NEW] [ExposedSheetsManager.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/ExposedSheetsManager.tsx)
+- Renders an **"Exposed Google Sheets"** card in the dashboard.
+- Displays a table of all spreadsheets added by the user:
+  - **File Name & Icon**: e.g., `Q3 Financials` (with Google Sheets icon).
+  - **Spreadsheet ID**: Truncated ID with copy button.
+  - **Permission Selector (Per File)**:
+    - `<select>` dropdown with options:
+      - `Read Only` (`sheet_read`): Agent can read cells and metadata. Mutating calls are blocked (403).
+      - `Read & Write` (`sheet_read_write`): Agent can read, update, and append rows.
+      - `Blocked` (`sheet_block`): Agent access is explicitly denied (403).
+  - **Proxy Key Scoping**: Select which proxy keys (e.g. "Claude Agent", "Work Bot") can access this file.
+  - **Action**: "Remove / Revoke Access" button (deletes rule).
+- Includes **"Add Google Sheet +"** primary button to launch Google Picker.
+
+---
+
+### D. REST Proxy Enforcement
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/proxy/[...path]/route.ts)
+- Intercepts paths matching `/v4/spreadsheets/{spreadsheetId}...`.
+- Extracts `spreadsheetId`.
+- Queries `accessRules` for `service = 'sheets'` and `targetResourceId = spreadsheetId`.
+- **Enforcement Rules**:
+  - No matching rule -> Return `403 Forbidden` ("Spreadsheet not exposed in FGAC").
+  - Rule is `sheet_block` -> Return `403 Forbidden` ("Access to this sheet is blocked").
+  - Mutating request (`POST`, `PUT`, `PATCH`, `DELETE`) and rule is `sheet_read` -> Return `403 Forbidden` ("Write permission denied on this spreadsheet").
+  - Rule is `sheet_read_write` (or `sheet_read` for `GET`) -> Retrieve Google token from Clerk & proxy request to `https://sheets.googleapis.com`.
+
+---
+
+### E. MCP Server Tools
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/mcp/route.ts)
+- Add `sheetsFetch(...)` helper for Sheets REST API.
+- Implement Sheets MCP Tools:
+  - **`sheets_get_spreadsheet`**: Get sheet names/tabs and structural metadata.
+  - **`sheets_read_range`**: Read values from range (e.g. `'Sheet1'!A1:C10`). Allowed for `sheet_read` and `sheet_read_write`.
+  - **`sheets_update_range`**: Update values in range. Requires `sheet_read_write`.
+  - **`sheets_append_rows`**: Append new data rows. Requires `sheet_read_write`.
+- All tools validate proxy key assignment and per-file rules before calling Google API.
+
+---
+
+### F. Database Schema
+
+#### [MODIFY] [schema.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/db/schema.ts)
+- Add `targetResourceId` text column to `accessRules` (or utilize `regexPattern` for `spreadsheetId`).
+- Add resource metadata columns: `resourceName` (e.g. "Q3 Financials").
+- Update supported action types: `'sheet_read'`, `'sheet_read_write'`, `'sheet_block'`.
+
+---
+
+## 4. Verification & Testing Plan
+
+### Automated Verification
+1. `npm run build`: Verify TypeScript compilation across new routes, picker hooks, and components.
+2. DB Migration: `npm run db:branch` and `npm run db:push` to verify schema updates.
+
+### Manual Acceptance Flow
+1. **Scope Upgrade**: Click "Add Google Sheet +" in FGAC dashboard. Verify Clerk triggers scope consent for `https://www.googleapis.com/auth/drive.file`.
+2. **Google Picker**: Verify Google Picker modal launches and displays user's Google Sheets. Select 2 spreadsheets.
+3. **Per-File Rules UI**:
+   - Set Sheet 1 to `Read Only`.
+   - Set Sheet 2 to `Read & Write`.
+4. **Proxy & MCP Verification**:
+   - Call `sheets_read_range` on Sheet 1 -> Succeeds.
+   - Call `sheets_update_range` on Sheet 1 -> Fails with `403 Forbidden`.
+   - Call `sheets_update_range` on Sheet 2 -> Succeeds.
+   - Change Sheet 1 to `Blocked` in dashboard -> Calling `sheets_read_range` on Sheet 1 immediately returns `403 Forbidden`.

--- a/docs/implementation_plans/feature-google-drive-sheets-fgac_v5.md
+++ b/docs/implementation_plans/feature-google-drive-sheets-fgac_v5.md
@@ -1,0 +1,144 @@
+# Fine-Grained Access Control (FGAC) Expansion: Google Sheets via Per-File Scope (`drive.file`) (v5)
+
+Fully flushed-out implementation plan to expand FGAC to **Google Sheets** using Google's **Per-File Access Scope (`https://www.googleapis.com/auth/drive.file`)**, **Google Picker API**, and **Clerk Token Vault**.
+
+---
+
+## 1. Token Vault Architecture & Persistence Mechanics
+
+### Where are Access Tokens & Scopes Persisted?
+**Zero Token Liability**: The FGAC application and Neon Postgres database **NEVER** store raw Google OAuth Access Tokens or Refresh Tokens. All OAuth credentials and granted scopes are persisted exclusively in **Clerk's SOC2-compliant Token Vault**.
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                   Token Storage & Refresh Flow                                 │
+└────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+1. Scope Reauthorization Prompt
+   Frontend triggers: externalAccount.reauthorize({ additionalScopes: ['drive.file'] })
+      │
+      ▼
+2. Google OAuth 2.0 Authorization Endpoint
+   User grants drive.file scope in Google's Consent Screen
+      │
+      ▼
+3. Clerk OAuth Callback Server (https://<clerk-domain>/v1/oauth/callback)
+   Google redirects authorization code to Clerk.
+   Clerk's backend server exchanges code with Google for new Access Token & Refresh Token.
+      │
+      ▼
+4. Clerk Encrypted Token Vault (SOC2 Audited Infrastructure)
+   Clerk automatically updates the user's external_account record.
+   The new Refresh Token (containing gmail.modify + drive.file scopes) is persisted in Clerk.
+   Browser receives redirect back to FGAC Dashboard.
+      │
+      ▼
+5. File Selection in Google Picker
+   User selects Spreadsheet 1BxiM... in Google Picker.
+   Google's OAuth Servers register 1BxiM... under the user's drive.file grant.
+   FGAC saves ONLY metadata (spreadsheetId, name, permission level) in Neon Postgres access_rules.
+      │
+      ▼
+6. Proxy Request Execution
+   Agent calls FGAC REST Proxy / MCP Server -> FGAC validates proxy key.
+   FGAC queries Clerk Backend SDK: clerkClient.users.getUserOauthAccessToken(userId, 'oauth_google')
+   Clerk retrieves fresh token from Vault -> FGAC forwards to https://sheets.googleapis.com.
+```
+
+### Detailed Token Lifecycle Summary
+
+| Lifecycle Phase | Handled By | Storage Location | Data Stored |
+| :--- | :--- | :--- | :--- |
+| **OAuth Scope Upgrade** | Clerk OAuth Redirect Handler | Clerk Token Vault | Google Refresh Token with `gmail.modify` + `drive.file` scopes |
+| **Token Expiration / Refresh**| Clerk Backend SDK | Clerk Infrastructure | Automatic token exchange with `oauth2.googleapis.com/token` |
+| **File Selection Grant** | Google OAuth Servers | Google Authorization Server | File ID permission binding (`1BxiM...`) |
+| **FGAC Access Rules** | FGAC Backend API | Neon Postgres DB (`access_rules`) | `spreadsheetId`, `resourceName`, `permission` (`sheet_read` / `sheet_read_write`), `proxyKeyId` |
+
+---
+
+## 2. Complete Integration Architecture
+
+### A. Intentional Scope Upgrade Flow
+
+#### [NEW] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/auth/google-picker-token/route.ts)
+- Authenticated Next.js route (`auth()` via Clerk).
+- Fetches the user's fresh Google OAuth access token from Clerk's Vault using `clerkClient.users.getUserOauthAccessToken(userId, 'oauth_google')`.
+- Returns `{ accessToken, clientId }` back to the frontend to initialize the Google Picker modal.
+
+#### [NEW] [useGooglePicker.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/useGooglePicker.ts)
+- Custom React hook managing Google Picker initialization and scope checking.
+- Step 1: Checks if user's Clerk account has granted `drive.file` scope.
+- Step 2: If missing, calls `existingGoogleAccount.reauthorize({ additionalScopes: ['https://www.googleapis.com/auth/drive.file'] })`.
+- Step 3: Once Clerk completes reauthorization and returns to the dashboard, hook fetches temporary token from `/api/auth/google-picker-token` and launches `google.picker.PickerBuilder()`.
+- Step 4: User selects 1 or more Google Sheets in Picker.
+- Step 5: Hook posts selected spreadsheet metadata (`id`, `name`) to FGAC backend route `/api/rules/grant-sheets-access`.
+
+---
+
+### B. FGAC Database Schema Updates
+
+#### [MODIFY] [schema.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/db/schema.ts)
+- Add `targetResourceId` text column to `accessRules` for storing Google `spreadsheetId`.
+- Add `resourceName` text column to `accessRules` for storing human-readable document titles (e.g., "Q3 Financials").
+- Update supported action types: `'sheet_read'`, `'sheet_read_write'`, `'sheet_block'`.
+
+---
+
+### C. Per-File Dashboard Management UI
+
+#### [NEW] [ExposedSheetsManager.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/ExposedSheetsManager.tsx)
+- Dashboard component rendering the **"Exposed Google Sheets"** manager.
+- Displays table of all exposed spreadsheets:
+  - Document Title & Google Sheets Icon.
+  - Spreadsheet ID (truncated).
+  - **Permission Selector**:
+    - `Read Only` (`sheet_read`): Read cells (`GET`), block mutating calls (403).
+    - `Read & Write` (`sheet_read_write`): Read, update cells, and append rows.
+    - `Blocked` (`sheet_block`): Block all access (403).
+  - **Proxy Key Mapping**: Select which proxy keys can access this sheet.
+  - **Remove / Revoke Access**: Deletes rule from FGAC.
+- Includes **"Add Google Sheet +"** primary button to launch Google Picker.
+
+---
+
+### D. REST Proxy Enforcement Engine
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/proxy/[...path]/route.ts)
+- Intercepts requests to `/v4/spreadsheets/{spreadsheetId}...`.
+- Extracts `spreadsheetId`.
+- Evaluates rules in `accessRules` for matching `targetResourceId`:
+  - No rule found -> Return `403 Forbidden` ("Spreadsheet not exposed in FGAC").
+  - Rule is `sheet_block` -> Return `403 Forbidden`.
+  - Mutating request (`POST`, `PUT`, `PATCH`, `DELETE`) with `sheet_read` rule -> Return `403 Forbidden`.
+  - Allowed -> Fetch real token from Clerk Vault via `getUserOauthAccessToken()` and forward request to `https://sheets.googleapis.com`.
+
+---
+
+### E. MCP Server Integration
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/mcp/route.ts)
+- Implement `sheetsFetch(token, path, method, body)`.
+- Register Sheets MCP Tools:
+  - **`sheets_get_spreadsheet`**: Get tab names and structure.
+  - **`sheets_read_range`**: Read values from range.
+  - **`sheets_update_range`**: Update values in range (requires `sheet_read_write`).
+  - **`sheets_append_rows`**: Append rows (requires `sheet_read_write`).
+- Enforce proxy key permissions and per-file rules before execution.
+
+---
+
+## 3. Verification & Testing Plan
+
+### Automated Verification
+1. `npm run build`: Type-check Next.js API routes and components.
+2. DB Migration: Run `npm run db:branch` and `npm run db:push` on local dev branch.
+
+### Manual Acceptance Flow
+1. **Scope Reauthorization**: Click "Add Google Sheet +" -> Verify Clerk reauthorize flow redirects to Google consent screen for `drive.file`.
+2. **Token Vault Storage**: Verify Google returns to Clerk callback, and Clerk updates stored tokens in vault.
+3. **Google Picker Selection**: Select 2 Google Sheets. Verify FGAC creates `access_rules` with spreadsheet IDs and titles.
+4. **Per-File Rules UI**: Set Sheet 1 to `Read Only` and Sheet 2 to `Read & Write`.
+5. **Proxy & MCP Enforcement**:
+   - Call `sheets_read_range` on Sheet 1 -> Succeeds.
+   - Call `sheets_update_range` on Sheet 1 -> Returns `403 Forbidden`.
+   - Call `sheets_update_range` on Sheet 2 -> Succeeds.

--- a/docs/implementation_plans/feature-google-drive-sheets-fgac_v6.md
+++ b/docs/implementation_plans/feature-google-drive-sheets-fgac_v6.md
@@ -1,0 +1,149 @@
+# Fine-Grained Access Control (FGAC) Expansion: Google Sheets via Per-File Scope (`drive.file`) (v6)
+
+Deep-dive implementation plan detailing the exact two-phase mechanics of **OAuth Scope Upgrade (Clerk Token Vault)** vs **Per-File Selection Permission Binding (Google Authorization Servers)**.
+
+---
+
+## 1. Deep Dive: Token & Scope Persistence Mechanics
+
+To answer the core question of **where tokens and scopes are stored when selecting files**:
+
+> **The Short Answer**:
+> Your intuition is **100% correct!** We do **NOT** need to send a new token to Clerk after the user selects a file in Google Picker.
+> 
+> When a user selects a sheet in Google Picker, **Google's servers directly update the permission grant for the existing OAuth token in Google's database.** Clerk already holds the `drive.file` Refresh Token in its vault from the initial scope authorization step.
+
+---
+
+### The Two Distinct Phases of `drive.file` Access
+
+```
+┌───────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ PHASE 1: OAuth Scope Authorization (Handled & Persisted by Clerk)                                │
+└───────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+1. User clicks "Add Google Sheet +" in FGAC Dashboard.
+2. Frontend calls Clerk SDK: user.externalAccounts[0].reauthorize({ additionalScopes: ['drive.file'] })
+3. User approves drive.file scope in Google's Consent Screen.
+4. Google redirects authorization code to Clerk Callback Server (https://<clerk-domain>/v1/oauth/callback).
+5. Clerk Backend exchanges code with Google for a Refresh Token containing `gmail.modify` + `drive.file`.
+6. CLERK PERSISTS THIS REFRESH TOKEN IN CLERK'S ENCRYPTED TOKEN VAULT.
+
+Result of Phase 1: Clerk holds an active Refresh Token authorized for `drive.file`.
+At this exact moment, the token does NOT yet have access to any specific file.
+
+┌───────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ PHASE 2: Per-File Selection in Google Picker (Handled & Persisted by Google Servers)             │
+└───────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+1. Frontend opens Google Picker modal using a short-lived access token derived from Clerk.
+2. User selects "Q3 Financials" (Spreadsheet ID: 1BxiMVs0...).
+3. Google Picker (running inside Google's official iframe) notifies Google's Backend API:
+   "User X has explicitly granted App Y (Client ID) access to File ID 1BxiMVs0..."
+4. GOOGLE'S OAUTH AUTHORIZATION SERVERS BIND FILE ID 1BxiMVs0... TO THE APP'S SCOPE GRANT IN GOOGLE'S DATABASE.
+5. NO NEW TOKEN OR SCOPE PAYLOAD IS SENT TO CLERK! Clerk's existing Refresh Token from Phase 1 is NOW
+   capable of fetching access tokens that can read/write Spreadsheet 1BxiMVs0...
+6. Frontend posts ONLY metadata ({ spreadsheetId: "1BxiMVs0...", name: "Q3 Financials" }) to FGAC backend
+   to save in Neon Postgres access_rules table.
+
+Result of Phase 2: Google's API Gateway will now accept API calls targeting 1BxiMVs0... when signed by
+the user's access token fetched from Clerk!
+```
+
+---
+
+### Detailed Comparison: What Gets Persisted Where?
+
+| Component | Responsible Party | Where It Is Saved | Exact Data Saved |
+| :--- | :--- | :--- | :--- |
+| **OAuth Refresh Token & Scope** | Clerk Vault | Clerk Infrastructure (SOC2 Audited) | Encrypted Google Refresh Token granted with `gmail.modify` and `https://www.googleapis.com/auth/drive.file`. |
+| **File-Level Access Binding** | Google Cloud OAuth Infrastructure | Google Authorization Database | Permission entry linking `(User ID, Client ID, File ID: 1BxiMVs0...)`. |
+| **FGAC Policy & Key Rules** | FGAC Backend App | Neon Postgres Database (`access_rules`) | `spreadsheetId: "1BxiMVs0..."`, `resourceName: "Q3 Financials"`, `permission: "sheet_read"`, `proxyKeyId`. |
+
+---
+
+## 2. Complete Component Specifications
+
+### A. Token Bridge Endpoint for Picker Initialization
+
+#### [NEW] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/auth/google-picker-token/route.ts)
+- Authenticated Next.js route (`auth()` via Clerk).
+- Fetches the user's fresh Google OAuth access token from Clerk's Vault via `clerkClient.users.getUserOauthAccessToken(userId, 'oauth_google')`.
+- Returns `{ accessToken, clientId }` to the frontend strictly for initializing `gapi.picker.PickerBuilder()`.
+
+---
+
+### B. Google Picker Hook & Step-by-step Flow
+
+#### [NEW] [useGooglePicker.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/useGooglePicker.ts)
+- React hook to orchestrate Phase 1 (Clerk Reauthorization) and Phase 2 (Google Picker Launch):
+  1. **Check Scope**: Checks if the user's Clerk account has `drive.file` in its scopes.
+  2. **Phase 1 Trigger**: If missing, triggers `externalAccount.reauthorize({ additionalScopes: ['https://www.googleapis.com/auth/drive.file'] })`. User grants scope -> Clerk receives & saves new token in Vault.
+  3. **Phase 2 Trigger**: Once scope is present, hook fetches temporary token from `/api/auth/google-picker-token` and opens Google Picker modal.
+  4. **File Selection**: User selects 1 or more Google Sheets. Google's servers register the file IDs automatically under the `drive.file` grant.
+  5. **Rule Persistence**: Hook receives selected document metadata (`id`, `name`) and posts to FGAC backend route `/api/rules/grant-sheets-access`.
+
+---
+
+### C. FGAC Database Schema
+
+#### [MODIFY] [schema.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/db/schema.ts)
+- Add `targetResourceId` text column to `accessRules` to store `spreadsheetId`.
+- Add `resourceName` text column to `accessRules` to store human-readable file title.
+- Update supported action types: `'sheet_read'`, `'sheet_read_write'`, `'sheet_block'`.
+
+---
+
+### D. Per-File Dashboard Management UI
+
+#### [NEW] [ExposedSheetsManager.tsx](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/dashboard/ExposedSheetsManager.tsx)
+- Renders **"Exposed Google Sheets"** manager in the dashboard.
+- Displays table of all exposed spreadsheets:
+  - File Title & Google Sheets Icon.
+  - Truncated Spreadsheet ID with copy button.
+  - **Permission Selector**:
+    - `Read Only` (`sheet_read`): Read cells (`GET`), block mutating calls (403).
+    - `Read & Write` (`sheet_read_write`): Read, update cells, and append rows.
+    - `Blocked` (`sheet_block`): Block all access (403).
+  - **Proxy Key Mapping**: Select which proxy keys can access this sheet.
+  - **Remove / Revoke Access**: Deletes rule from FGAC.
+- Includes **"Add Google Sheet +"** primary button to launch Google Picker.
+
+---
+
+### E. REST Proxy Enforcement Engine
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/proxy/[...path]/route.ts)
+- Intercepts requests to `/v4/spreadsheets/{spreadsheetId}...`.
+- Extracts `spreadsheetId`.
+- Evaluates rules in `accessRules` for matching `targetResourceId`:
+  - No rule found -> Return `403 Forbidden` ("Spreadsheet not exposed in FGAC").
+  - Rule is `sheet_block` -> Return `403 Forbidden`.
+  - Mutating request (`POST`, `PUT`, `PATCH`, `DELETE`) with `sheet_read` rule -> Return `403 Forbidden`.
+  - Allowed -> Fetch real token from Clerk Vault via `getUserOauthAccessToken()` and forward request to `https://sheets.googleapis.com`.
+
+---
+
+### F. MCP Server Integration
+
+#### [MODIFY] [route.ts](file:///home/kyesh/GitRepos/fine_grain_access_control/src/app/api/mcp/route.ts)
+- Implement `sheetsFetch(token, path, method, body)`.
+- Register Sheets MCP Tools: `sheets_get_spreadsheet`, `sheets_read_range`, `sheets_update_range`, `sheets_append_rows`.
+- Enforce proxy key permissions and per-file rules before execution.
+
+---
+
+## 3. Verification & Testing Plan
+
+### Automated Verification
+1. `npm run build`: Type-check Next.js API routes and components.
+2. DB Migration: Run `npm run db:branch` and `npm run db:push` on local dev branch.
+
+### Manual Acceptance Flow
+1. **Scope Reauthorization (Phase 1)**: Click "Add Google Sheet +" -> Verify Clerk reauthorize flow redirects to Google consent screen for `drive.file`. Verify Clerk updates stored token in vault.
+2. **Google Picker Selection (Phase 2)**: Select 2 Google Sheets in Google Picker. Verify Google registers permission for those file IDs and FGAC creates `access_rules`.
+3. **Per-File Rules UI**: Set Sheet 1 to `Read Only` and Sheet 2 to `Read & Write`.
+4. **Proxy & MCP Enforcement**:
+   - Call `sheets_read_range` on Sheet 1 -> Succeeds.
+   - Call `sheets_update_range` on Sheet 1 -> Returns `403 Forbidden`.
+   - Call `sheets_update_range` on Sheet 2 -> Succeeds.

--- a/src/app/api/auth/google-picker-token/route.ts
+++ b/src/app/api/auth/google-picker-token/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth, clerkClient } from '@clerk/nextjs/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const client = await clerkClient();
+    const tokenResponse = await client.users.getUserOauthAccessToken(userId, 'oauth_google');
+    const googleToken = tokenResponse.data?.[0]?.token;
+    const scopes = tokenResponse.data?.[0]?.scopes || [];
+
+    if (!googleToken) {
+      return NextResponse.json({
+        error: 'No Google account connected or missing token.',
+        hasDriveFileScope: false
+      }, { status: 404 });
+    }
+
+    const hasDriveFileScope = scopes.some((s: string) =>
+      s.includes('drive.file') || s.includes('drive')
+    );
+
+    return NextResponse.json({
+      accessToken: googleToken,
+      hasDriveFileScope,
+      scopes
+    });
+  } catch (error) {
+    console.error('Error fetching Google Picker token:', error);
+    return NextResponse.json({ error: 'Failed to retrieve Google token' }, { status: 500 });
+  }
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -397,6 +397,7 @@ const handler = createMcpHandler(
         const readBlacklist = rules.filter(r => r.service === 'gmail' && r.actionType === 'read_blacklist');
         const bodyStr = JSON.stringify(data);
         for (const rule of readBlacklist) {
+          if (!rule.regexPattern) continue;
           const regexStr = rule.regexPattern.replace(/\*/g, '.*');
           if (!safeRegex(regexStr)) continue;
           if (new RegExp(regexStr, 'i').test(bodyStr)) {
@@ -435,6 +436,7 @@ const handler = createMcpHandler(
 
         let isWhitelisted = false;
         for (const rule of sendRules) {
+          if (!rule.regexPattern) continue;
           const regexStr = rule.regexPattern.replace(/\*/g, '.*');
           if (!safeRegex(regexStr)) continue;
           if (new RegExp(regexStr, 'i').test(to)) { isWhitelisted = true; break; }

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -218,6 +218,11 @@ async function gmailFetch(token: string, email: string, path: string, method = '
   return res.json();
 }
 
+function extractSheetsSpreadsheetId(path: string): string | null {
+  const match = path.match(/(?:v4\/spreadsheets|sheets\/v4\/spreadsheets|spreadsheets)\/([^/?:#]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 async function sheetsFetch(token: string, path: string, method = 'GET', body?: string) {
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${path}`;
   const res = await fetch(url, {
@@ -565,6 +570,73 @@ const handler = createMcpHandler(
         const body = JSON.stringify({ values });
         const data = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body);
         return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      }
+    );
+
+    // ── raw_google_api_call ───────────────────────────────────────────
+    server.tool(
+      'raw_google_api_call',
+      'Execute any raw Google API request (Gmail or Google Sheets) through FGAC access control rules. Guarantees access to any API endpoint even if no dedicated tool exists.',
+      {
+        path: z.string().describe('API path (e.g. "v4/spreadsheets/1BxiM.../values/Sheet1" or "gmail/v1/users/me/messages")'),
+        method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).optional().describe('HTTP method (default: GET)'),
+        body: z.union([z.string(), z.record(z.string(), z.any())]).optional().describe('Request body (JSON object or string)'),
+        account: z.string().optional().describe('Email account to use.'),
+      },
+      async ({ path, method = 'GET', body, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+
+        const isMutating = method !== 'GET';
+        let googleUrl = '';
+
+        // Evaluate FGAC rules based on path
+        if (path.includes('spreadsheets')) {
+          const spreadsheetId = extractSheetsSpreadsheetId(path);
+          if (spreadsheetId) {
+            const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, isMutating);
+            if (!perm.allowed) {
+              return { content: [{ type: 'text' as const, text: perm.reason! }] };
+            }
+          }
+          const cleanPath = path.replace(/^sheets\//, '');
+          googleUrl = `https://sheets.googleapis.com/${cleanPath}`;
+        } else {
+          // Gmail / general Google API
+          const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
+
+          if (isMutating && path.includes('messages/send')) {
+            const sendRules = rules.filter(r => r.service === 'gmail' && r.actionType === 'send_whitelist');
+            if (sendRules.length === 0) {
+              return { content: [{ type: 'text' as const, text: '🚫 Access Denied: No send whitelist rules configured.' }] };
+            }
+          }
+
+          if (method === 'DELETE' && (path.includes('messages/trash') || path.includes('emptyTrash'))) {
+            return { content: [{ type: 'text' as const, text: '🚫 Access Denied: Safeguard prevents deletion of emails.' }] };
+          }
+
+          googleUrl = `https://www.googleapis.com/${path}`;
+        }
+
+        const bodyString = typeof body === 'object' ? JSON.stringify(body) : body;
+        const res = await fetch(googleUrl, {
+          method,
+          headers: {
+            'Authorization': `Bearer ${resolved.token}`,
+            'Content-Type': 'application/json',
+          },
+          body: isMutating ? bodyString : undefined,
+        });
+
+        const resText = await res.text();
+        let parsedData: any = resText;
+        try { parsedData = JSON.parse(resText); } catch {}
+
+        return { content: [{ type: 'text' as const, text: typeof parsedData === 'string' ? parsedData : JSON.stringify(parsedData, null, 2) }] };
       }
     );
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -218,6 +218,52 @@ async function gmailFetch(token: string, email: string, path: string, method = '
   return res.json();
 }
 
+async function sheetsFetch(token: string, path: string, method = 'GET', body?: string) {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${path}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body,
+  });
+  return res.json();
+}
+
+async function checkSheetsPermission(userId: string, proxyKeyId: string, spreadsheetId: string, isMutating: boolean) {
+  const allRules = await db.select().from(accessRules).where(eq(accessRules.userId, userId));
+  const keyAssignments = await db.select().from(keyRuleAssignments).where(eq(keyRuleAssignments.proxyKeyId, proxyKeyId));
+  const assignedRuleIds = new Set(keyAssignments.map(a => a.accessRuleId));
+  const allAssignments = await db.select().from(keyRuleAssignments);
+  const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
+
+  const sheetsRules = allRules.filter(rule => {
+    if (rule.service !== 'sheets') return false;
+    const isGlobal = !rulesWithAssignments.has(rule.id);
+    const isAssigned = assignedRuleIds.has(rule.id);
+    const matchesId = rule.targetResourceId === spreadsheetId || rule.regexPattern === spreadsheetId;
+    return (isGlobal || isAssigned) && matchesId;
+  });
+
+  if (sheetsRules.length === 0) {
+    return { allowed: false, reason: `🚫 Access Denied: Spreadsheet '${spreadsheetId}' is not exposed in your FGAC rules.` };
+  }
+
+  if (sheetsRules.some(r => r.actionType === 'sheet_block')) {
+    return { allowed: false, reason: `🚫 Access Denied: Access to spreadsheet '${spreadsheetId}' is explicitly blocked.` };
+  }
+
+  if (isMutating) {
+    const hasReadWrite = sheetsRules.some(r => r.actionType === 'sheet_read_write');
+    if (!hasReadWrite) {
+      return { allowed: false, reason: `🚫 Access Denied: Write access to spreadsheet '${spreadsheetId}' is restricted (Read Only).` };
+    }
+  }
+
+  return { allowed: true };
+}
+
 // ─── Require Approval Wrapper ───────────────────────────────────────────────
 
 type AuthInfo = { extra?: { userId?: string }; clientId?: string };
@@ -416,6 +462,108 @@ const handler = createMcpHandler(
         if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
 
         const data = await gmailFetch(resolved.token, resolved.targetEmail, 'labels');
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      }
+    );
+
+    // ── sheets_get_spreadsheet ────────────────────────────────────────
+    server.tool(
+      'sheets_get_spreadsheet',
+      'Get metadata and sheet tabs for an exposed Google Spreadsheet.',
+      {
+        spreadsheetId: z.string().describe('Google Spreadsheet ID (e.g. 1BxiMVs0...)'),
+        account: z.string().optional().describe('Email account to use.'),
+      },
+      async ({ spreadsheetId, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+
+        const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, false);
+        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+
+        const data = await sheetsFetch(resolved.token, `${spreadsheetId}`);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      }
+    );
+
+    // ── sheets_read_range ─────────────────────────────────────────────
+    server.tool(
+      'sheets_read_range',
+      'Read cell values from a specific sheet tab and range in a Google Spreadsheet.',
+      {
+        spreadsheetId: z.string().describe('Google Spreadsheet ID'),
+        range: z.string().describe("Cell range (e.g. 'Sheet1'!A1:D20 or 'Sheet1')"),
+        account: z.string().optional().describe('Email account to use.'),
+      },
+      async ({ spreadsheetId, range, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+
+        const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, false);
+        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+
+        const encodedRange = encodeURIComponent(range);
+        const data = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      }
+    );
+
+    // ── sheets_update_range ───────────────────────────────────────────
+    server.tool(
+      'sheets_update_range',
+      'Update cell values in a range within a Google Spreadsheet (requires Read & Write permission).',
+      {
+        spreadsheetId: z.string().describe('Google Spreadsheet ID'),
+        range: z.string().describe("Cell range (e.g. 'Sheet1'!A1:B2)"),
+        values: z.array(z.array(z.any())).describe('2D array of cell values'),
+        account: z.string().optional().describe('Email account to use.'),
+      },
+      async ({ spreadsheetId, range, values, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+
+        const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, true);
+        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+
+        const encodedRange = encodeURIComponent(range);
+        const body = JSON.stringify({ values, range });
+        const data = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}?valueInputOption=USER_ENTERED`, 'PUT', body);
+        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+      }
+    );
+
+    // ── sheets_append_rows ────────────────────────────────────────────
+    server.tool(
+      'sheets_append_rows',
+      'Append data rows to a sheet in a Google Spreadsheet (requires Read & Write permission).',
+      {
+        spreadsheetId: z.string().describe('Google Spreadsheet ID'),
+        range: z.string().describe("Sheet tab or range to append to (e.g. 'Sheet1')"),
+        values: z.array(z.array(z.any())).describe('2D array of rows to append'),
+        account: z.string().optional().describe('Email account to use.'),
+      },
+      async ({ spreadsheetId, range, values, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+
+        const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, true);
+        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+
+        const encodedRange = encodeURIComponent(range);
+        const body = JSON.stringify({ values });
+        const data = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body);
         return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
       }
     );

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -409,6 +409,48 @@ const handler = createMcpHandler(
       }
     );
 
+    // ── gmail_get_attachment ──────────────────────────────────────────
+    server.tool(
+      'gmail_get_attachment',
+      'Download and retrieve an email attachment by message ID and attachment ID.',
+      {
+        messageId: z.string().describe('Gmail message ID containing the attachment'),
+        attachmentId: z.string().describe('Attachment ID (found in message details payload.parts)'),
+        account: z.string().optional().describe('Email account to use.'),
+      },
+      async ({ messageId, attachmentId, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+
+        // Check read blacklist rules on parent message
+        const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
+        const parentMsg = await gmailFetch(resolved.token, resolved.targetEmail, `messages/${messageId}?format=full`);
+
+        const readBlacklist = rules.filter(r => r.service === 'gmail' && r.actionType === 'read_blacklist');
+        const parentBodyStr = JSON.stringify(parentMsg);
+        for (const rule of readBlacklist) {
+          if (!rule.regexPattern) continue;
+          const regexStr = rule.regexPattern.replace(/\*/g, '.*');
+          if (!safeRegex(regexStr)) continue;
+          if (new RegExp(regexStr, 'i').test(parentBodyStr)) {
+            return { content: [{ type: 'text' as const, text: `🚫 Access restricted: Parent email content blocked by rule '${rule.ruleName}'.` }] };
+          }
+        }
+
+        // Fetch attachment body from Gmail API
+        const attachmentData = await gmailFetch(
+          resolved.token,
+          resolved.targetEmail,
+          `messages/${messageId}/attachments/${attachmentId}`
+        );
+
+        return { content: [{ type: 'text' as const, text: JSON.stringify(attachmentData, null, 2) }] };
+      }
+    );
+
     // ── gmail_send ────────────────────────────────────────────────────
     server.tool(
       'gmail_send',

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -29,6 +29,11 @@ function extractGmailUserId(fullPath: string): string {
   return match ? decodeURIComponent(match[1]) : 'me';
 }
 
+function extractSheetsSpreadsheetId(fullPath: string): string | null {
+  const match = fullPath.match(/(?:v4\/spreadsheets|sheets\/v4\/spreadsheets)\/([^/?:#]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 async function handleProxyRequest(request: NextRequest, params: { path: string[] }) {
   try {
     const authHeader = request.headers.get('authorization');
@@ -73,7 +78,100 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
       return NextResponse.json({ error: 'User not found.' }, { status: 401 });
     }
 
-    // ─── 2. Resolve Target Email ────────────────────────────────────────────
+    // ─── GOOGLE SHEETS PROXY HANDLER ─────────────────────────────────────────
+    if (fullPath.includes('spreadsheets')) {
+      const spreadsheetId = extractSheetsSpreadsheetId(fullPath);
+      if (!spreadsheetId) {
+        return NextResponse.json({ error: 'Invalid Google Sheets API path' }, { status: 400 });
+      }
+
+      const allUserRules = await db
+        .select()
+        .from(accessRules)
+        .where(eq(accessRules.userId, dbUser.id));
+
+      const keyAssignments = await db
+        .select()
+        .from(keyRuleAssignments)
+        .where(eq(keyRuleAssignments.proxyKeyId, dbKey.id));
+
+      const assignedRuleIds = new Set(keyAssignments.map(a => a.accessRuleId));
+      const allAssignments = await db.select().from(keyRuleAssignments);
+      const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
+
+      const applicableSheetsRules = allUserRules.filter(rule => {
+        if (rule.service !== 'sheets') return false;
+        const isGlobal = !rulesWithAssignments.has(rule.id);
+        const isAssignedToThisKey = assignedRuleIds.has(rule.id);
+        const resourceMatches = (rule.targetResourceId === spreadsheetId) || (rule.regexPattern === spreadsheetId);
+        return (isGlobal || isAssignedToThisKey) && resourceMatches;
+      });
+
+      if (applicableSheetsRules.length === 0) {
+        return NextResponse.json({
+          error: `Access Denied: Spreadsheet '${spreadsheetId}' is not exposed in FGAC rules for this API key.`
+        }, { status: 403 });
+      }
+
+      // Check explicit block
+      const hasBlockRule = applicableSheetsRules.some(r => r.actionType === 'sheet_block');
+      if (hasBlockRule) {
+        return NextResponse.json({
+          error: `Access Denied: Access to spreadsheet '${spreadsheetId}' has been explicitly blocked.`
+        }, { status: 403 });
+      }
+
+      // Check write restrictions
+      const isMutatingRequest = request.method !== 'GET' && request.method !== 'HEAD';
+      if (isMutatingRequest) {
+        const hasReadWritePermission = applicableSheetsRules.some(r => r.actionType === 'sheet_read_write');
+        if (!hasReadWritePermission) {
+          return NextResponse.json({
+            error: `Access Denied: Write operations on spreadsheet '${spreadsheetId}' are restricted to Read-Only.`
+          }, { status: 403 });
+        }
+      }
+
+      // Fetch Real Google Token from Clerk
+      const client = await clerkClient();
+      const tokenResponse = await client.users.getUserOauthAccessToken(dbUser.clerkUserId, 'oauth_google');
+      const realGoogleToken = tokenResponse.data?.[0]?.token;
+
+      if (!realGoogleToken) {
+        return NextResponse.json({
+          error: `Could not fetch Google access token for user '${dbUser.email}'. Please reconnect your Google account.`
+        }, { status: 403 });
+      }
+
+      // Forward to Google Sheets API
+      const cleanPath = fullPath.replace(/^sheets\//, '');
+      const googleUrl = `https://sheets.googleapis.com/${cleanPath}${request.nextUrl.search}`;
+      const headers = new Headers(request.headers);
+      headers.set('Authorization', `Bearer ${realGoogleToken}`);
+      headers.delete('host');
+
+      let requestBody: ArrayBuffer | undefined = undefined;
+      if (isMutatingRequest) {
+        requestBody = await request.clone().arrayBuffer();
+      }
+
+      const googleResponse = await fetch(googleUrl, {
+        method: request.method,
+        headers,
+        body: requestBody,
+      });
+
+      const returnBody = await googleResponse.text();
+      const responseHeaders = new Headers(googleResponse.headers);
+      responseHeaders.delete('content-encoding');
+
+      return new NextResponse(returnBody, {
+        status: googleResponse.status,
+        headers: responseHeaders,
+      });
+    }
+
+    // ─── 2. Resolve Target Email (Gmail Proxy Handler) ───────────────────────────
     const gmailUserId = extractGmailUserId(fullPath);
 
     // Resolve 'me' to the key owner's primary email, or use the specific email from the path

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -255,6 +255,7 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
         if (sendRules.length > 0) {
           let isWhitelisted = false;
           for (const rule of sendRules) {
+            if (!rule.regexPattern) continue;
             const regexStr = rule.regexPattern.replace(/\*/g, '.*');
             if (!safeRegex(regexStr)) {
               console.error(`Skipping unsafe regex pattern: ${regexStr}`);
@@ -350,12 +351,12 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
       const labelWhitelists = applicableRules.filter(r => r.service === 'gmail' && r.actionType === 'label_whitelist');
       
       for (const rule of labelBlacklists) {
-        existingQ += ` -label:${rule.regexPattern}`;
+        if (rule.regexPattern) existingQ += ` -label:${rule.regexPattern}`;
       }
       
       if (labelWhitelists.length > 0) {
-        const whitelistQuery = labelWhitelists.map(r => `label:${r.regexPattern}`).join(' OR ');
-        existingQ += ` {${whitelistQuery}}`;
+        const whitelistQuery = labelWhitelists.filter(r => !!r.regexPattern).map(r => `label:${r.regexPattern}`).join(' OR ');
+        if (whitelistQuery) existingQ += ` {${whitelistQuery}}`;
       }
       
       if (existingQ.trim() !== '') {
@@ -395,7 +396,7 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
       if (parsedBody && parsedBody.labelIds && Array.isArray(parsedBody.labelIds)) {
         // 1. Check Label Blacklists First (Precedence)
         for (const rule of labelBlacklistRules) {
-          if (parsedBody.labelIds.includes(rule.regexPattern)) {
+          if (rule.regexPattern && parsedBody.labelIds.includes(rule.regexPattern)) {
              return NextResponse.json({
                error: `Access restricted: Email contains blacklisted label '${rule.regexPattern}'.`
              }, { status: 403 });
@@ -406,7 +407,7 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
         if (labelWhitelistRules.length > 0) {
            let hasWhitelistedLabel = false;
            for (const rule of labelWhitelistRules) {
-             if (parsedBody.labelIds.includes(rule.regexPattern)) {
+             if (rule.regexPattern && parsedBody.labelIds.includes(rule.regexPattern)) {
                hasWhitelistedLabel = true;
                break;
              }
@@ -421,6 +422,7 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
 
       if (readBlacklistRules.length > 0) {
         for (const rule of readBlacklistRules) {
+          if (!rule.regexPattern) continue;
           const regexStr = rule.regexPattern.replace(/\*/g, '.*');
           if (!safeRegex(regexStr)) {
             console.error(`Skipping unsafe regex pattern: ${regexStr}`);

--- a/src/app/api/rules/grant-sheets-access/route.ts
+++ b/src/app/api/rules/grant-sheets-access/route.ts
@@ -1,0 +1,205 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { db } from '@/db';
+import { users, accessRules, keyRuleAssignments, proxyKeys } from '@/db/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/rules/grant-sheets-access - List all sheets rules for current user
+export async function GET(request: NextRequest) {
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const dbUser = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1)
+      .then(res => res[0]);
+
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const rules = await db
+      .select()
+      .from(accessRules)
+      .where(
+        and(
+          eq(accessRules.userId, dbUser.id),
+          eq(accessRules.service, 'sheets')
+        )
+      );
+
+    // Fetch key assignments for each rule
+    const ruleAssignments = await db.select().from(keyRuleAssignments);
+    const rulesWithKeys = rules.map(rule => {
+      const assignedKeyIds = ruleAssignments
+        .filter(a => a.accessRuleId === rule.id)
+        .map(a => a.proxyKeyId);
+      return {
+        ...rule,
+        assignedKeyIds
+      };
+    });
+
+    return NextResponse.json({ sheetsRules: rulesWithKeys });
+  } catch (error) {
+    console.error('Error fetching sheets rules:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+// POST /api/rules/grant-sheets-access - Create or update a sheets access rule
+export async function POST(request: NextRequest) {
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const dbUser = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1)
+      .then(res => res[0]);
+
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { targetResourceId, resourceName, actionType, proxyKeyIds } = body;
+
+    if (!targetResourceId) {
+      return NextResponse.json({ error: 'targetResourceId (spreadsheetId) is required' }, { status: 400 });
+    }
+
+    const validActionTypes = ['sheet_read', 'sheet_read_write', 'sheet_block'];
+    const chosenActionType = validActionTypes.includes(actionType) ? actionType : 'sheet_read';
+
+    // Check if rule for this spreadsheetId already exists for this user
+    const existingRule = await db
+      .select()
+      .from(accessRules)
+      .where(
+        and(
+          eq(accessRules.userId, dbUser.id),
+          eq(accessRules.service, 'sheets'),
+          eq(accessRules.regexPattern, targetResourceId)
+        )
+      )
+      .limit(1)
+      .then(res => res[0]);
+
+    let ruleId: string;
+
+    if (existingRule) {
+      ruleId = existingRule.id;
+      await db
+        .update(accessRules)
+        .set({
+          ruleName: resourceName || existingRule.ruleName,
+          resourceName: resourceName || existingRule.resourceName,
+          actionType: chosenActionType,
+          updatedAt: new Date()
+        })
+        .where(eq(accessRules.id, ruleId));
+    } else {
+      const [newRule] = await db
+        .insert(accessRules)
+        .values({
+          userId: dbUser.id,
+          ruleName: resourceName || `Spreadsheet ${targetResourceId.slice(0, 8)}...`,
+          service: 'sheets',
+          actionType: chosenActionType,
+          regexPattern: targetResourceId,
+          targetResourceId,
+          resourceName: resourceName || `Spreadsheet (${targetResourceId.slice(0, 8)})`
+        })
+        .returning();
+      ruleId = newRule.id;
+    }
+
+    // Sync Key Rule Assignments if proxyKeyIds provided
+    if (Array.isArray(proxyKeyIds)) {
+      // Clear existing assignments for this rule
+      await db.delete(keyRuleAssignments).where(eq(keyRuleAssignments.accessRuleId, ruleId));
+
+      if (proxyKeyIds.length > 0) {
+        // Filter valid proxy keys belonging to user
+        const userKeys = await db
+          .select()
+          .from(proxyKeys)
+          .where(
+            and(
+              eq(proxyKeys.userId, dbUser.id),
+              inArray(proxyKeys.id, proxyKeyIds)
+            )
+          );
+        
+        const validKeyIds = userKeys.map(k => k.id);
+        if (validKeyIds.length > 0) {
+          await db.insert(keyRuleAssignments).values(
+            validKeyIds.map(keyId => ({
+              proxyKeyId: keyId,
+              accessRuleId: ruleId
+            }))
+          );
+        }
+      }
+    }
+
+    return NextResponse.json({ success: true, ruleId });
+  } catch (error) {
+    console.error('Error saving sheets rule:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+// DELETE /api/rules/grant-sheets-access - Delete a sheets access rule
+export async function DELETE(request: NextRequest) {
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const dbUser = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1)
+      .then(res => res[0]);
+
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const ruleId = searchParams.get('ruleId');
+
+    if (!ruleId) {
+      return NextResponse.json({ error: 'ruleId parameter is required' }, { status: 400 });
+    }
+
+    await db
+      .delete(accessRules)
+      .where(
+        and(
+          eq(accessRules.id, ruleId),
+          eq(accessRules.userId, dbUser.id)
+        )
+      );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting sheets rule:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/rules/grant-sheets-access/route.ts
+++ b/src/app/api/rules/grant-sheets-access/route.ts
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest) {
         and(
           eq(accessRules.userId, dbUser.id),
           eq(accessRules.service, 'sheets'),
-          eq(accessRules.regexPattern, targetResourceId)
+          eq(accessRules.targetResourceId, targetResourceId)
         )
       )
       .limit(1)
@@ -118,7 +118,6 @@ export async function POST(request: NextRequest) {
           ruleName: resourceName || `Spreadsheet ${targetResourceId.slice(0, 8)}...`,
           service: 'sheets',
           actionType: chosenActionType,
-          regexPattern: targetResourceId,
           targetResourceId,
           resourceName: resourceName || `Spreadsheet (${targetResourceId.slice(0, 8)})`
         })

--- a/src/app/dashboard/EditRuleButton.tsx
+++ b/src/app/dashboard/EditRuleButton.tsx
@@ -14,7 +14,7 @@ interface EditableRule {
   ruleName: string;
   service: string;
   actionType: string;
-  regexPattern: string;
+  regexPattern: string | null;
   targetResourceId?: string | null;
   resourceName?: string | null;
   targetEmail: string | null;
@@ -182,7 +182,7 @@ export function EditRuleButton({
                     type="text"
                     name="regexPattern"
                     required
-                    defaultValue={rule.regexPattern}
+                    defaultValue={rule.targetResourceId || rule.regexPattern || ""}
                     placeholder="e.g. 1cS2oyMtx-Wa..."
                     className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm font-mono text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
                   />
@@ -199,7 +199,7 @@ export function EditRuleButton({
                     <select
                       name="regexPattern"
                       required
-                      defaultValue={rule.regexPattern}
+                      defaultValue={rule.regexPattern || ""}
                       className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
                     >
                       <option value="">{isLoadingLabels ? "Loading labels..." : "Choose a Gmail Label..."}</option>
@@ -212,7 +212,7 @@ export function EditRuleButton({
                       type="text"
                       name="regexPattern"
                       required
-                      defaultValue={rule.regexPattern}
+                      defaultValue={rule.regexPattern || ""}
                       className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm font-mono text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
                     />
                   )}

--- a/src/app/dashboard/EditRuleButton.tsx
+++ b/src/app/dashboard/EditRuleButton.tsx
@@ -15,6 +15,8 @@ interface EditableRule {
   service: string;
   actionType: string;
   regexPattern: string;
+  targetResourceId?: string | null;
+  resourceName?: string | null;
   targetEmail: string | null;
   assignedKeyIds: string[];
 }
@@ -35,13 +37,14 @@ export function EditRuleButton({
 }) {
   const [isPending, startTransition] = useTransition();
   const [isOpen, setIsOpen] = useState(false);
+  const [selectedService, setSelectedService] = useState(rule.service);
   const [selectedActionType, setSelectedActionType] = useState(rule.actionType);
   const [gmailLabels, setGmailLabels] = useState<GmailLabel[]>([]);
   const [isLoadingLabels, setIsLoadingLabels] = useState(false);
 
   useEffect(() => {
     let ignore = false;
-    if (isOpen && gmailLabels.length === 0) {
+    if (isOpen && selectedService === 'gmail' && gmailLabels.length === 0) {
       const fetchLabels = async () => {
         setIsLoadingLabels(true);
         try {
@@ -60,7 +63,7 @@ export function EditRuleButton({
       fetchLabels();
     }
     return () => { ignore = true; };
-  }, [isOpen, gmailLabels.length]);
+  }, [isOpen, selectedService, gmailLabels.length]);
 
   async function onSubmit(formData: FormData) {
     startTransition(async () => {
@@ -110,10 +113,19 @@ export function EditRuleButton({
                 </label>
                 <select
                   name="service"
-                  defaultValue={rule.service}
+                  value={selectedService}
+                  onChange={(e) => {
+                    setSelectedService(e.target.value);
+                    if (e.target.value === 'sheets') {
+                      setSelectedActionType('sheet_read');
+                    } else {
+                      setSelectedActionType('read_blacklist');
+                    }
+                  }}
                   className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
                 >
                   <option value="gmail">Gmail</option>
+                  <option value="sheets">Google Sheets</option>
                 </select>
               </div>
 
@@ -127,50 +139,85 @@ export function EditRuleButton({
                   onChange={(e) => setSelectedActionType(e.target.value)}
                   className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
                 >
-                  <option value="read_blacklist">
-                    Read Blacklist (Inbound Regex)
-                  </option>
-                  <option value="send_whitelist">
-                    Send Whitelist (Outbound To:)
-                  </option>
-                  <option value="delete_whitelist">
-                    Delete Whitelist (From:)
-                  </option>
-                  <option value="label_blacklist">
-                    Label Blacklist (Block Email via Label)
-                  </option>
-                  <option value="label_whitelist">
-                    Label Whitelist (Allow Only via Required Label)
-                  </option>
+                  {selectedService === 'sheets' ? (
+                    <>
+                      <option value="sheet_read">
+                        Read Only (GET)
+                      </option>
+                      <option value="sheet_read_write">
+                        Read & Write (GET + POST/PUT)
+                      </option>
+                      <option value="sheet_block">
+                        Blocked (Deny All)
+                      </option>
+                    </>
+                  ) : (
+                    <>
+                      <option value="read_blacklist">
+                        Read Blacklist (Inbound Regex)
+                      </option>
+                      <option value="send_whitelist">
+                        Send Whitelist (Outbound To:)
+                      </option>
+                      <option value="delete_whitelist">
+                        Delete Whitelist (From:)
+                      </option>
+                      <option value="label_blacklist">
+                        Label Blacklist (Block Email via Label)
+                      </option>
+                      <option value="label_whitelist">
+                        Label Whitelist (Allow Only via Required Label)
+                      </option>
+                    </>
+                  )}
                 </select>
               </div>
 
-              <div>
-                <label className="block text-sm font-semibold text-slate-700 mb-1.5">
-                  {selectedActionType.startsWith('label_') ? 'Select Label' : 'Regex Pattern'}
-                </label>
-                {selectedActionType.startsWith('label_') ? (
-                  <select
-                    name="regexPattern"
-                    required
-                    defaultValue={rule.regexPattern}
-                    className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
-                  >
-                    <option value="">{isLoadingLabels ? "Loading labels..." : "Choose a Gmail Label..."}</option>
-                    {gmailLabels.map(label => (
-                       <option key={label.id} value={label.id}>{label.name} ({label.type})</option>
-                    ))}
-                  </select>
-                ) : (
+              {selectedService === 'sheets' ? (
+                <div>
+                  <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                    Spreadsheet ID
+                  </label>
                   <input
                     type="text"
                     name="regexPattern"
                     required
                     defaultValue={rule.regexPattern}
+                    placeholder="e.g. 1cS2oyMtx-Wa..."
                     className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm font-mono text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
                   />
-                )}
-              </div>
+                  <p className="text-xs text-slate-500 mt-1">
+                    Document Title: {rule.resourceName || 'Google Sheet'}
+                  </p>
+                </div>
+              ) : (
+                <div>
+                  <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                    {selectedActionType.startsWith('label_') ? 'Select Label' : 'Regex Pattern'}
+                  </label>
+                  {selectedActionType.startsWith('label_') ? (
+                    <select
+                      name="regexPattern"
+                      required
+                      defaultValue={rule.regexPattern}
+                      className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
+                    >
+                      <option value="">{isLoadingLabels ? "Loading labels..." : "Choose a Gmail Label..."}</option>
+                      {gmailLabels.map(label => (
+                         <option key={label.id} value={label.id}>{label.name} ({label.type})</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="text"
+                      name="regexPattern"
+                      required
+                      defaultValue={rule.regexPattern}
+                      className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm font-mono text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
+                    />
+                  )}
+                </div>
+              )}
 
               <div>
                 <label className="block text-sm font-semibold text-slate-700 mb-1.5">

--- a/src/app/dashboard/ExposedSheetsManager.tsx
+++ b/src/app/dashboard/ExposedSheetsManager.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import { useGooglePicker, PickedSheet } from './useGooglePicker';
+
+interface SheetsRule {
+  id: string;
+  ruleName: string;
+  targetResourceId: string;
+  resourceName: string | null;
+  actionType: string;
+  assignedKeyIds: string[];
+}
+
+interface ProxyKeyInfo {
+  id: string;
+  label: string;
+}
+
+export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKeyInfo[] }) {
+  const [sheetsRules, setSheetsRules] = useState<SheetsRule[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const fetchSheetsRules = useCallback(async () => {
+    try {
+      const res = await fetch('/api/rules/grant-sheets-access');
+      const data = await res.json();
+      if (data.sheetsRules) {
+        setSheetsRules(data.sheetsRules);
+      }
+    } catch (err) {
+      console.error('Failed to load sheets rules:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSheetsRules();
+  }, [fetchSheetsRules]);
+
+  const handleSheetsPicked = async (pickedSheets: PickedSheet[]) => {
+    setStatusMessage('Saving exposed sheets to FGAC...');
+    for (const sheet of pickedSheets) {
+      await fetch('/api/rules/grant-sheets-access', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetResourceId: sheet.id,
+          resourceName: sheet.name,
+          actionType: 'sheet_read', // Default to Read Only
+        })
+      });
+    }
+    await fetchSheetsRules();
+    setStatusMessage(`Successfully added ${pickedSheets.length} sheet(s)!`);
+    setTimeout(() => setStatusMessage(null), 4000);
+  };
+
+  const { triggerAddSheets, isLoading: isPickerLoading } = useGooglePicker(handleSheetsPicked);
+
+  const handlePermissionChange = async (targetResourceId: string, resourceName: string | null, newActionType: string) => {
+    try {
+      await fetch('/api/rules/grant-sheets-access', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          targetResourceId,
+          resourceName: resourceName || `Spreadsheet (${targetResourceId.slice(0, 6)})`,
+          actionType: newActionType
+        })
+      });
+      await fetchSheetsRules();
+    } catch (err) {
+      console.error('Failed to update permission:', err);
+    }
+  };
+
+  const handleDeleteRule = async (ruleId: string) => {
+    try {
+      await fetch(`/api/rules/grant-sheets-access?ruleId=${ruleId}`, {
+        method: 'DELETE'
+      });
+      await fetchSheetsRules();
+    } catch (err) {
+      console.error('Failed to remove sheet rule:', err);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-6 shadow-sm mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <svg className="w-6 h-6 text-emerald-600" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
+            </svg>
+            <h3 className="text-lg font-bold text-slate-900">Google Sheets Access Rules</h3>
+          </div>
+          <p className="text-sm text-slate-600 mt-1">
+            Grant agents intentional access to specific Google Sheets via per-file (<code className="bg-slate-100 px-1 py-0.5 rounded text-slate-800 text-xs">drive.file</code>) permission.
+          </p>
+        </div>
+        <button
+          onClick={triggerAddSheets}
+          disabled={isPickerLoading}
+          className="flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white font-medium text-sm px-4 py-2 rounded-lg transition-colors shadow-sm disabled:opacity-50 flex-shrink-0"
+        >
+          {isPickerLoading ? (
+            <span>Connecting...</span>
+          ) : (
+            <>
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+              </svg>
+              <span>Add Google Sheet +</span>
+            </>
+          )}
+        </button>
+      </div>
+
+      {statusMessage && (
+        <div className="mb-4 p-3 bg-emerald-50 border border-emerald-200 text-emerald-800 text-sm rounded-lg flex items-center gap-2">
+          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
+          {statusMessage}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="py-8 text-center text-slate-400 text-sm">Loading sheets access rules...</div>
+      ) : sheetsRules.length === 0 ? (
+        <div className="py-8 border-2 border-dashed border-slate-200 rounded-lg text-center p-6 bg-slate-50/50">
+          <svg className="w-10 h-10 text-slate-400 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <p className="text-sm font-medium text-slate-700">No Google Sheets exposed yet</p>
+          <p className="text-xs text-slate-500 mt-1 mb-3">
+            Click &quot;Add Google Sheet +&quot; to pick spreadsheets using Google Picker and define Read or Read/Write permissions.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-slate-200 text-slate-500 font-semibold text-xs uppercase tracking-wider bg-slate-50">
+                <th className="py-3 px-4">Document Title</th>
+                <th className="py-3 px-4">Spreadsheet ID</th>
+                <th className="py-3 px-4">FGAC Permission</th>
+                <th className="py-3 px-4 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {sheetsRules.map((rule) => (
+                <tr key={rule.id} className="hover:bg-slate-50/80 transition-colors">
+                  <td className="py-3 px-4 font-medium text-slate-900 flex items-center gap-2">
+                    <svg className="w-4 h-4 text-emerald-600 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
+                    </svg>
+                    <span>{rule.resourceName || rule.ruleName}</span>
+                  </td>
+                  <td className="py-3 px-4 font-mono text-xs text-slate-600">
+                    {rule.targetResourceId ? (
+                      <span className="bg-slate-100 px-2 py-1 rounded border border-slate-200" title={rule.targetResourceId}>
+                        {rule.targetResourceId.length > 16 ? `${rule.targetResourceId.slice(0, 12)}...` : rule.targetResourceId}
+                      </span>
+                    ) : (
+                      <span className="text-slate-400">N/A</span>
+                    )}
+                  </td>
+                  <td className="py-3 px-4">
+                    <select
+                      value={rule.actionType}
+                      onChange={(e) => handlePermissionChange(rule.targetResourceId, rule.resourceName, e.target.value)}
+                      className={`text-xs font-semibold px-2.5 py-1.5 rounded-md border focus:outline-none focus:ring-2 ${
+                        rule.actionType === 'sheet_read'
+                          ? 'bg-blue-50 text-blue-700 border-blue-200 focus:ring-blue-500'
+                          : rule.actionType === 'sheet_read_write'
+                          ? 'bg-emerald-50 text-emerald-700 border-emerald-200 focus:ring-emerald-500'
+                          : 'bg-rose-50 text-rose-700 border-rose-200 focus:ring-rose-500'
+                      }`}
+                    >
+                      <option value="sheet_read">Read Only (GET)</option>
+                      <option value="sheet_read_write">Read & Write (GET + POST/PUT)</option>
+                      <option value="sheet_block">Blocked (Deny All)</option>
+                    </select>
+                  </td>
+                  <td className="py-3 px-4 text-right">
+                    <button
+                      onClick={() => handleDeleteRule(rule.id)}
+                      className="text-xs text-rose-600 hover:text-rose-800 font-medium px-2 py-1 hover:bg-rose-50 rounded transition-colors"
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -235,18 +235,26 @@ export async function createRule(formData: FormData) {
   const ruleName = formData.get("ruleName") as string;
   const service = formData.get("service") as string;
   const actionType = formData.get("actionType") as string;
-  const regexPattern = formData.get("regexPattern") as string;
+  const rawPattern = formData.get("regexPattern") as string;
   const targetEmail = formData.get("targetEmail") as string || null;
   const keyIds = formData.getAll("keyIds") as string[];
 
-  if (!ruleName || !service || !actionType || !regexPattern) {
-    console.error("[createRule] Missing required fields:", { ruleName, service, actionType, regexPattern });
+  if (!ruleName || !service || !actionType) {
+    console.error("[createRule] Missing required fields:", { ruleName, service, actionType });
     revalidatePath("/dashboard");
     return;
   }
 
-  if (!safeRegex(regexPattern)) {
-    throw new Error(`The provided regular expression '${regexPattern}' is too complex and poses a performance risk. Please simplify it (e.g. avoid nested quantifiers).`);
+  let finalRegexPattern: string | null = null;
+  let targetResourceId: string | null = null;
+
+  if (service === 'sheets') {
+    targetResourceId = rawPattern;
+  } else {
+    finalRegexPattern = rawPattern;
+    if (finalRegexPattern && !safeRegex(finalRegexPattern)) {
+      throw new Error(`The provided regular expression '${finalRegexPattern}' is too complex and poses a performance risk.`);
+    }
   }
 
   const newRule = await db.insert(accessRules).values({
@@ -254,7 +262,8 @@ export async function createRule(formData: FormData) {
     ruleName,
     service,
     actionType,
-    regexPattern,
+    regexPattern: finalRegexPattern,
+    targetResourceId,
     targetEmail: targetEmail || null,
   }).returning().then(res => res[0]);
 
@@ -274,18 +283,26 @@ export async function updateRule(formData: FormData) {
   const ruleName = formData.get("ruleName") as string;
   const service = formData.get("service") as string;
   const actionType = formData.get("actionType") as string;
-  const regexPattern = formData.get("regexPattern") as string;
+  const rawPattern = formData.get("regexPattern") as string;
   const targetEmail = formData.get("targetEmail") as string || null;
   const keyIds = formData.getAll("keyIds") as string[];
 
-  if (!ruleId || !ruleName || !service || !actionType || !regexPattern) {
+  if (!ruleId || !ruleName || !service || !actionType) {
     console.error("[updateRule] Missing required fields");
     revalidatePath("/dashboard");
     return;
   }
 
-  if (!safeRegex(regexPattern)) {
-    throw new Error(`The provided regular expression '${regexPattern}' is too complex and poses a performance risk. Please simplify it (e.g. avoid nested quantifiers).`);
+  let finalRegexPattern: string | null = null;
+  let targetResourceId: string | null = null;
+
+  if (service === 'sheets') {
+    targetResourceId = rawPattern;
+  } else {
+    finalRegexPattern = rawPattern;
+    if (finalRegexPattern && !safeRegex(finalRegexPattern)) {
+      throw new Error(`The provided regular expression '${finalRegexPattern}' is too complex and poses a performance risk.`);
+    }
   }
 
   // Verify ownership
@@ -299,7 +316,8 @@ export async function updateRule(formData: FormData) {
     ruleName,
     service,
     actionType,
-    regexPattern,
+    regexPattern: finalRegexPattern,
+    targetResourceId: service === 'sheets' ? targetResourceId : rule.targetResourceId,
     targetEmail: targetEmail || null,
   }).where(eq(accessRules.id, ruleId));
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { DelegateAccessButton } from './DelegateAccessButton';
 import { RevokeDelegationButton } from './RevokeDelegationButton';
 import { ConnectGoogleWarning } from './ConnectGoogleWarning';
 import { ConnectionsPanel } from './ConnectionsPanel';
+import { ExposedSheetsManager } from './ExposedSheetsManager';
 
 export default async function DashboardPage() {
   const user = await currentUser();
@@ -157,6 +158,9 @@ export default async function DashboardPage() {
 
           {/* ─── Agent Connections ─────────────────────────────────── */}
           <ConnectionsPanel />
+
+          {/* ─── Google Sheets FGAC ─────────────────────────────────── */}
+          <ExposedSheetsManager activeKeys={activeKeys.map(k => ({ id: k.id, label: k.label }))} />
 
           {/* ─── Your Email & Delegated Emails ─────────────────────── */}
           <div className="bg-white overflow-hidden shadow rounded-lg border border-gray-200">

--- a/src/app/dashboard/useGooglePicker.ts
+++ b/src/app/dashboard/useGooglePicker.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useCallback, useEffect } from 'react';
+import { useUser, useReverification } from '@clerk/nextjs';
+import { isReverificationCancelledError } from '@clerk/nextjs/errors';
+
+declare global {
+  interface Window {
+    gapi: any;
+    google: any;
+  }
+}
+
+export interface PickedSheet {
+  id: string;
+  name: string;
+}
+
+export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[]) => void) {
+  const { user } = useUser();
+  const [isLoading, setIsLoading] = useState(false);
+  const [gapiLoaded, setGapiLoaded] = useState(false);
+
+  // Dynamically load Google API script (api.js)
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (window.gapi) {
+      setGapiLoaded(true);
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'https://apis.google.com/js/api.js';
+    script.onload = () => {
+      window.gapi.load('picker', () => {
+        setGapiLoaded(true);
+      });
+    };
+    document.body.appendChild(script);
+  }, []);
+
+  const openPickerFlow = async () => {
+    if (!user) return;
+    setIsLoading(true);
+
+    try {
+      // 1. Fetch token and scope info from backend token bridge
+      const tokenRes = await fetch('/api/auth/google-picker-token');
+      const tokenData = await tokenRes.json();
+
+      if (!tokenRes.ok) {
+        throw new Error(tokenData.error || 'Failed to fetch Google OAuth token.');
+      }
+
+      const existingGoogleAccount = user.externalAccounts.find(
+        acc => acc.provider === 'google' || (acc.provider as any) === 'oauth_google'
+      );
+
+      // 2. If drive.file scope is missing, trigger Clerk reauthorization
+      if (!tokenData.hasDriveFileScope) {
+        let verificationUrl: string | undefined;
+        if (existingGoogleAccount && existingGoogleAccount.verification?.status === 'verified') {
+          const response = await existingGoogleAccount.reauthorize({
+            additionalScopes: ['https://www.googleapis.com/auth/drive.file'],
+            redirectUrl: window.location.href,
+            oidcPrompt: 'consent'
+          });
+          verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
+        } else {
+          if (existingGoogleAccount) {
+            await existingGoogleAccount.destroy();
+          }
+          const response = await user.createExternalAccount({
+            strategy: 'oauth_google',
+            redirectUrl: window.location.href,
+          });
+          verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
+        }
+
+        if (verificationUrl) {
+          window.location.href = verificationUrl;
+          return;
+        }
+      }
+
+      // 3. Launch Google Picker
+      if (!window.gapi || !window.google) {
+        alert('Google Picker library loading... Please try again in a moment.');
+        setIsLoading(false);
+        return;
+      }
+
+      const pickerCallback = (data: any) => {
+        if (data.action === window.google.picker.Action.PICKED) {
+          const docs = data.docs.map((doc: any) => ({
+            id: doc.id,
+            name: doc.name || `Spreadsheet (${doc.id.slice(0, 6)})`
+          }));
+          onSheetsPicked(docs);
+        }
+        setIsLoading(false);
+      };
+
+      const view = new window.google.picker.View(window.google.picker.ViewId.SPREADSHEETS);
+      const picker = new window.google.picker.PickerBuilder()
+        .addView(view)
+        .setOAuthToken(tokenData.accessToken)
+        .setCallback(pickerCallback)
+        .setTitle('Select Google Sheets to Expose in FGAC')
+        .enableFeature(window.google.picker.Feature.MULTISELECT_ENABLED)
+        .build();
+
+      picker.setVisible(true);
+    } catch (err) {
+      console.error('Error opening Google Picker:', err);
+      setIsLoading(false);
+    }
+  };
+
+  const enhancedOpenPicker = useReverification(openPickerFlow);
+
+  const triggerAddSheets = async () => {
+    try {
+      await enhancedOpenPicker();
+    } catch (err) {
+      if (!isReverificationCancelledError(err)) {
+        console.error('Picker error:', err);
+      }
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    triggerAddSheets,
+    isLoading,
+    gapiLoaded
+  };
+}

--- a/src/app/dashboard/useGooglePicker.ts
+++ b/src/app/dashboard/useGooglePicker.ts
@@ -39,7 +39,7 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[]) => void)
     document.body.appendChild(script);
   }, []);
 
-  const openPickerFlow = async () => {
+  const openPickerFlow = useCallback(async () => {
     if (!user) return;
     setIsLoading(true);
 
@@ -58,11 +58,13 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[]) => void)
 
       // 2. If drive.file scope is missing, trigger Clerk reauthorization
       if (!tokenData.hasDriveFileScope) {
+        const autoRedirectUrl = `${window.location.origin}/dashboard?autoOpenPicker=true`;
         let verificationUrl: string | undefined;
+
         if (existingGoogleAccount && existingGoogleAccount.verification?.status === 'verified') {
           const response = await existingGoogleAccount.reauthorize({
             additionalScopes: ['https://www.googleapis.com/auth/drive.file'],
-            redirectUrl: window.location.href,
+            redirectUrl: autoRedirectUrl,
             oidcPrompt: 'consent'
           });
           verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
@@ -72,7 +74,7 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[]) => void)
           }
           const response = await user.createExternalAccount({
             strategy: 'oauth_google',
-            redirectUrl: window.location.href,
+            redirectUrl: autoRedirectUrl,
           });
           verificationUrl = response.verification?.externalVerificationRedirectURL?.href;
         }
@@ -115,7 +117,20 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[]) => void)
       console.error('Error opening Google Picker:', err);
       setIsLoading(false);
     }
-  };
+  }, [user, onSheetsPicked]);
+
+  // Automatically launch Google Picker if returning from OAuth reauthorization redirect
+  useEffect(() => {
+    if (typeof window === 'undefined' || !user || !gapiLoaded) return;
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('autoOpenPicker') === 'true') {
+      // Clean up URL parameter without page reload
+      const newUrl = window.location.pathname;
+      window.history.replaceState({}, document.title, newUrl);
+      // Auto-launch picker
+      openPickerFlow();
+    }
+  }, [user, gapiLoaded, openPickerFlow]);
 
   const enhancedOpenPicker = useReverification(openPickerFlow);
 

--- a/src/db/migrations/0004_early_masked_marvel.sql
+++ b/src/db/migrations/0004_early_masked_marvel.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "access_rules" ALTER COLUMN "regex_pattern" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "access_rules" ADD COLUMN "target_resource_id" text;--> statement-breakpoint
+ALTER TABLE "access_rules" ADD COLUMN "resource_name" text;

--- a/src/db/migrations/meta/0004_snapshot.json
+++ b/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,755 @@
+{
+  "id": "a5eab33b-a941-42f5-b1aa-e8e21ec303d2",
+  "prevId": "d729179c-214c-433d-abb0-18ee6043728f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_rules": {
+      "name": "access_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_pattern": {
+          "name": "regex_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "access_rules_user_id_users_id_fk": {
+          "name": "access_rules_user_id_users_id_fk",
+          "tableFrom": "access_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connections": {
+      "name": "agent_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_key_id": {
+          "name": "proxy_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connection_user_client_unique": {
+          "name": "connection_user_client_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connections_user_id_users_id_fk": {
+          "name": "agent_connections_user_id_users_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connections_proxy_key_id_proxy_keys_id_fk": {
+          "name": "agent_connections_proxy_key_id_proxy_keys_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "proxy_keys",
+          "columnsFrom": [
+            "proxy_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_delegations": {
+      "name": "email_delegations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "delegation_unique": {
+          "name": "delegation_unique",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_delegations_owner_user_id_users_id_fk": {
+          "name": "email_delegations_owner_user_id_users_id_fk",
+          "tableFrom": "email_delegations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_delegations_delegate_user_id_users_id_fk": {
+          "name": "email_delegations_delegate_user_id_users_id_fk",
+          "tableFrom": "email_delegations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.key_email_access": {
+      "name": "key_email_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proxy_key_id": {
+          "name": "proxy_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegation_id": {
+          "name": "delegation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "key_email_unique": {
+          "name": "key_email_unique",
+          "columns": [
+            {
+              "expression": "proxy_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "key_email_access_proxy_key_id_proxy_keys_id_fk": {
+          "name": "key_email_access_proxy_key_id_proxy_keys_id_fk",
+          "tableFrom": "key_email_access",
+          "tableTo": "proxy_keys",
+          "columnsFrom": [
+            "proxy_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "key_email_access_delegation_id_email_delegations_id_fk": {
+          "name": "key_email_access_delegation_id_email_delegations_id_fk",
+          "tableFrom": "key_email_access",
+          "tableTo": "email_delegations",
+          "columnsFrom": [
+            "delegation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.key_rule_assignments": {
+      "name": "key_rule_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proxy_key_id": {
+          "name": "proxy_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_rule_id": {
+          "name": "access_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "key_rule_unique": {
+          "name": "key_rule_unique",
+          "columns": [
+            {
+              "expression": "proxy_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "key_rule_assignments_proxy_key_id_proxy_keys_id_fk": {
+          "name": "key_rule_assignments_proxy_key_id_proxy_keys_id_fk",
+          "tableFrom": "key_rule_assignments",
+          "tableTo": "proxy_keys",
+          "columnsFrom": [
+            "proxy_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "key_rule_assignments_access_rule_id_access_rules_id_fk": {
+          "name": "key_rule_assignments_access_rule_id_access_rules_id_fk",
+          "tableFrom": "key_rule_assignments",
+          "tableTo": "access_rules",
+          "columnsFrom": [
+            "access_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_keys": {
+      "name": "proxy_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proxy_keys_user_id_users_id_fk": {
+          "name": "proxy_keys_user_id_users_id_fk",
+          "tableFrom": "proxy_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "proxy_keys_key_unique": {
+          "name": "proxy_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_accounts": {
+          "name": "num_accounts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_too_cheap": {
+          "name": "price_too_cheap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_bargain": {
+          "name": "price_bargain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_expensive": {
+          "name": "price_expensive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_too_expensive": {
+          "name": "price_too_expensive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_model_preference": {
+          "name": "pricing_model_preference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wants_beta": {
+          "name": "wants_beta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreed_to_interview": {
+          "name": "agreed_to_interview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreed_to_beta_pricing": {
+          "name": "agreed_to_beta_pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comfortable_with_unverified_app": {
+          "name": "comfortable_with_unverified_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'partial'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1779024068820,
       "tag": "0003_chubby_tomorrow_man",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1785031714902,
+      "tag": "0004_early_masked_marvel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -66,7 +66,7 @@ export const accessRules = pgTable('access_rules', {
   ruleName: text('rule_name').notNull(), // e.g., "Block Project X" or "Q3 Financials Read Only"
   service: text('service').notNull(), // 'gmail', 'sheets'
   actionType: text('action_type').notNull(), // Gmail: 'read_blacklist', 'send_whitelist', etc. | Sheets: 'sheet_read', 'sheet_read_write', 'sheet_block'
-  regexPattern: text('regex_pattern').notNull(), // e.g., "*@competitor.com" or spreadsheetId for sheets
+  regexPattern: text('regex_pattern'), // Optional: Gmail regex pattern or label ID
   targetResourceId: text('target_resource_id'), // e.g. spreadsheetId for Google Sheets
   resourceName: text('resource_name'), // e.g. human-readable document title "Q3 Financials"
   createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -57,16 +57,18 @@ export const keyEmailAccess = pgTable('key_email_access', {
 ]);
 
 // ─── Access Rules ────────────────────────────────────────────────────────────
-// Fine-grained access control rules. Scoped to a user, optionally to a specific email.
+// Fine-grained access control rules. Scoped to a user, optionally to a specific email or resource.
 // Rules with no key_rule_assignments rows are GLOBAL (apply to all keys).
 export const accessRules = pgTable('access_rules', {
   id: uuid('id').defaultRandom().primaryKey(),
   userId: uuid('user_id').references(() => users.id, { onDelete: 'cascade' }).notNull(),
   targetEmail: text('target_email'), // NULL = applies to all emails, or specific email address
-  ruleName: text('rule_name').notNull(), // e.g., "Block Project X"
-  service: text('service').notNull(), // 'gmail'
-  actionType: text('action_type').notNull(), // 'read_blacklist', 'send_whitelist', 'delete_whitelist', 'label_whitelist', 'label_blacklist'
-  regexPattern: text('regex_pattern').notNull(), // e.g., "*@competitor.com" or "CONFIDENTIAL_PROJECT_X"
+  ruleName: text('rule_name').notNull(), // e.g., "Block Project X" or "Q3 Financials Read Only"
+  service: text('service').notNull(), // 'gmail', 'sheets'
+  actionType: text('action_type').notNull(), // Gmail: 'read_blacklist', 'send_whitelist', etc. | Sheets: 'sheet_read', 'sheet_read_write', 'sheet_block'
+  regexPattern: text('regex_pattern').notNull(), // e.g., "*@competitor.com" or spreadsheetId for sheets
+  targetResourceId: text('target_resource_id'), // e.g. spreadsheetId for Google Sheets
+  resourceName: text('resource_name'), // e.g. human-readable document title "Q3 Financials"
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });


### PR DESCRIPTION
## Summary

Combines two workstreams into a single deploy so the Vercel preview is validated once, as one coherent state:

1. **Google Sheets FGAC** (7 commits) — per-file access control via `drive.file` + Google Picker, `raw_google_api_call` and `gmail_get_attachment` MCP tools, schema changes isolating Sheets IDs to `targetResourceId`, and migration `0004_early_masked_marvel.sql`.
2. **Antigravity → Claude Code config port** (1 commit) — mirrors `.agent/` into `CLAUDE.md`, `.claude/commands/`, and `.claude/settings.json`.

32 files changed, +3519 / −61.

## Google Sheets FGAC

- `feat(sheets-fgac)`: per-file access control via `drive.file` scope and Google Picker
- `fix(sheets-fgac)`: auto-open the Picker modal on return from OAuth reauthorization redirect
- `feat(mcp)`: `raw_google_api_call` for raw Google API proxying through FGAC rules
- `fix(dashboard)`: `EditRuleButton` modal handles the sheets service and per-file action types
- `refactor(schema)`: `regexPattern` becomes optional; Sheets IDs isolated to `targetResourceId`
- `feat(mcp)`: `gmail_get_attachment` for downloading attachments under FGAC rules
- `chore(db)`: migration `0004_early_masked_marvel.sql`

## Agent config port

- `.agent/rules/{general,database}.md` → `CLAUDE.md`, inline rather than `@`-imported so a broken path cannot silently drop the never-push-to-main / never-deploy-prod rules.
- `.agent/rules/session-stability.md` → context-efficiency section. Antigravity-specific parts (ptyHost pacing, `command_status` polling, `view_file` line ranges) dropped as inapplicable to Claude Code.
- `.agent/workflows/*.md` → `.claude/commands/*.md`, 10 files, names 1:1. Antigravity's `// turbo-all` becomes scoped `allowed-tools` frontmatter.
- New `.claude/settings.json` enforces the Vercel production bans (`--prod`, `promote`, `alias`) as `deny` rules instead of prose, and routes state-modifying operations through `ask`.
- `/browser-agent` was Linux-only; now uses `$CLAUDE_PROJECT_DIR` and documents both macOS and Linux Chrome invocations.
- `/recover-session` was rebuilt around git state and Claude Code transcripts, since the Antigravity `brain/` artifacts it previously read do not exist under Claude Code.

The two workstreams touch disjoint file sets — the port is confined to `CLAUDE.md` and `.claude/`, so it carries no runtime risk for the Sheets work.

## Validation

- [ ] Vercel preview builds green (migration `0004` applies cleanly against the Neon preview branch)
- [ ] Sheets per-file access control verified in the preview UI via `/browser-agent`
- [ ] Google Picker opens correctly after OAuth reauthorization redirect
- [ ] Applicable `docs/QA_Acceptance_Test` suites pass against the preview

## Note

If `feature/google-sheets-fgac` has its own open PR, close it in favour of this one — those 7 commits are contained here, and merging both would double-apply them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
