### PR TITLE
MCP connector directory readiness: annotations, raw tool split, auth hardening

### DIFF
--- a/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
+++ b/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
@@ -1,0 +1,61 @@
+# Capability: Raw Google API Pair (Deny-by-Default)
+
+> Covers the `google_api_get` / `google_api_modify` MCP tools that replaced
+> `raw_google_api_call` for Anthropic Connectors Directory compliance
+> (no single tool may mix safe and unsafe HTTP methods). Classification lives
+> in `src/app/api/mcp/googleApiPolicy.ts`; enforcement must be identical to
+> the dedicated tools. Hosted-MCP interface only (the REST proxy at
+> `/api/proxy` is a separate surface).
+
+## Assertions
+
+### A1: Raw pair is annotated; legacy tool is gone
+- Call `tools/list` on the hosted MCP endpoint
+- **Expected**: `google_api_get` present with `readOnlyHint: true`;
+  `google_api_modify` present with `destructiveHint: true`; every listed tool
+  has a `title`; `raw_google_api_call` is absent; `google_api_modify`'s input
+  schema offers only POST/PUT/PATCH (no DELETE, no GET)
+
+### A2: Raw Gmail read succeeds
+- `google_api_get` with path `gmail/v1/users/me/messages?maxResults=2`
+- **Expected**: Real Gmail message list JSON (ids), no error
+
+### A3: Unsupported Google API is denied
+- `google_api_get` with path `drive/v3/files`
+- **Expected**: Access-denied message naming the supported paths (Gmail,
+  Sheets); no Google API call is made
+
+### A4: Non-send Gmail write is denied
+- `google_api_modify` with path `gmail/v1/users/me/messages/<any-id>/modify`
+- **Expected**: Denied with a message that only `messages/send` is a
+  supported Gmail write
+
+### A5: Raw send to non-whitelisted recipient is denied
+- `google_api_modify` to `gmail/v1/users/me/messages/send` with a base64url
+  RFC 2822 `raw` body addressed to `blocked@untrusted.com`
+- **Expected**: Unauthorized-recipient denial (recipient parsed out of the
+  raw message); nothing is sent
+
+### A6: Raw send to whitelisted recipient succeeds
+- `google_api_modify` to `gmail/v1/users/me/messages/send` with a `raw` body
+  addressed to a whitelisted address (e.g. `USER_B_EMAIL`)
+- **Expected**: Gmail returns a real message id; the mail is actually sent
+
+### A7: Raw send with unparseable recipients is denied
+- `google_api_modify` to `gmail/v1/users/me/messages/send` with a body that
+  has no parseable To/Cc/Bcc (e.g. `{"raw": "!!!"}` or a missing `raw`)
+- **Expected**: Denied with a could-not-determine-recipients message (deny on
+  parse failure, never forward blind)
+
+### A8: Raw Sheets write honors per-spreadsheet rules
+- `google_api_modify` PUT to
+  `v4/spreadsheets/<exposed-id>/values/<range>?valueInputOption=USER_ENTERED`
+- **Expected**: Succeeds when the spreadsheet's rule is Read & Write; denied
+  with the read-only message when the rule is Read Only (toggle via dashboard
+  UI, as in capability 09 A8)
+
+### A9: Batch and id-less Sheets endpoints are denied
+- `google_api_modify` with path `batch/gmail/v1`; and `google_api_modify`
+  POST with path `v4/spreadsheets` (spreadsheet creation, no id)
+- **Expected**: Both denied — batch endpoints are unsupported; Sheets access
+  requires a spreadsheet id

--- a/docs/distribution_architecture.md
+++ b/docs/distribution_architecture.md
@@ -60,6 +60,35 @@ Each proxy key can access multiple email accounts via `key_email_access`:
 - **Delegated emails:** Resolved via `email_delegations` table; Google token fetched from the email owner's Clerk account
 - **Account parameter:** All tools accept an optional `account` param. `"me"` = key owner's primary email
 
+## Hosted MCP Tool Surface
+
+Tool metadata (names, titles, descriptions, `readOnlyHint`/`destructiveHint`
+annotations) lives in `src/app/api/mcp/toolDefs.ts` and is linted by
+`npm run mcp:lint` (also run at the start of every build) against the Anthropic
+Connectors Directory requirements: every tool titled and annotated, names ≤ 64
+chars, no tool forwarding both safe and unsafe HTTP methods.
+
+- **Read-only tools** (`readOnlyHint: true` — MCP clients may auto-run these):
+  `list_accounts`, `gmail_list`, `gmail_read`, `gmail_get_attachment`,
+  `gmail_labels`, `sheets_get_spreadsheet`, `sheets_read_range`,
+  `get_my_permissions`, `google_api_get`
+- **Write tools** (`destructiveHint` set — MCP clients prompt before running):
+  `gmail_send`, `sheets_update_range`, `sheets_append_rows`, `google_api_modify`
+
+**Raw Google API pair.** The former `raw_google_api_call` (one tool spanning
+GET→DELETE — an automatic directory rejection) is split into `google_api_get`
+(GET only) and `google_api_modify` (POST/PUT/PATCH). Both classify the request
+deny-by-default in `src/app/api/mcp/googleApiPolicy.ts`:
+
+- Gmail GETs are forwarded, then the **full response** passes the same
+  label/content read-restriction checks as `gmail_read` (labels are collected
+  recursively, so thread/list responses are covered).
+- The only Gmail write is `messages/send`, with recipients parsed out of the
+  RFC 2822 payload and checked against the send whitelist (unparseable → deny).
+- Sheets calls require a per-spreadsheet rule; writes require Read & Write.
+- Batch endpoints, spreadsheet creation, all other Gmail writes, and every
+  other Google API are denied. DELETE is not exposed at all.
+
 ## API Surfaces
 
 | Surface | URL | Auth | Used By |

--- a/docs/implementation_plans/connector-approval-audit_v1.md
+++ b/docs/implementation_plans/connector-approval-audit_v1.md
@@ -1,0 +1,169 @@
+# Anthropic Connectors Directory — FGAC MCP Audit & Submission Plan (v1)
+
+Branch: `claude/connector-approval-audit-4bf125` · Date: 2026-07-27
+
+Research sources: official Claude docs (submission page, pre-submission checklist /
+review criteria, authentication, Software Directory Policy) plus firsthand accounts
+(joeir.substack.com, sunpeak.ai, Tallyfy, TheTechDude on Medium). Full source list at
+the bottom.
+
+## How the process works (2026)
+
+- Submission happens in the **Claude.ai submission portal** (`claude.ai/admin-settings/directory/submissions/new`).
+  It requires a **Team or Enterprise Claude organization**; only Owners (or Enterprise
+  custom roles with Directory management) can submit. The portal walks through 11 steps:
+  Connection → Tools → Listing → Use cases → Company → Authentication → Data handling →
+  Test & launch → Compliance (7 acknowledgments) → Review.
+- On submit, an **automated policy scan** runs and, if passed, the server lists as a
+  **community connector**. Anthropic may escalate popular listings to **verified review**
+  (human reviewers functionally test every tool). Same criteria apply either way.
+- **Timelines are unpublished.** Community reports range from ~2 weeks to months; a
+  resubmission goes to the back of the queue, so one missing checklist item costs ~a week+.
+  Escalations: `mcp-review@anthropic.com`.
+- The connector keeps working as a **custom connector** the whole time — the directory
+  adds discovery, not functionality.
+
+## Hard requirements (each missing item = rejection)
+
+1. Every tool: `title` + `readOnlyHint: true` (reads) or `destructiveHint: true` (writes).
+2. No catch-all tool mixing safe and unsafe HTTP methods (`api_request` with a `method`
+   param is called out by name as an automatic rejection).
+3. OAuth 2.0 with PKCE S256; DCR or CIMD or Anthropic-held credentials; token endpoint
+   accepts `application/x-www-form-urlencoded`; 401 + `WWW-Authenticate: Bearer
+   resource_metadata=…` on every unauthenticated request including `initialize`;
+   RFC 9728 / RFC 8414 discovery reachable from Anthropic egress `160.79.104.0/21`
+   (WAF/bot protection in front of MCP *or* the IdP is a common silent failure).
+4. Published HTTPS **privacy policy** covering collection, usage, storage/retention,
+   third-party sharing, and a real contact. "Missing or incomplete privacy policies
+   result in immediate rejection."
+5. **Public documentation** (blog/help-center is fine) by publish date: product summary,
+   setup + auth steps, ≥3 example prompts with expected outcomes, limitations, support
+   contact. Reviewer should succeed in ~10 minutes.
+6. **Fully populated test account** with credentials + step-by-step access instructions.
+7. Functional quality: valid params → success; actionable (not generic) errors;
+   right-sized, token-frugal responses; no conversation-data collection.
+8. Tool descriptions narrow and factual; no prompt-injection patterns; custom query
+   tools must name/link the target API.
+9. First-party API ownership: MCP domain should match the service; verify domain control.
+10. Streamable HTTP transport (SSE deprecated). Tool names ≤ 64 chars.
+11. No financial-transaction or AI-media-generation use cases (FGAC is fine here).
+
+## Audit of `src/app/api/mcp/route.ts` (and related)
+
+### Blockers (would fail the automated scan or review)
+
+- **B1 — No tool annotations anywhere.** None of the 11 tools has `title`,
+  `readOnlyHint`, or `destructiveHint`. The portal's Tools step flags these before you
+  can even submit. The installed `@modelcontextprotocol/sdk` (via `mcp-handler` ^1.1.0)
+  supports `server.tool(name, description, schema, annotations, cb)` — code change only.
+  Mapping: `list_accounts`, `gmail_list`, `gmail_read`, `gmail_get_attachment`,
+  `gmail_labels`, `sheets_get_spreadsheet`, `sheets_read_range`, `get_my_permissions`
+  → `readOnlyHint: true`; `gmail_send`, `sheets_update_range`, `sheets_append_rows`
+  → `destructiveHint: true` (+ `openWorldHint` where appropriate: `gmail_send` true).
+- **B2 — `raw_google_api_call` is the exact named auto-reject pattern**: freeform `path`
+  + `method` enum spanning GET→DELETE. Options: (a) drop it from the hosted MCP surface
+  (keep the raw proxy on `/api/proxy` for API-key users), or (b) split into
+  `google_api_get` (readOnlyHint) and `google_api_modify` (destructiveHint), each
+  description explicitly naming/linking the Gmail and Sheets API docs. Recommendation:
+  (a) for the directory build — it also closes enforcement gaps (see B5).
+- **B3 — Unauthenticated `GET`/`DELETE` exports.** Only `POST` is wrapped in
+  `experimental_withMcpAuth`; `GET = handler` and `DELETE = handler` bypass the 401 +
+  `WWW-Authenticate` contract (cited by one guide as ~30% of rejections). Wrap all three
+  verbs.
+- **B4 — Privacy policy gaps.** `/privacy` exists but ends with "please contact support"
+  — no actual contact channel; no explicit retention periods for logs/metadata while an
+  account is active. Both are named review items. Add a real support email (and put the
+  same one in the listing's support-contact field).
+
+### Security findings (reviewers test against "Anthropic's security standards")
+
+- **B5 — `verifyClerkJwtDirect` trusts the token's own `iss`.** The fallback derives the
+  JWKS URL from the attacker-controlled `iss` claim — any issuer on the internet can
+  mint a token that passes verification. Downstream damage is limited (connection starts
+  `pending`), but a forged token with a known Clerk user id auto-creates connections and
+  touches `lastUsedAt`. Pin the expected issuer (the Clerk frontend API origin) before
+  fetching JWKS.
+- **B6 — Enforcement asymmetry in `raw_google_api_call`** (moot if dropped): send path
+  only checks that send rules *exist* (not that the recipient matches the whitelist);
+  Gmail read/list via raw path skips `checkReadRestrictions`; non-Gmail, non-Sheets
+  Google APIs pass through with no rules at all. If B2 chooses option (b), enforcement
+  must reach parity with the dedicated tools first.
+
+### Quality issues (functional-review failures, fix before submitting)
+
+- **Q1 — No Google API error handling.** `gmailFetch`/`sheetsFetch` return `res.json()`
+  regardless of status; an expired Google token, 403 scope error, or HTML error page
+  surfaces as a raw dump or a throw. Reviewers explicitly fail "generic errors". Wrap
+  with status checks and map to actionable messages ("Google token expired — reconnect
+  in the dashboard", etc.).
+- **Q2 — Oversized responses.** `gmail_read` returns the entire `format=full` payload;
+  `gmail_get_attachment` returns base64 file bodies as text (unbounded); `gmail_list`
+  re-dumps raw JSON. The policy requires token-frugal responses "commensurate" with the
+  task. Trim: default `gmail_read` to parsed headers + decoded text body; cap/paginate
+  attachment size with a clear over-limit message; summarize list results.
+- **Q3 — Tool description hygiene.** `raw_google_api_call`'s "Guarantees access to any
+  API endpoint" is promotional and wrong (rules can deny). `gmail_send`'s "Subject to
+  send whitelist rules" is fine; keep descriptions factual. The pending-approval text
+  ("Please share this exact error message with the user") is acceptable in a *response*
+  but reads as behavior-steering — rephrase to plain data ("This connection is awaiting
+  approval. Approve at: <url>").
+- **Q4 — `serverInfo` polish.** Add `title` and website URL; bump version honestly.
+
+### Already in good shape
+
+- OAuth: Clerk MCP tooling gives DCR + PKCE S256, RFC 8414 + RFC 9728 metadata routes
+  with CORS, and `resourceMetadataPath` is wired into the POST auth wrapper. Hosted on
+  Vercel over HTTPS with streamable HTTP transport. `/terms` exists. No financial or
+  AI-media use cases. Read-time rule enforcement (labels, content, send whitelist,
+  sheets permissions) is exactly the kind of scoped behavior the directory rewards.
+- Watch item: Vercel WAF/bot protection must not block `160.79.104.0/21` (Cloudflare
+  Bot Fight broke one submitter's server); verify discovery endpoints from outside.
+- Watch item: DCR registers a new client per fresh connection; at directory scale Clerk
+  will accumulate registered clients. Anthropic recommends CIMD or Anthropic-held
+  credentials for high-traffic listings — acceptable to launch on DCR, revisit later.
+
+## Plan
+
+**Phase 1 — Code changes (this repo)**
+1. Add `title` + `readOnlyHint`/`destructiveHint`/`openWorldHint` annotations to all tools (B1).
+2. Remove `raw_google_api_call` from the hosted MCP tool surface (B2/B6).
+3. Wrap GET and DELETE in `experimental_withMcpAuth` (B3).
+4. Pin the Clerk issuer in `verifyClerkJwtDirect` (B5).
+5. Add Google API error handling with actionable messages (Q1).
+6. Right-size `gmail_read` / `gmail_get_attachment` / `gmail_list` responses (Q2).
+7. Clean descriptions + pending-approval copy + `serverInfo` (Q3/Q4).
+
+**Phase 2 — Content & compliance**
+8. Privacy policy: add support email, retention periods (B4). Mirror contact on `/terms`.
+9. Public docs page (marketing site or help article): what FGAC is, connect steps,
+   3+ example prompts w/ expected outcomes, limitations, support contact.
+10. Prepare reviewer test account: dedicated Google account, populated inbox + a shared
+    spreadsheet, pre-approved connection + proxy key + sample rules, written click-path.
+
+**Phase 3 — Validation**
+11. Exercise every tool via MCP Inspector and as a custom connector in Claude.ai
+    (the portal makes you attest to this). Verify the 401/`WWW-Authenticate` shape and
+    both `.well-known` docs from an external network; confirm token endpoint accepts
+    form-urlencoded and responds < 10 s.
+12. Run existing QA capability suites against the changed tool surface.
+
+**Phase 4 — Submission**
+13. Ensure access to a Claude **Team/Enterprise org** (portal prerequisite — Owner role).
+14. Complete the portal (have ready: docs URL, privacy URL, square icon, tagline ≤ 55
+    chars, description ≤ 2000 chars, categories, slug — permanent once published —
+    test credentials, company info). Data-handling step: FGAC proxies Google's APIs on
+    the user's behalf — answer the first-party/proxy question accordingly and be ready
+    to justify it; our MCP domain (fgac.ai) matches our service.
+15. Track status in the submissions dashboard; fix feedback fast (resubmits requeue).
+
+## Sources
+
+- https://claude.com/docs/connectors/building/submission
+- https://claude.com/docs/connectors/building/review-criteria
+- https://claude.com/docs/connectors/building/authentication
+- https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy
+- https://support.claude.com/en/articles/11596036-anthropic-connectors-directory-faq
+- https://joeir.substack.com/p/submitting-my-mcp-server-as-a-claude
+- https://sunpeak.ai/blogs/claude-connector-directory-submission/
+- https://tallyfy.com/how-to-list-mcp-server-anthropic-claude-connectors/
+- https://medium.com/@TheTechDude/how-to-submit-to-anthropic-connectors-directory-the-full-guide-da0bfed4d21c

--- a/docs/implementation_plans/connector-approval-audit_v2.md
+++ b/docs/implementation_plans/connector-approval-audit_v2.md
@@ -1,0 +1,226 @@
+# Anthropic Connectors Directory — FGAC MCP Audit & Submission Plan (v2)
+
+Branch: `claude/connector-approval-audit-4bf125` · Date: 2026-07-27
+
+Supersedes v1. Two design decisions changed after further research and discussion:
+
+1. **`raw_google_api_call` is split, not dropped.** The full-API-surface passthrough is
+   core product value. The directory rule only forbids *mixing* safe and unsafe HTTP
+   methods in one tool; freeform-path "custom query tools" are explicitly allowed when
+   the description names/links the target API. We keep the power via a read/write pair.
+2. **No dual MCP endpoints.** Server-side updates to a listed connector deploy live with
+   no per-release re-review; only *listing* edits go through reviewer approval. The
+   listed URL must simply be our stable prod deployment. Iteration continues on Vercel
+   previews (as custom connectors), promotion via `/deploy-prod` — the existing
+   pipeline. The consequence is that review criteria become standing invariants on
+   `main`, enforced in CI, because prod is permanently "in review."
+
+## How the process works (2026)
+
+- Submission happens in the **Claude.ai submission portal**
+  (`claude.ai/admin-settings/directory/submissions/new`). Requires a **Team or
+  Enterprise Claude organization**; only Owners (or Enterprise custom roles with
+  Directory management) can submit. 11 portal steps: Connection → Tools → Listing →
+  Use cases → Company → Authentication → Data handling → Test & launch → Compliance
+  (7 acknowledgments) → Review.
+- On submit, an **automated policy scan** runs; passing lists the server as a
+  **community connector**. Anthropic may escalate popular listings to **verified
+  review** (humans functionally test every tool). Same criteria either way.
+- **Timelines are unpublished.** Community reports: ~2 weeks to months. Resubmissions
+  requeue at the back, so one missing item costs a week+. Escalations:
+  `mcp-review@anthropic.com`.
+- The connector keeps working as a **custom connector** throughout — the directory adds
+  discovery, not functionality.
+
+## Update / release model (new in v2)
+
+- The listing is **metadata + our server URL**. Claude syncs `tools/list` from the
+  live server; there is no artifact upload and **no per-release review gate**. New
+  tools, behavior changes, and bug fixes reach all connected users on deploy.
+- **Listing edits** (tagline, description, doc/privacy links, icon, company details)
+  are submitted via the dashboard and stay *pending until a reviewer approves*.
+  Changing the **display name requires full re-review**. The **URL slug is permanent**.
+- Compliance is **ongoing, not per-update**: the Software Directory Policy provides for
+  "initial and ongoing reviews," and the dashboard continuously reports health (30-day
+  disconnect rate ≤ 5% = Healthy), error rates (request-level 4xx/5xx + `isError`
+  results), latency, and per-tool usage. A non-compliant deploy risks delisting rather
+  than a blocked release.
+- **Operational consequences:**
+  - The listed URL = production (`fgac.ai/api/mcp`). Never point the listing at
+    anything we churn. Preview deployments remain the iteration surface, connected as
+    custom connectors during QA.
+  - Add a CI/lint gate on the MCP tool registry enforcing: every tool has `title` +
+    `readOnlyHint`/`destructiveHint`; no tool accepts both safe and unsafe HTTP
+    methods; names ≤ 64 chars. This makes the standing review invariants unbreakable
+    by future tool additions.
+  - Watch the dashboard error-rate metric post-publication: tool results returning
+    `isError: true` and 5xxs count against health, which strengthens the case for the
+    Q1 error-handling work below.
+
+## Hard requirements (each missing item = rejection)
+
+1. Every tool: `title` + `readOnlyHint: true` (reads) or `destructiveHint: true`
+   (writes).
+2. No single tool mixing safe (GET/HEAD/OPTIONS) and unsafe (POST/PUT/PATCH/DELETE)
+   methods. Read/write must be separate tools; per-action splits are recommended, not
+   required. Freeform-path tools are allowed if the description names/links the API.
+3. OAuth 2.0 with PKCE S256; DCR or CIMD or Anthropic-held credentials; token endpoint
+   accepts `application/x-www-form-urlencoded`; 401 + `WWW-Authenticate: Bearer
+   resource_metadata=…` on every unauthenticated request including `initialize`;
+   RFC 9728 / RFC 8414 discovery reachable from Anthropic egress `160.79.104.0/21`
+   (WAF/bot protection in front of MCP *or* the IdP is a common silent failure).
+4. Published HTTPS **privacy policy** covering collection, usage, storage/retention,
+   third-party sharing, and a real contact. Missing/incomplete = immediate rejection.
+5. **Public documentation** by publish date: product summary, setup + auth steps, ≥3
+   example prompts with expected outcomes, limitations, support contact. A reviewer
+   should succeed in ~10 minutes.
+6. **Fully populated test account** with credentials + step-by-step instructions.
+7. Functional quality: valid params → success; actionable (not generic) errors;
+   right-sized, token-frugal responses; no conversation-data collection.
+8. Tool descriptions narrow and factual; no prompt-injection patterns.
+9. First-party API ownership: MCP domain should match the service (fgac.ai does).
+10. Streamable HTTP transport (SSE deprecated). Tool names ≤ 64 chars.
+11. No financial-transaction or AI-media-generation use cases (FGAC is fine).
+
+## Raw passthrough strategy (revised B2)
+
+The auto-reject pattern is one tool with a `method` enum spanning GET→DELETE. The
+replacement preserves the full Google API surface in two tools:
+
+- **`google_api_get`** — freeform `path`, GET only, `readOnlyHint: true`.
+  Description names and links the Gmail API
+  (developers.google.com/gmail/api/reference/rest) and Sheets API
+  (developers.google.com/sheets/api/reference/rest) and states that FGAC access rules
+  govern every call.
+- **`google_api_modify`** — freeform `path`, method ∈ {POST, PUT, PATCH},
+  `destructiveHint: true`. Same doc links and rule statement.
+- **DELETE is not exposed.** We already hard-block trash/emptyTrash; "FGAC never
+  deletes" becomes an explicit safety property of the listing.
+- Dedicated convenience tools (`gmail_*`, `sheets_*`) remain the primary interface;
+  the raw pair is the documented long-tail escape hatch.
+
+Why this passes AND helps the pitch: Claude's permission model keys off the
+annotations — `readOnlyHint` tools auto-run without per-call confirmation, destructive
+tools always prompt. A raw read tool that is provably safe because FGAC rules gate it
+is the product thesis; say so in the Use-cases step.
+
+**Enforcement parity is a prerequisite** (was B6): the raw path currently skips
+read-restriction checks on message fetches, checks only that send rules *exist* (not
+that the recipient matches), and passes non-Gmail/Sheets Google APIs through
+unchecked. Centralize rule evaluation on **path + method classification** so the raw
+pair gives identical guarantees to the dedicated tools, **deny-by-default** for any
+path family the classifier doesn't recognize. Also deny Google's **batch endpoints**
+(`/batch/...`, multipart bodies): batch rides on a single POST, so it would land in
+`google_api_modify` yet can smuggle both reads that bypass read-restrictions and
+unclassified writes inside its body.
+
+## Audit findings (unchanged from v1 except B2/B6)
+
+### Blockers
+
+- **B1 — No tool annotations.** None of the 11 tools has `title`, `readOnlyHint`, or
+  `destructiveHint`; the portal's Tools step flags this pre-submission. Installed SDK
+  supports annotations (code change only). Mapping: `list_accounts`, `gmail_list`,
+  `gmail_read`, `gmail_get_attachment`, `gmail_labels`, `sheets_get_spreadsheet`,
+  `sheets_read_range`, `get_my_permissions`, `google_api_get` → `readOnlyHint: true`;
+  `gmail_send`, `sheets_update_range`, `sheets_append_rows`, `google_api_modify` →
+  `destructiveHint: true` (`openWorldHint: true` on `gmail_send`).
+- **B2 — `raw_google_api_call` mixes methods** → replace with the
+  `google_api_get`/`google_api_modify` pair per the strategy above.
+- **B3 — Unauthenticated `GET`/`DELETE` exports.** Only `POST` is wrapped in
+  `experimental_withMcpAuth`; wrap all verbs to honor the 401 + `WWW-Authenticate`
+  contract (~30% of rejections per one firsthand guide).
+- **B4 — Privacy policy gaps.** `/privacy` ends with "contact support" (no actual
+  channel) and lacks retention periods for logs/metadata during account life. Add a
+  real support email; mirror it in the listing's support-contact field and `/terms`.
+
+### Security
+
+- **B5 — `verifyClerkJwtDirect` trusts the token's own `iss`.** JWKS URL is derived
+  from the attacker-controlled `iss` claim, so any issuer can mint a passing token.
+  Blast radius limited (connections start `pending`) but pin the expected Clerk
+  issuer before fetching JWKS.
+- **B6 — folded into the raw passthrough strategy above** (enforcement parity +
+  deny-by-default + batch-endpoint block).
+
+### Quality
+
+- **Q1 — No Google API error handling.** `gmailFetch`/`sheetsFetch` ignore HTTP
+  status; expired tokens/scope errors surface as raw dumps or throws. Map to
+  actionable messages. Post-publication this also protects the dashboard error-rate
+  health metric.
+- **Q2 — Oversized responses.** `gmail_read` dumps `format=full`;
+  `gmail_get_attachment` returns unbounded base64; `gmail_list` re-dumps raw JSON.
+  Trim to parsed headers + text body by default; cap attachment size with a clear
+  over-limit message; summarize listings.
+- **Q3 — Description hygiene.** Remove "Guarantees access to any API endpoint"
+  phrasing; keep descriptions factual. Rephrase the pending-approval response to plain
+  data ("This connection is awaiting approval. Approve at: <url>").
+- **Q4 — `serverInfo` polish.** Add `title`, website URL, honest version.
+
+### Already in good shape
+
+- Clerk MCP tooling: DCR + PKCE S256, RFC 8414/9728 metadata with CORS,
+  `resourceMetadataPath` wired on POST. HTTPS + streamable HTTP on Vercel. `/terms`
+  exists. No prohibited use cases. Rule-scoped behavior is what the directory rewards.
+- Watch: Vercel WAF must not block `160.79.104.0/21`; verify discovery externally.
+- Watch: DCR registers a client per fresh connection; at directory scale prefer CIMD
+  or Anthropic-held credentials later (launching on DCR is acceptable).
+
+## Plan
+
+**Phase 1 — Code changes (this repo)**
+1. Add `title` + `readOnlyHint`/`destructiveHint`/`openWorldHint` to all tools (B1).
+2. Centralize FGAC rule enforcement on path+method classification with deny-by-default
+   and batch-endpoint blocking; bring the raw path to parity with dedicated tools (B6).
+3. Replace `raw_google_api_call` with `google_api_get` + `google_api_modify` (no
+   DELETE), descriptions linking Gmail/Sheets API docs (B2). Depends on step 2.
+4. Wrap GET and DELETE exports in `experimental_withMcpAuth` (B3).
+5. Pin the Clerk issuer in `verifyClerkJwtDirect` (B5).
+6. Add Google API error handling with actionable messages (Q1).
+7. Right-size `gmail_read` / `gmail_get_attachment` / `gmail_list` responses (Q2).
+8. Clean descriptions, pending-approval copy, `serverInfo` (Q3/Q4).
+9. Add a CI/lint check over the tool registry: annotations present, no mixed-method
+   tools, names ≤ 64 chars — the standing invariants for post-listing deploys.
+
+**Phase 2 — Content & compliance**
+10. Privacy policy: real support email + retention periods (B4); mirror on `/terms`.
+11. Public docs page: what FGAC is, connect steps, ≥3 example prompts with expected
+    outcomes (include one exercising `google_api_get` to document the escape hatch),
+    limitations, support contact.
+12. Reviewer test account: dedicated Google account, populated inbox + shared
+    spreadsheet, pre-approved connection + proxy key + sample rules demonstrating both
+    an allow and a deny, written click-path.
+
+**Phase 3 — Validation**
+13. Exercise every tool via MCP Inspector and as a custom connector in Claude.ai
+    (portal attestation). Verify 401/`WWW-Authenticate` shape and both `.well-known`
+    docs from an external network; token endpoint form-urlencoded, < 10 s.
+14. Run existing QA capability suites against the changed tool surface (raw-API
+    capability docs need updating for the new tool pair first).
+
+**Phase 4 — Submission & operations**
+15. Ensure access to a Claude **Team/Enterprise org** (Owner) — the portal gate.
+16. Complete the portal (docs URL, privacy URL, square icon, tagline ≤ 55 chars,
+    description ≤ 2000 chars, categories, permanent slug, test credentials, company
+    info). Data handling: FGAC proxies Google's APIs on the user's own OAuth grant —
+    answer the proxy question accordingly. Point the Connection step at production
+    `fgac.ai/api/mcp` only.
+17. Track the submissions dashboard; fix feedback fast (resubmits requeue).
+18. Post-publication: monitor health/error metrics in the dashboard; treat review
+    criteria as `main` invariants (CI gate from step 9); route listing-metadata edits
+    through the dashboard knowing they pend on reviewer approval; never rename the
+    display name casually (full re-review) — the slug is permanent either way.
+
+## Sources
+
+- https://claude.com/docs/connectors/building/submission
+- https://claude.com/docs/connectors/building/review-criteria
+- https://claude.com/docs/connectors/building/authentication
+- https://claude.com/docs/connectors/building/managing-your-listing
+- https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy
+- https://support.claude.com/en/articles/11596036-anthropic-connectors-directory-faq
+- https://joeir.substack.com/p/submitting-my-mcp-server-as-a-claude
+- https://sunpeak.ai/blogs/claude-connector-directory-submission/
+- https://tallyfy.com/how-to-list-mcp-server-anthropic-claude-connectors/
+- https://medium.com/@TheTechDude/how-to-submit-to-anthropic-connectors-directory-the-full-guide-da0bfed4d21c

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev",
     "dev:qa": "rm -rf .next/dev && NODE_OPTIONS='--max-old-space-size=8192' next dev --webpack",
-    "build": "tsx src/db/migrate.ts && next build",
+    "build": "npm run mcp:lint && tsx src/db/migrate.ts && next build",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "npm run mcp:lint && eslint .",
+    "mcp:lint": "tsx scripts/mcp-tool-lint.ts && tsx scripts/test-google-api-policy.ts",
     "db:branch": "tsx scripts/branch-db.ts",
     "db:push": "drizzle-kit push",
     "db:migrate": "tsx src/db/migrate.ts",

--- a/scripts/mcp-tool-lint.ts
+++ b/scripts/mcp-tool-lint.ts
@@ -1,0 +1,69 @@
+/**
+ * MCP tool-registry lint — the standing Anthropic Connectors Directory
+ * invariants, enforced in CI (chained into `npm run lint`).
+ *
+ * Once the connector is listed, every deploy to main goes live for directory
+ * users with no re-review, so these must hold on every commit:
+ *   1. Every tool has a non-empty `title`.
+ *   2. Every tool is readOnly (→ readOnlyHint) or declares `destructive`
+ *      explicitly (→ destructiveHint).
+ *   3. Tool names are ≤ 64 chars, [a-zA-Z0-9_-] only.
+ *   4. No tool forwards both safe (GET/HEAD/OPTIONS) and unsafe HTTP methods.
+ *   5. DELETE is never forwarded.
+ *   6. Freeform-path tools name the target API docs in their description.
+ *   7. Descriptions are non-empty and don't instruct the model how to behave.
+ */
+import { TOOL_DEFS, type FgacToolDef } from '../src/app/api/mcp/toolDefs';
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+const errors: string[] = [];
+
+const defs = Object.values(TOOL_DEFS) as FgacToolDef[];
+
+for (const def of defs) {
+  const where = `tool '${def.name}'`;
+
+  if (def.name.length > 64) errors.push(`${where}: name exceeds 64 characters`);
+  if (!/^[a-zA-Z0-9_-]+$/.test(def.name)) errors.push(`${where}: name has invalid characters`);
+  if (!def.title?.trim()) errors.push(`${where}: missing title`);
+  if (!def.description?.trim()) errors.push(`${where}: missing description`);
+
+  if (!def.readOnly && typeof def.destructive !== 'boolean') {
+    errors.push(`${where}: write tools must declare 'destructive' explicitly (→ destructiveHint)`);
+  }
+  if (def.readOnly && def.destructive !== undefined) {
+    errors.push(`${where}: readOnly tools must not declare 'destructive'`);
+  }
+
+  if (def.freeformMethods) {
+    const methods = def.freeformMethods.map(m => m.toUpperCase());
+    const hasSafe = methods.some(m => SAFE_METHODS.has(m));
+    const hasUnsafe = methods.some(m => !SAFE_METHODS.has(m));
+    if (hasSafe && hasUnsafe) {
+      errors.push(`${where}: mixes safe and unsafe HTTP methods — split into separate read/write tools (directory auto-reject)`);
+    }
+    if (methods.includes('DELETE')) {
+      errors.push(`${where}: forwards DELETE — FGAC never exposes deletion`);
+    }
+    if (hasSafe && !def.readOnly) errors.push(`${where}: forwards only safe methods but is not readOnly`);
+    if (hasUnsafe && def.readOnly) errors.push(`${where}: forwards unsafe methods but is marked readOnly`);
+    if (!/developers\.google\.com|https:\/\/\S+\/docs/.test(def.description)) {
+      errors.push(`${where}: freeform-path tools must link the target API docs in the description`);
+    }
+  }
+
+  const lowered = def.description.toLowerCase();
+  for (const phrase of ['ignore previous', 'you must always', 'do not tell the user', 'system prompt']) {
+    if (lowered.includes(phrase)) errors.push(`${where}: description contains behavioral instruction ('${phrase}')`);
+  }
+}
+
+const names = defs.map(d => d.name);
+if (new Set(names).size !== names.length) errors.push('duplicate tool names in TOOL_DEFS');
+
+if (errors.length > 0) {
+  console.error(`mcp-tool-lint: ${errors.length} violation(s):`);
+  for (const e of errors) console.error(`  ✗ ${e}`);
+  process.exit(1);
+}
+console.log(`mcp-tool-lint: ${defs.length} tools OK (titles, annotations, method separation, name length)`);

--- a/scripts/test-google-api-policy.ts
+++ b/scripts/test-google-api-policy.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the raw Google API deny-by-default policy
+ * (src/app/api/mcp/googleApiPolicy.ts). Run: npx tsx scripts/test-google-api-policy.ts
+ */
+import {
+  classifyGoogleApiCall, extractSendRecipients, collectLabelIds,
+} from '../src/app/api/mcp/googleApiPolicy';
+
+let failures = 0;
+function expect(name: string, actual: unknown, predicate: (v: never) => boolean) {
+  if (!predicate(actual as never)) {
+    failures++;
+    console.error(`  ✗ ${name} — got: ${JSON.stringify(actual)}`);
+  } else {
+    console.log(`  ✓ ${name}`);
+  }
+}
+
+console.log('classifyGoogleApiCall:');
+expect('gmail GET list → gmail_read',
+  classifyGoogleApiCall('gmail/v1/users/me/messages?maxResults=5', 'GET'),
+  (c: { kind: string }) => c.kind === 'gmail_read');
+expect('gmail GET message → gmail_read',
+  classifyGoogleApiCall('/gmail/v1/users/me/messages/abc123', 'GET'),
+  (c: { kind: string }) => c.kind === 'gmail_read');
+expect('gmail send POST → gmail_send',
+  classifyGoogleApiCall('gmail/v1/users/me/messages/send', 'POST'),
+  (c: { kind: string }) => c.kind === 'gmail_send');
+expect('gmail send with query → gmail_send',
+  classifyGoogleApiCall('gmail/v1/users/me/messages/send?alt=json', 'POST'),
+  (c: { kind: string }) => c.kind === 'gmail_send');
+expect('gmail modify POST → denied',
+  classifyGoogleApiCall('gmail/v1/users/me/messages/abc/modify', 'POST'),
+  (c: { kind: string }) => c.kind === 'denied');
+expect('gmail settings forwarding POST → denied',
+  classifyGoogleApiCall('gmail/v1/users/me/settings/forwardingAddresses', 'POST'),
+  (c: { kind: string }) => c.kind === 'denied');
+expect('gmail drafts POST → denied',
+  classifyGoogleApiCall('gmail/v1/users/me/drafts', 'POST'),
+  (c: { kind: string }) => c.kind === 'denied');
+expect('gmail trash DELETE-ish POST → denied',
+  classifyGoogleApiCall('gmail/v1/users/me/messages/abc/trash', 'POST'),
+  (c: { kind: string }) => c.kind === 'denied');
+expect('sheets GET values → sheets read',
+  classifyGoogleApiCall('v4/spreadsheets/1BxiM/values/Sheet1', 'GET'),
+  (c: { kind: string; spreadsheetId?: string; isMutating?: boolean }) =>
+    c.kind === 'sheets' && c.spreadsheetId === '1BxiM' && c.isMutating === false);
+expect('sheets append POST → sheets write',
+  classifyGoogleApiCall('sheets/v4/spreadsheets/1BxiM/values/Sheet1:append', 'POST'),
+  (c: { kind: string; isMutating?: boolean }) => c.kind === 'sheets' && c.isMutating === true);
+expect('sheets create (no id) → denied',
+  classifyGoogleApiCall('v4/spreadsheets', 'POST'),
+  (c: { kind: string }) => c.kind === 'denied');
+expect('batch endpoint → denied',
+  classifyGoogleApiCall('batch/gmail/v1', 'POST'),
+  (c: { kind: string }) => c.kind === 'denied');
+expect('unknown API (drive) → denied',
+  classifyGoogleApiCall('drive/v3/files', 'GET'),
+  (c: { kind: string }) => c.kind === 'denied');
+expect('unknown API (calendar) → denied',
+  classifyGoogleApiCall('calendar/v3/calendars/primary/events', 'GET'),
+  (c: { kind: string }) => c.kind === 'denied');
+
+console.log('extractSendRecipients:');
+const raw = Buffer.from(
+  'To: alice@example.com\r\nCc: Bob <bob@example.org>\r\nSubject: hi\r\n\r\nBody mentions carol@nowhere.test',
+).toString('base64url');
+expect('parses To and Cc, ignores body',
+  extractSendRecipients({ raw }),
+  (r: string[] | null) => !!r && r.length === 2 && r.includes('alice@example.com') && r.includes('bob@example.org'));
+expect('JSON string body works',
+  extractSendRecipients(JSON.stringify({ raw })),
+  (r: string[] | null) => !!r && r.includes('alice@example.com'));
+expect('missing raw → null', extractSendRecipients({ foo: 1 }), (r: unknown) => r === null);
+expect('garbage → null', extractSendRecipients('not json'), (r: unknown) => r === null);
+const foldedRaw = Buffer.from(
+  'To: alice@example.com,\r\n bob@example.org\r\nSubject: folded\r\n\r\nx',
+).toString('base64url');
+expect('unfolds continuation lines',
+  extractSendRecipients({ raw: foldedRaw }),
+  (r: string[] | null) => !!r && r.includes('bob@example.org'));
+
+console.log('collectLabelIds:');
+expect('top-level labels',
+  collectLabelIds({ labelIds: ['INBOX', 'SECRET'] }),
+  (l: string[]) => l.includes('SECRET'));
+expect('nested thread messages',
+  collectLabelIds({ messages: [{ labelIds: ['INBOX'] }, { labelIds: ['SECRET'] }] }),
+  (l: string[]) => l.includes('SECRET') && l.includes('INBOX'));
+expect('no labels → empty', collectLabelIds({ messages: [{ id: 'a' }] }), (l: string[]) => l.length === 0);
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) FAILED`);
+  process.exit(1);
+}
+console.log('\nAll google-api-policy tests passed.');

--- a/src/app/.well-known/oauth-protected-resource/mcp/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/mcp/route.ts
@@ -2,18 +2,39 @@
  * OAuth 2.0 Protected Resource Metadata (RFC 9728)
  *
  * This endpoint tells MCP clients where to authenticate.
- * When a client hits /mcp and gets a 401, it follows the WWW-Authenticate
+ * When a client hits /api/mcp and gets a 401, it follows the WWW-Authenticate
  * header to this endpoint, which points it to Clerk's authorization server.
  *
- * SPIKE: Validates that MCP clients can discover our auth requirements.
+ * We build the metadata ourselves rather than using Clerk's
+ * protectedResourceHandlerClerk because that helper sets `resource` to the
+ * bare origin. Claude requires the `resource` field to match the MCP server
+ * URL exactly as users enter it — including the /api/mcp path.
  */
 import {
-  protectedResourceHandlerClerk,
-  metadataCorsOptionsRequestHandler,
-} from '@clerk/mcp-tools/next';
+  generateClerkProtectedResourceMetadata,
+  corsHeaders,
+} from '@clerk/mcp-tools/server';
+import { metadataCorsOptionsRequestHandler } from '@clerk/mcp-tools/next';
 
-const handler = protectedResourceHandlerClerk();
-const corsHandler = metadataCorsOptionsRequestHandler();
+export function GET(req: Request) {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  if (!publishableKey) {
+    return Response.json({ error: 'server_misconfigured' }, { status: 500 });
+  }
 
-export const GET = handler;
-export const OPTIONS = corsHandler;
+  const origin = new URL(req.url).origin;
+  const metadata = generateClerkProtectedResourceMetadata({
+    publishableKey,
+    resourceUrl: `${origin}/api/mcp`,
+  });
+
+  return Response.json(metadata, {
+    headers: {
+      'Cache-Control': 'max-age=3600',
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+    },
+  });
+}
+
+export const OPTIONS = metadataCorsOptionsRequestHandler();

--- a/src/app/api/mcp/googleApiPolicy.ts
+++ b/src/app/api/mcp/googleApiPolicy.ts
@@ -1,0 +1,116 @@
+/**
+ * Pure classification + parsing helpers for the raw Google API tools
+ * (google_api_get / google_api_modify).
+ *
+ * Deny-by-default: only path families we can map onto FGAC rule enforcement
+ * are forwarded. Everything else — unknown Google APIs, batch endpoints,
+ * unrecognized Gmail writes — is refused before any network call.
+ *
+ * No db/env imports: unit-testable via `npx tsx scripts/test-google-api-policy.ts`.
+ */
+
+export type RawCallClass =
+  | { kind: 'sheets'; spreadsheetId: string; isMutating: boolean }
+  | { kind: 'gmail_read' }
+  | { kind: 'gmail_send' }
+  | { kind: 'denied'; reason: string };
+
+export function extractSheetsSpreadsheetId(path: string): string | null {
+  const match = path.match(/(?:v4\/spreadsheets|sheets\/v4\/spreadsheets|spreadsheets)\/([^/?:#]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Classify a raw Google API call. `rawPath` is the caller-supplied path
+ * (query string allowed); `method` is the HTTP method the tool forwards.
+ */
+export function classifyGoogleApiCall(rawPath: string, method: string): RawCallClass {
+  const path = rawPath.replace(/^\/+/, '').split(/[?#]/)[0];
+  const segments = path.split('/').filter(Boolean).map(s => s.toLowerCase());
+
+  // Google batch endpoints multiplex many sub-requests (each with its own
+  // method and path) inside one POST body, which would smuggle reads past
+  // read-restriction checks and writes past the deny-by-default policy.
+  if (segments.includes('batch') || segments.some(s => s.startsWith('batch'))) {
+    return { kind: 'denied', reason: '🚫 Access Denied: Google batch endpoints are not supported through FGAC. Call individual endpoints instead.' };
+  }
+
+  const isMutating = method !== 'GET';
+
+  if (segments.includes('spreadsheets')) {
+    const spreadsheetId = extractSheetsSpreadsheetId(path);
+    if (!spreadsheetId) {
+      return { kind: 'denied', reason: '🚫 Access Denied: A spreadsheet ID is required — FGAC Sheets rules are granted per spreadsheet. Creating spreadsheets is not supported.' };
+    }
+    return { kind: 'sheets', spreadsheetId, isMutating };
+  }
+
+  if (segments[0] === 'gmail') {
+    if (!isMutating) return { kind: 'gmail_read' };
+    if (segments[segments.length - 1] === 'send' && segments[segments.length - 2] === 'messages') {
+      return { kind: 'gmail_send' };
+    }
+    return { kind: 'denied', reason: '🚫 Access Denied: This Gmail write endpoint is not permitted through FGAC. The only supported Gmail write is messages/send (recipients are checked against the send whitelist).' };
+  }
+
+  return { kind: 'denied', reason: '🚫 Access Denied: This Google API is not exposed through FGAC. Supported paths: Gmail ("gmail/v1/users/...") and Google Sheets ("v4/spreadsheets/{id}/...").' };
+}
+
+/**
+ * Extract all recipient addresses (To/Cc/Bcc) from a Gmail messages/send
+ * request body ({ raw: <base64url RFC 2822 message> }).
+ * Returns null when recipients cannot be determined — callers must deny.
+ */
+export function extractSendRecipients(body: unknown): string[] | null {
+  let raw: string | undefined;
+  try {
+    const obj = typeof body === 'string' ? JSON.parse(body) : body;
+    if (obj && typeof obj === 'object' && typeof (obj as { raw?: unknown }).raw === 'string') {
+      raw = (obj as { raw: string }).raw;
+    }
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let message: string;
+  try {
+    message = Buffer.from(raw, 'base64url').toString('utf8');
+  } catch {
+    return null;
+  }
+
+  // Header section ends at the first blank line. Unfold continuation lines.
+  const headerSection = message.split(/\r?\n\r?\n/)[0].replace(/\r?\n[ \t]+/g, ' ');
+  const recipients: string[] = [];
+  for (const line of headerSection.split(/\r?\n/)) {
+    if (/^(to|cc|bcc):/i.test(line)) {
+      const found = line.match(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g);
+      if (found) recipients.push(...found);
+    }
+  }
+  return recipients.length > 0 ? recipients : null;
+}
+
+/**
+ * Collect every `labelIds` array reachable in a Gmail API response.
+ * Thread and list responses nest messages, so label-based read rules must
+ * consider the union — not just the top-level object.
+ */
+export function collectLabelIds(value: unknown, depth = 0): string[] {
+  if (depth > 6 || value === null || typeof value !== 'object') return [];
+  const out: string[] = [];
+  if (Array.isArray(value)) {
+    for (const item of value) out.push(...collectLabelIds(item, depth + 1));
+    return out;
+  }
+  const obj = value as Record<string, unknown>;
+  if (Array.isArray(obj.labelIds)) {
+    out.push(...obj.labelIds.filter((l): l is string => typeof l === 'string'));
+  }
+  for (const key of Object.keys(obj)) {
+    if (key === 'labelIds') continue;
+    out.push(...collectLabelIds(obj[key], depth + 1));
+  }
+  return out;
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -6,6 +6,11 @@
  *
  * Auth chain: OAuth token → userId + clientId → agent_connections →
  *   proxy_key → key_email_access → Clerk Google token → Gmail API
+ *
+ * Tool metadata (names, titles, annotations) lives in ./toolDefs.ts and is
+ * linted by scripts/mcp-tool-lint.ts against the Anthropic Connectors
+ * Directory requirements. Raw Google API calls are classified deny-by-default
+ * in ./googleApiPolicy.ts.
  */
 import { createMcpHandler, experimental_withMcpAuth } from 'mcp-handler';
 import { verifyClerkToken } from '@clerk/mcp-tools/next';
@@ -21,6 +26,10 @@ import { filterLiveDelegatedAccess } from '@/db/delegationQueries';
 import { clerkClient } from '@clerk/nextjs/server';
 import safeRegex from 'safe-regex';
 import { resolveDbUser } from '@/db/userHelpers';
+import { TOOL_DEFS, toolAnnotations, type FgacToolDef } from './toolDefs';
+import {
+  classifyGoogleApiCall, extractSendRecipients, collectLabelIds,
+} from './googleApiPolicy';
 
 const DASHBOARD_URL = process.env.NEXT_PUBLIC_APP_URL
   || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : null)
@@ -60,11 +69,11 @@ async function resolveConnection(userId: string, clientId: string | undefined): 
       const client = await clerkClient();
       const clerkUser = await client.users.getUser(userId);
       const email = clerkUser.emailAddresses[0]?.emailAddress;
-      
+
       if (!email) {
         return { authorized: false, reason: 'user_not_found' };
       }
-      
+
       user = await resolveDbUser(userId, email);
       console.log(`[MCP] Auto-created DB user for ${email}`);
     } catch (err) {
@@ -134,15 +143,27 @@ async function resolveConnection(userId: string, clientId: string | undefined): 
   };
 }
 
+// ─── Tool Result Helpers ────────────────────────────────────────────────────
+
+/** Successful tool response, including FGAC policy denials — a denial is the
+ * tool working as designed, not a tool failure. */
+const textResult = (text: string) => ({ content: [{ type: 'text' as const, text }] });
+
+/** Upstream/auth failure: marked isError so clients (and the directory's
+ * health metrics) see it as a genuine tool error. */
+const errorResult = (text: string) => ({ content: [{ type: 'text' as const, text }], isError: true });
+
+const jsonResult = (data: unknown) => textResult(JSON.stringify(data, null, 2));
+
 // ─── Pending Approval Message ───────────────────────────────────────────────
 
 function pendingMessage(result: ConnectionDenied) {
   switch (result.reason) {
     case 'pending_approval':
       return [
-        'Please share this exact error message with the user:',
-        `You have not assigned this client ${result.connectionId} to a permission profile please assign a profile by visiting:`,
-        `${result.dashboardUrl}`,
+        '⏳ This connection is awaiting user approval, so tools cannot run yet.',
+        `Connection ID: ${result.connectionId}`,
+        `The user can approve it by attaching it to a permission profile at: ${result.dashboardUrl}`,
       ].join('\n');
     case 'blocked':
       return '🚫 This connection has been blocked by the user.';
@@ -219,22 +240,25 @@ async function loadApplicableRules(userId: string, proxyKeyId: string, targetEma
   });
 }
 
+type ApplicableRules = Awaited<ReturnType<typeof loadApplicableRules>>;
+
 /**
  * Read-time enforcement, shared by every path that returns message content.
  * Policy: messages may APPEAR in listings, but reading content must respect
  * label blacklists (checked first — precedence), label whitelists, and content
  * read-blacklists — identically on MCP and the raw API proxy.
+ *
+ * Label rules consider every labelIds array in the response (thread and list
+ * responses nest messages). Whitelists only apply when the response carries
+ * labels at all — ID-only listings stay visible, matching the policy above.
  * Returns a user-facing restriction message, or null if the read is allowed.
  */
 function checkReadRestrictions(
-  rules: Awaited<ReturnType<typeof loadApplicableRules>>,
+  rules: ApplicableRules,
   message: unknown,
 ): string | null {
   const gmailRules = rules.filter(r => r.service === 'gmail');
-  const labelIds: string[] =
-    message && typeof message === 'object' && Array.isArray((message as { labelIds?: unknown }).labelIds)
-      ? (message as { labelIds: string[] }).labelIds
-      : [];
+  const labelIds = collectLabelIds(message);
 
   for (const rule of gmailRules.filter(r => r.actionType === 'label_blacklist')) {
     if (rule.regexPattern && labelIds.includes(rule.regexPattern)) {
@@ -243,7 +267,7 @@ function checkReadRestrictions(
   }
 
   const whitelists = gmailRules.filter(r => r.actionType === 'label_whitelist' && !!r.regexPattern);
-  if (whitelists.length > 0 && !whitelists.some(r => labelIds.includes(r.regexPattern!))) {
+  if (whitelists.length > 0 && labelIds.length > 0 && !whitelists.some(r => labelIds.includes(r.regexPattern!))) {
     return '🚫 Access restricted: Email lacks a required whitelisted label.';
   }
 
@@ -260,38 +284,95 @@ function checkReadRestrictions(
   return null;
 }
 
-// ─── Gmail API Helpers ──────────────────────────────────────────────────────
+/**
+ * Send-whitelist enforcement shared by gmail_send and google_api_modify.
+ * Every recipient must match a whitelist pattern; unknown recipients deny.
+ * Returns a user-facing denial message, or null if sending is allowed.
+ */
+function checkSendWhitelist(rules: ApplicableRules, recipients: string[] | null): string | null {
+  const sendRules = rules.filter(r => r.service === 'gmail' && r.actionType === 'send_whitelist');
 
-async function gmailFetch(token: string, email: string, path: string, method = 'GET', body?: string) {
+  if (sendRules.length === 0) {
+    return '🚫 No send whitelist rules configured. Ask the user to add the recipient to the sending whitelist in the FGAC dashboard.';
+  }
+
+  if (!recipients || recipients.length === 0) {
+    return '🚫 Could not determine the message recipients, so sending was denied. Provide a standard RFC 2822 message with To/Cc/Bcc headers.';
+  }
+
+  for (const recipient of recipients) {
+    let isWhitelisted = false;
+    for (const rule of sendRules) {
+      if (!rule.regexPattern) continue;
+      const regexStr = rule.regexPattern.replace(/\*/g, '.*');
+      if (!safeRegex(regexStr)) continue;
+      if (new RegExp(regexStr, 'i').test(recipient)) { isWhitelisted = true; break; }
+    }
+    if (!isWhitelisted) {
+      return `🚫 Unauthorized recipient. '${recipient}' is not in the send whitelist. Ask the user to add it in the FGAC dashboard.`;
+    }
+  }
+
+  return null;
+}
+
+// ─── Google API Helpers ─────────────────────────────────────────────────────
+
+type GoogleFetchResult =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string };
+
+function describeGoogleError(status: number, data: unknown, targetEmail: string): string {
+  const detail = (data as { error?: { message?: string } })?.error?.message
+    || (typeof data === 'string' ? data.slice(0, 300) : '');
+  switch (status) {
+    case 401:
+      return `❌ Google authorization expired for '${targetEmail}'. The account owner needs to reconnect Google in the FGAC dashboard, then retry.`;
+    case 403:
+      return `❌ Google denied the request (403): ${detail || 'insufficient permissions or missing OAuth scope for this operation'}.`;
+    case 404:
+      return `❌ Google resource not found (404)${detail ? `: ${detail}` : ''}. Check the ID and try again.`;
+    case 429:
+      return '❌ Google API rate limit exceeded (429). Wait a moment and retry.';
+    default:
+      return `❌ Google API error (${status})${detail ? `: ${detail}` : ''}.`;
+  }
+}
+
+async function googleFetch(
+  url: string, token: string, method = 'GET', body?: string, targetEmail = '',
+): Promise<GoogleFetchResult> {
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+  } catch (err) {
+    return { ok: false, error: `❌ Could not reach the Google API: ${err instanceof Error ? err.message : 'network error'}.` };
+  }
+
+  const text = await res.text();
+  let data: unknown = text;
+  try { data = text ? JSON.parse(text) : {}; } catch { /* non-JSON body: keep text */ }
+
+  if (!res.ok) {
+    return { ok: false, error: describeGoogleError(res.status, data, targetEmail) };
+  }
+  return { ok: true, data };
+}
+
+async function gmailFetch(token: string, email: string, path: string, method = 'GET', body?: string): Promise<GoogleFetchResult> {
   const userId = email === 'me' ? 'me' : encodeURIComponent(email);
-  const url = `https://www.googleapis.com/gmail/v1/users/${userId}/${path}`;
-  const res = await fetch(url, {
-    method,
-    headers: {
-      'Authorization': `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body,
-  });
-  return res.json();
+  return googleFetch(`https://www.googleapis.com/gmail/v1/users/${userId}/${path}`, token, method, body, email);
 }
 
-function extractSheetsSpreadsheetId(path: string): string | null {
-  const match = path.match(/(?:v4\/spreadsheets|sheets\/v4\/spreadsheets|spreadsheets)\/([^/?:#]+)/);
-  return match ? decodeURIComponent(match[1]) : null;
-}
-
-async function sheetsFetch(token: string, path: string, method = 'GET', body?: string) {
-  const url = `https://sheets.googleapis.com/v4/spreadsheets/${path}`;
-  const res = await fetch(url, {
-    method,
-    headers: {
-      'Authorization': `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body,
-  });
-  return res.json();
+async function sheetsFetch(token: string, path: string, method = 'GET', body?: string, targetEmail = ''): Promise<GoogleFetchResult> {
+  return googleFetch(`https://sheets.googleapis.com/v4/spreadsheets/${path}`, token, method, body, targetEmail);
 }
 
 async function checkSheetsPermission(userId: string, proxyKeyId: string, spreadsheetId: string, isMutating: boolean) {
@@ -327,6 +408,83 @@ async function checkSheetsPermission(userId: string, proxyKeyId: string, spreads
   return { allowed: true };
 }
 
+// ─── Gmail Message Parsing (token-frugal responses) ─────────────────────────
+
+const MAX_BODY_CHARS = 20_000;
+const MAX_ATTACHMENT_CHARS = 200_000; // base64url chars ≈ 150 KB decoded
+
+function decodeB64Url(s: string): string {
+  try { return Buffer.from(s, 'base64url').toString('utf8'); } catch { return ''; }
+}
+
+interface GmailPart {
+  mimeType?: string;
+  filename?: string;
+  body?: { data?: string; attachmentId?: string; size?: number };
+  parts?: GmailPart[];
+}
+
+/**
+ * Reduce a Gmail `format=full` message to headers, decoded body text, and
+ * attachment metadata. The full payload (nested base64 parts, redundant
+ * headers) routinely runs 10-50x the size of the content the model needs.
+ */
+function parseGmailMessage(msg: Record<string, unknown>) {
+  const payload = msg.payload as (GmailPart & { headers?: Array<{ name?: string; value?: string }> }) | undefined;
+  const headersArr = payload?.headers ?? [];
+  const header = (name: string) =>
+    headersArr.find(h => h.name?.toLowerCase() === name)?.value;
+
+  let bodyText = '';
+  let htmlFallback = '';
+  const attachments: Array<{ filename: string; mimeType?: string; attachmentId: string; sizeBytes?: number }> = [];
+
+  const stack: GmailPart[] = payload ? [payload] : [];
+  while (stack.length) {
+    const part = stack.pop()!;
+    if (part.parts) stack.push(...part.parts);
+    if (part.filename && part.body?.attachmentId) {
+      attachments.push({
+        filename: part.filename,
+        mimeType: part.mimeType,
+        attachmentId: part.body.attachmentId,
+        sizeBytes: part.body.size,
+      });
+    } else if (part.mimeType === 'text/plain' && part.body?.data) {
+      bodyText += decodeB64Url(part.body.data);
+    } else if (part.mimeType === 'text/html' && part.body?.data && !htmlFallback) {
+      htmlFallback = decodeB64Url(part.body.data);
+    }
+  }
+
+  if (!bodyText && htmlFallback) {
+    bodyText = htmlFallback
+      .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  const truncated = bodyText.length > MAX_BODY_CHARS;
+  return {
+    id: msg.id,
+    threadId: msg.threadId,
+    labelIds: msg.labelIds,
+    snippet: msg.snippet,
+    headers: {
+      from: header('from'),
+      to: header('to'),
+      cc: header('cc'),
+      subject: header('subject'),
+      date: header('date'),
+    },
+    body: truncated
+      ? `${bodyText.slice(0, MAX_BODY_CHARS)}\n…[truncated ${bodyText.length - MAX_BODY_CHARS} characters — use gmail_read with format "metadata" or narrow the request]`
+      : bodyText,
+    attachments,
+  };
+}
+
 // ─── Require Approval Wrapper ───────────────────────────────────────────────
 
 type AuthInfo = { extra?: { userId?: string }; clientId?: string };
@@ -336,12 +494,12 @@ async function requireApproval(authInfo: AuthInfo | undefined): Promise<Connecti
   const clientId = authInfo?.clientId;
 
   if (!userId) {
-    return { content: [{ type: 'text' as const, text: '❌ Authentication failed.' }] };
+    return textResult('❌ Authentication failed.');
   }
 
   const result = await resolveConnection(userId, clientId);
   if (!result.authorized) {
-    return { content: [{ type: 'text' as const, text: pendingMessage(result) }] };
+    return textResult(pendingMessage(result));
   }
   return result;
 }
@@ -376,370 +534,393 @@ async function resolveAccountAndToken(
   return { targetEmail, token, proxyKeyId: conn.proxyKeyId };
 }
 
+// ─── Raw Google API Execution ───────────────────────────────────────────────
+
+function serializeBody(body?: string | Record<string, unknown>): string | undefined {
+  if (body === undefined) return undefined;
+  return typeof body === 'string' ? body : JSON.stringify(body);
+}
+
+/**
+ * Shared executor for google_api_get / google_api_modify. Classification is
+ * deny-by-default (see googleApiPolicy.ts); every allowed family maps onto
+ * the same FGAC enforcement the dedicated tools use.
+ */
+async function executeRawGoogleCall(
+  conn: ConnectionApproved,
+  resolved: ResolvedAccount,
+  path: string,
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH',
+  body?: string | Record<string, unknown>,
+) {
+  const cls = classifyGoogleApiCall(path, method);
+  if (cls.kind === 'denied') return textResult(cls.reason);
+
+  const cleanPath = path.replace(/^\/+/, '');
+
+  if (cls.kind === 'sheets') {
+    const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, cls.spreadsheetId, cls.isMutating);
+    if (!perm.allowed) return textResult(perm.reason!);
+
+    const url = `https://sheets.googleapis.com/${cleanPath.replace(/^sheets\//, '')}`;
+    const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
+    if (!result.ok) return errorResult(result.error);
+    return jsonResult(result.data);
+  }
+
+  const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
+
+  if (cls.kind === 'gmail_send') {
+    const denial = checkSendWhitelist(rules, extractSendRecipients(body));
+    if (denial) return textResult(denial);
+  }
+
+  const url = `https://www.googleapis.com/${cleanPath}`;
+  const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
+  if (!result.ok) return errorResult(result.error);
+
+  if (cls.kind === 'gmail_read') {
+    const restriction = checkReadRestrictions(rules, result.data);
+    if (restriction) return textResult(restriction);
+  }
+
+  return jsonResult(result.data);
+}
+
 // ─── MCP Handler ────────────────────────────────────────────────────────────
+
+function toolConfig<S extends z.ZodRawShape>(def: FgacToolDef, inputSchema: S) {
+  return {
+    title: def.title,
+    description: def.description,
+    inputSchema,
+    annotations: toolAnnotations(def),
+  };
+}
 
 const handler = createMcpHandler(
   (server) => {
 
     // ── list_accounts ─────────────────────────────────────────────────
-    server.tool(
-      'list_accounts',
-      'Lists all email accounts this agent can access.',
-      {},
+    server.registerTool(
+      TOOL_DEFS.list_accounts.name,
+      toolConfig(TOOL_DEFS.list_accounts, {}),
       async (_params, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
         if (!conn.proxyKeyId) {
-          return { content: [{ type: 'text' as const, text: '❌ No proxy key assigned.' }] };
+          return textResult('❌ No proxy key assigned.');
         }
         const emails = await getAccessibleEmails(conn.proxyKeyId);
-        return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              accounts: emails.map(e => e.targetEmail),
-              default: conn.user.email,
-              nickname: conn.nickname,
-            }, null, 2),
-          }],
-        };
+        return jsonResult({
+          accounts: emails.map(e => e.targetEmail),
+          default: conn.user.email,
+          nickname: conn.nickname,
+        });
       }
     );
 
     // ── gmail_list ────────────────────────────────────────────────────
-    server.tool(
-      'gmail_list',
-      'List recent emails. Optionally filter by query.',
-      {
+    server.registerTool(
+      TOOL_DEFS.gmail_list.name,
+      toolConfig(TOOL_DEFS.gmail_list, {
         account: z.string().optional().describe('Email account to use. Defaults to primary.'),
         query: z.string().optional().describe('Gmail search query (e.g., "is:unread")'),
         max: z.number().optional().describe('Max results (default: 10)'),
-      },
+      }),
       async ({ account, query, max }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         const params = new URLSearchParams();
         if (query) params.set('q', query);
         params.set('maxResults', String(max || 10));
 
-        const data = await gmailFetch(resolved.token, resolved.targetEmail, `messages?${params}`);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        const result = await gmailFetch(resolved.token, resolved.targetEmail, `messages?${params}`);
+        if (!result.ok) return errorResult(result.error);
+        return jsonResult(result.data);
       }
     );
 
     // ── gmail_read ────────────────────────────────────────────────────
-    server.tool(
-      'gmail_read',
-      'Read a specific email by message ID.',
-      {
+    server.registerTool(
+      TOOL_DEFS.gmail_read.name,
+      toolConfig(TOOL_DEFS.gmail_read, {
         account: z.string().optional().describe('Email account to use.'),
         messageId: z.string().describe('Gmail message ID'),
-        format: z.enum(['full', 'metadata', 'minimal']).optional().describe('Response format'),
-      },
+        format: z.enum(['full', 'metadata', 'minimal']).optional().describe('Response format. "full" (default) returns parsed headers, body text, and attachment metadata.'),
+      }),
       async ({ account, messageId, format }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         // Read-time enforcement: label blacklist/whitelist + content blacklist
         const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
-        const data = await gmailFetch(resolved.token, resolved.targetEmail, `messages/${messageId}?format=${format || 'full'}`);
+        const result = await gmailFetch(resolved.token, resolved.targetEmail, `messages/${messageId}?format=${format || 'full'}`);
+        if (!result.ok) return errorResult(result.error);
 
-        const restriction = checkReadRestrictions(rules, data);
+        const restriction = checkReadRestrictions(rules, result.data);
         if (restriction) {
-          return { content: [{ type: 'text' as const, text: restriction }] };
+          return textResult(restriction);
         }
 
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        // Rules were evaluated on the complete payload; the response is the
+        // parsed, token-frugal view unless a lighter format was requested.
+        if (!format || format === 'full') {
+          return jsonResult(parseGmailMessage(result.data as Record<string, unknown>));
+        }
+        return jsonResult(result.data);
       }
     );
 
     // ── gmail_get_attachment ──────────────────────────────────────────
-    server.tool(
-      'gmail_get_attachment',
-      'Download and retrieve an email attachment by message ID and attachment ID.',
-      {
+    server.registerTool(
+      TOOL_DEFS.gmail_get_attachment.name,
+      toolConfig(TOOL_DEFS.gmail_get_attachment, {
         messageId: z.string().describe('Gmail message ID containing the attachment'),
-        attachmentId: z.string().describe('Attachment ID (found in message details payload.parts)'),
+        attachmentId: z.string().describe('Attachment ID (from gmail_read attachments list)'),
         account: z.string().optional().describe('Email account to use.'),
-      },
+      }),
       async ({ messageId, attachmentId, account }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         // Read-time enforcement on the parent message (labels + content rules):
         // an attachment is only as readable as the email that carries it
         const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
-        const parentMsg = await gmailFetch(resolved.token, resolved.targetEmail, `messages/${messageId}?format=full`);
+        const parentResult = await gmailFetch(resolved.token, resolved.targetEmail, `messages/${messageId}?format=full`);
+        if (!parentResult.ok) return errorResult(parentResult.error);
 
-        const restriction = checkReadRestrictions(rules, parentMsg);
+        const restriction = checkReadRestrictions(rules, parentResult.data);
         if (restriction) {
-          return { content: [{ type: 'text' as const, text: restriction }] };
+          return textResult(restriction);
         }
 
-        // Fetch attachment body from Gmail API
-        const attachmentData = await gmailFetch(
+        const attachmentResult = await gmailFetch(
           resolved.token,
           resolved.targetEmail,
           `messages/${messageId}/attachments/${attachmentId}`
         );
+        if (!attachmentResult.ok) return errorResult(attachmentResult.error);
 
-        return { content: [{ type: 'text' as const, text: JSON.stringify(attachmentData, null, 2) }] };
+        const attachment = attachmentResult.data as { size?: number; data?: string };
+        if (attachment.data && attachment.data.length > MAX_ATTACHMENT_CHARS) {
+          const approxKb = Math.round((attachment.data.length * 3) / 4 / 1024);
+          return textResult(`⚠️ Attachment is ~${approxKb} KB, which exceeds the ~150 KB limit for MCP responses. Ask the user to retrieve it directly from Gmail.`);
+        }
+        return jsonResult(attachment);
       }
     );
 
     // ── gmail_send ────────────────────────────────────────────────────
-    server.tool(
-      'gmail_send',
-      'Send an email. Subject to send whitelist rules.',
-      {
+    server.registerTool(
+      TOOL_DEFS.gmail_send.name,
+      toolConfig(TOOL_DEFS.gmail_send, {
         account: z.string().optional().describe('Email account to send from.'),
         to: z.string().describe('Recipient email address'),
         subject: z.string().describe('Email subject line'),
         body: z.string().describe('Email body (plain text)'),
-      },
+      }),
       async ({ account, to, subject, body }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         // Enforce send whitelist
         const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
-        const sendRules = rules.filter(r => r.service === 'gmail' && r.actionType === 'send_whitelist');
-
-        if (sendRules.length === 0) {
-          return { content: [{ type: 'text' as const, text: `🚫 No send whitelist rules configured. Ask the user to add '${to}' to the sending whitelist.` }] };
-        }
-
-        let isWhitelisted = false;
-        for (const rule of sendRules) {
-          if (!rule.regexPattern) continue;
-          const regexStr = rule.regexPattern.replace(/\*/g, '.*');
-          if (!safeRegex(regexStr)) continue;
-          if (new RegExp(regexStr, 'i').test(to)) { isWhitelisted = true; break; }
-        }
-
-        if (!isWhitelisted) {
-          return { content: [{ type: 'text' as const, text: `🚫 Unauthorized recipient. '${to}' is not in the send whitelist. Ask the user to add it.` }] };
-        }
+        const denial = checkSendWhitelist(rules, [to]);
+        if (denial) return textResult(denial);
 
         // Build RFC 2822 message
         const raw = Buffer.from(
           `To: ${to}\r\nSubject: ${subject}\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n${body}`
         ).toString('base64url');
 
-        const data = await gmailFetch(resolved.token, resolved.targetEmail, 'messages/send', 'POST', JSON.stringify({ raw }));
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        const result = await gmailFetch(resolved.token, resolved.targetEmail, 'messages/send', 'POST', JSON.stringify({ raw }));
+        if (!result.ok) return errorResult(result.error);
+        return jsonResult(result.data);
       }
     );
 
     // ── gmail_labels ──────────────────────────────────────────────────
-    server.tool(
-      'gmail_labels',
-      'List all Gmail labels for an account.',
-      { account: z.string().optional().describe('Email account to use.') },
+    server.registerTool(
+      TOOL_DEFS.gmail_labels.name,
+      toolConfig(TOOL_DEFS.gmail_labels, {
+        account: z.string().optional().describe('Email account to use.'),
+      }),
       async ({ account }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
-        const data = await gmailFetch(resolved.token, resolved.targetEmail, 'labels');
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        const result = await gmailFetch(resolved.token, resolved.targetEmail, 'labels');
+        if (!result.ok) return errorResult(result.error);
+        return jsonResult(result.data);
       }
     );
 
     // ── sheets_get_spreadsheet ────────────────────────────────────────
-    server.tool(
-      'sheets_get_spreadsheet',
-      'Get metadata and sheet tabs for an exposed Google Spreadsheet.',
-      {
+    server.registerTool(
+      TOOL_DEFS.sheets_get_spreadsheet.name,
+      toolConfig(TOOL_DEFS.sheets_get_spreadsheet, {
         spreadsheetId: z.string().describe('Google Spreadsheet ID (e.g. 1BxiMVs0...)'),
         account: z.string().optional().describe('Email account to use.'),
-      },
+      }),
       async ({ spreadsheetId, account }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, false);
-        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+        if (!perm.allowed) return textResult(perm.reason!);
 
-        const data = await sheetsFetch(resolved.token, `${spreadsheetId}`);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        const result = await sheetsFetch(resolved.token, `${spreadsheetId}`, 'GET', undefined, resolved.targetEmail);
+        if (!result.ok) return errorResult(result.error);
+        return jsonResult(result.data);
       }
     );
 
     // ── sheets_read_range ─────────────────────────────────────────────
-    server.tool(
-      'sheets_read_range',
-      'Read cell values from a specific sheet tab and range in a Google Spreadsheet.',
-      {
+    server.registerTool(
+      TOOL_DEFS.sheets_read_range.name,
+      toolConfig(TOOL_DEFS.sheets_read_range, {
         spreadsheetId: z.string().describe('Google Spreadsheet ID'),
         range: z.string().describe("Cell range (e.g. 'Sheet1'!A1:D20 or 'Sheet1')"),
         account: z.string().optional().describe('Email account to use.'),
-      },
+      }),
       async ({ spreadsheetId, range, account }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, false);
-        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+        if (!perm.allowed) return textResult(perm.reason!);
 
         const encodedRange = encodeURIComponent(range);
-        const data = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`, 'GET', undefined, resolved.targetEmail);
+        if (!result.ok) return errorResult(result.error);
+        return jsonResult(result.data);
       }
     );
 
     // ── sheets_update_range ───────────────────────────────────────────
-    server.tool(
-      'sheets_update_range',
-      'Update cell values in a range within a Google Spreadsheet (requires Read & Write permission).',
-      {
+    server.registerTool(
+      TOOL_DEFS.sheets_update_range.name,
+      toolConfig(TOOL_DEFS.sheets_update_range, {
         spreadsheetId: z.string().describe('Google Spreadsheet ID'),
         range: z.string().describe("Cell range (e.g. 'Sheet1'!A1:B2)"),
         values: z.array(z.array(z.any())).describe('2D array of cell values'),
         account: z.string().optional().describe('Email account to use.'),
-      },
+      }),
       async ({ spreadsheetId, range, values, account }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, true);
-        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+        if (!perm.allowed) return textResult(perm.reason!);
 
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values, range });
-        const data = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}?valueInputOption=USER_ENTERED`, 'PUT', body);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}?valueInputOption=USER_ENTERED`, 'PUT', body, resolved.targetEmail);
+        if (!result.ok) return errorResult(result.error);
+        return jsonResult(result.data);
       }
     );
 
     // ── sheets_append_rows ────────────────────────────────────────────
-    server.tool(
-      'sheets_append_rows',
-      'Append data rows to a sheet in a Google Spreadsheet (requires Read & Write permission).',
-      {
+    server.registerTool(
+      TOOL_DEFS.sheets_append_rows.name,
+      toolConfig(TOOL_DEFS.sheets_append_rows, {
         spreadsheetId: z.string().describe('Google Spreadsheet ID'),
         range: z.string().describe("Sheet tab or range to append to (e.g. 'Sheet1')"),
         values: z.array(z.array(z.any())).describe('2D array of rows to append'),
         account: z.string().optional().describe('Email account to use.'),
-      },
+      }),
       async ({ spreadsheetId, range, values, account }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, true);
-        if (!perm.allowed) return { content: [{ type: 'text' as const, text: perm.reason! }] };
+        if (!perm.allowed) return textResult(perm.reason!);
 
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values });
-        const data = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body);
-        return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+        const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body, resolved.targetEmail);
+        if (!result.ok) return errorResult(result.error);
+        return jsonResult(result.data);
       }
     );
 
-    // ── raw_google_api_call ───────────────────────────────────────────
-    server.tool(
-      'raw_google_api_call',
-      'Execute any raw Google API request (Gmail or Google Sheets) through FGAC access control rules. Guarantees access to any API endpoint even if no dedicated tool exists.',
-      {
-        path: z.string().describe('API path (e.g. "v4/spreadsheets/1BxiM.../values/Sheet1" or "gmail/v1/users/me/messages")'),
-        method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).optional().describe('HTTP method (default: GET)'),
-        body: z.union([z.string(), z.record(z.string(), z.any())]).optional().describe('Request body (JSON object or string)'),
+    // ── google_api_get ────────────────────────────────────────────────
+    server.registerTool(
+      TOOL_DEFS.google_api_get.name,
+      toolConfig(TOOL_DEFS.google_api_get, {
+        path: z.string().describe('API path (e.g. "gmail/v1/users/me/messages" or "v4/spreadsheets/1BxiM.../values/Sheet1")'),
         account: z.string().optional().describe('Email account to use.'),
-      },
-      async ({ path, method = 'GET', body, account }, { authInfo }) => {
+      }),
+      async ({ path, account }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
 
         const resolved = await resolveAccountAndToken(conn, account);
-        if ('error' in resolved) return { content: [{ type: 'text' as const, text: resolved.error }] };
+        if ('error' in resolved) return textResult(resolved.error);
 
-        const isMutating = method !== 'GET';
-        let googleUrl = '';
+        return executeRawGoogleCall(conn, resolved, path, 'GET');
+      }
+    );
 
-        // Evaluate FGAC rules based on path
-        if (path.includes('spreadsheets')) {
-          const spreadsheetId = extractSheetsSpreadsheetId(path);
-          if (spreadsheetId) {
-            const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, isMutating);
-            if (!perm.allowed) {
-              return { content: [{ type: 'text' as const, text: perm.reason! }] };
-            }
-          }
-          const cleanPath = path.replace(/^sheets\//, '');
-          googleUrl = `https://sheets.googleapis.com/${cleanPath}`;
-        } else {
-          // Gmail / general Google API
-          const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
+    // ── google_api_modify ─────────────────────────────────────────────
+    server.registerTool(
+      TOOL_DEFS.google_api_modify.name,
+      toolConfig(TOOL_DEFS.google_api_modify, {
+        path: z.string().describe('API path (e.g. "gmail/v1/users/me/messages/send" or "v4/spreadsheets/1BxiM.../values/Sheet1:append")'),
+        method: z.enum(['POST', 'PUT', 'PATCH']).optional().describe('HTTP method (default: POST)'),
+        body: z.union([z.string(), z.record(z.string(), z.any())]).optional().describe('Request body (JSON object or string)'),
+        account: z.string().optional().describe('Email account to use.'),
+      }),
+      async ({ path, method = 'POST', body, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
 
-          if (isMutating && path.includes('messages/send')) {
-            const sendRules = rules.filter(r => r.service === 'gmail' && r.actionType === 'send_whitelist');
-            if (sendRules.length === 0) {
-              return { content: [{ type: 'text' as const, text: '🚫 Access Denied: No send whitelist rules configured.' }] };
-            }
-          }
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return textResult(resolved.error);
 
-          if (method === 'DELETE' && (path.includes('messages/trash') || path.includes('emptyTrash'))) {
-            return { content: [{ type: 'text' as const, text: '🚫 Access Denied: Safeguard prevents deletion of emails.' }] };
-          }
-
-          googleUrl = `https://www.googleapis.com/${path}`;
-        }
-
-        const bodyString = typeof body === 'object' ? JSON.stringify(body) : body;
-        const res = await fetch(googleUrl, {
-          method,
-          headers: {
-            'Authorization': `Bearer ${resolved.token}`,
-            'Content-Type': 'application/json',
-          },
-          body: isMutating ? bodyString : undefined,
-        });
-
-        const resText = await res.text();
-        let parsedData: any = resText;
-        try { parsedData = JSON.parse(resText); } catch {}
-
-        return { content: [{ type: 'text' as const, text: typeof parsedData === 'string' ? parsedData : JSON.stringify(parsedData, null, 2) }] };
+        return executeRawGoogleCall(conn, resolved, path, method, body);
       }
     );
 
     // ── get_my_permissions ────────────────────────────────────────────
-    server.tool(
-      'get_my_permissions',
-      'Shows the current access rules and permissions for this agent.',
-      {},
+    server.registerTool(
+      TOOL_DEFS.get_my_permissions.name,
+      toolConfig(TOOL_DEFS.get_my_permissions, {}),
       async (_params, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
         if (!conn.proxyKeyId) {
-          return { content: [{ type: 'text' as const, text: '❌ No proxy key assigned.' }] };
+          return textResult('❌ No proxy key assigned.');
         }
 
         const emails = await getAccessibleEmails(conn.proxyKeyId);
@@ -760,35 +941,30 @@ const handler = createMcpHandler(
           !rulesWithAssignments.has(r.id) || assignedToThisKey.has(r.id),
         );
 
-        return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              connection: { id: conn.connectionId, nickname: conn.nickname },
-              proxyKey: { id: key?.id, label: key?.label },
-              accessibleEmails: emails.map(e => e.targetEmail),
-              rules: applicableRules.map(r => ({
-                name: r.ruleName,
-                type: r.actionType,
-                pattern: r.regexPattern,
-                email: r.targetEmail || 'all',
-                scope: rulesWithAssignments.has(r.id) ? 'this-key' : 'global',
-                // Sheets rules are per-file: without the spreadsheet id an
-                // agent cannot locate the file it was granted access to.
-                ...(r.service === 'sheets'
-                  ? { spreadsheetId: r.targetResourceId, resourceName: r.resourceName }
-                  : {}),
-              })),
-            }, null, 2),
-          }],
-        };
+        return jsonResult({
+          connection: { id: conn.connectionId, nickname: conn.nickname },
+          proxyKey: { id: key?.id, label: key?.label },
+          accessibleEmails: emails.map(e => e.targetEmail),
+          rules: applicableRules.map(r => ({
+            name: r.ruleName,
+            type: r.actionType,
+            pattern: r.regexPattern,
+            email: r.targetEmail || 'all',
+            scope: rulesWithAssignments.has(r.id) ? 'this-key' : 'global',
+            // Sheets rules are per-file: without the spreadsheet id an
+            // agent cannot locate the file it was granted access to.
+            ...(r.service === 'sheets'
+              ? { spreadsheetId: r.targetResourceId, resourceName: r.resourceName }
+              : {}),
+          })),
+        });
       }
     );
   },
   {
     serverInfo: {
       name: 'fgac',
-      version: '1.0.0',
+      version: '1.1.0',
     },
   },
   {
@@ -797,9 +973,30 @@ const handler = createMcpHandler(
   }
 );
 
+// ─── Authentication ─────────────────────────────────────────────────────────
+
+/**
+ * The only issuer this server accepts tokens from: the Clerk frontend API
+ * derived from our own publishable key. Deriving the JWKS location from the
+ * token's `iss` claim would let ANY issuer mint accepted tokens.
+ */
+function expectedClerkIssuer(): string | null {
+  const pk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  if (!pk) return null;
+  try {
+    const domain = Buffer.from(pk.replace(/^pk_(test|live)_/, ''), 'base64')
+      .toString('utf8')
+      .replace(/\$$/, '');
+    return domain ? `https://${domain}` : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Direct JWT verification fallback for CLI/non-browser OAuth tokens.
  * Used when Clerk's auth()+verifyClerkToken fails to extract userId/clientId.
+ * Fails closed unless the token's issuer is exactly our Clerk instance.
  */
 async function verifyClerkJwtDirect(token: string) {
   try {
@@ -808,7 +1005,12 @@ async function verifyClerkJwtDirect(token: string) {
     if (!payloadB64) return undefined;
     const rawPayload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
     const issuer = rawPayload.iss;
-    if (!issuer) return undefined;
+
+    const expected = expectedClerkIssuer();
+    if (!expected || issuer !== expected) {
+      console.error(`[MCP] Rejecting token from unexpected issuer '${issuer}' (expected '${expected ?? 'unavailable'}')`);
+      return undefined;
+    }
 
     const JWKS = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
     const { payload: verified } = await jwtVerify(token, JWKS, { issuer, clockTolerance: 30 });
@@ -828,46 +1030,52 @@ async function verifyClerkJwtDirect(token: string) {
   }
 }
 
-export const POST = experimental_withMcpAuth(
+const verifyMcpAuth = async (_req: Request, bearerToken?: string) => {
+  let authInfo: ReturnType<typeof verifyClerkToken> | Awaited<ReturnType<typeof verifyClerkJwtDirect>> | undefined;
+
+  // Strategy 1: Try Clerk's built-in auth() + verifyClerkToken
+  try {
+    const clerkAuth = await auth({ acceptsToken: 'oauth_token' });
+    const result = verifyClerkToken(clerkAuth, bearerToken);
+    if (result?.extra?.userId) authInfo = result;
+  } catch (error) {
+    console.warn('[MCP] Clerk auth() failed, will try direct JWT:', error);
+  }
+
+  // Strategy 2: Direct JWT verification (fallback for CLI/non-browser contexts)
+  if (!authInfo && bearerToken) {
+    console.log('[MCP] Falling back to direct JWT verification');
+    authInfo = await verifyClerkJwtDirect(bearerToken);
+  }
+
+  // Eagerly create/touch agent_connection on ANY authenticated request
+  // (including initialize), so connections appear in the dashboard immediately.
+  // Tool handlers still call requireApproval() as a fallback safety net.
+  if (authInfo) {
+    const userId = authInfo.extra?.userId as string | undefined;
+    const clientId = (authInfo as Record<string, unknown>).clientId as string | undefined;
+    if (userId && clientId) {
+      resolveConnection(userId, clientId).catch((err) =>
+        console.error('[MCP] Eager connection creation failed:', err)
+      );
+    }
+  }
+
+  return authInfo;
+};
+
+// All verbs run behind auth: unauthenticated requests — including the
+// streamable-HTTP GET (SSE) and DELETE (session teardown) — must get the
+// 401 + WWW-Authenticate handshake, not an unauthenticated handler.
+const authedHandler = experimental_withMcpAuth(
   handler,
-  async (_req, bearerToken) => {
-    let authInfo: ReturnType<typeof verifyClerkToken> | Awaited<ReturnType<typeof verifyClerkJwtDirect>> | undefined;
-
-    // Strategy 1: Try Clerk's built-in auth() + verifyClerkToken
-    try {
-      const clerkAuth = await auth({ acceptsToken: 'oauth_token' });
-      const result = verifyClerkToken(clerkAuth, bearerToken);
-      if (result?.extra?.userId) authInfo = result;
-    } catch (error) {
-      console.warn('[MCP] Clerk auth() failed, will try direct JWT:', error);
-    }
-
-    // Strategy 2: Direct JWT verification (fallback for CLI/non-browser contexts)
-    if (!authInfo && bearerToken) {
-      console.log('[MCP] Falling back to direct JWT verification');
-      authInfo = await verifyClerkJwtDirect(bearerToken);
-    }
-
-    // Eagerly create/touch agent_connection on ANY authenticated request
-    // (including initialize), so connections appear in the dashboard immediately.
-    // Tool handlers still call requireApproval() as a fallback safety net.
-    if (authInfo) {
-      const userId = authInfo.extra?.userId as string | undefined;
-      const clientId = (authInfo as Record<string, unknown>).clientId as string | undefined;
-      if (userId && clientId) {
-        resolveConnection(userId, clientId).catch((err) =>
-          console.error('[MCP] Eager connection creation failed:', err)
-        );
-      }
-    }
-
-    return authInfo;
-  },
+  verifyMcpAuth,
   {
     required: true,
     resourceMetadataPath: '/.well-known/oauth-protected-resource/mcp',
   }
 );
 
-export const GET = handler;
-export const DELETE = handler;
+export const POST = authedHandler;
+export const GET = authedHandler;
+export const DELETE = authedHandler;

--- a/src/app/api/mcp/toolDefs.ts
+++ b/src/app/api/mcp/toolDefs.ts
@@ -1,0 +1,127 @@
+/**
+ * MCP tool definitions — names, titles, descriptions, and safety annotations.
+ *
+ * This module is intentionally pure (no db/env imports) so that
+ * `scripts/mcp-tool-lint.ts` can import it and enforce the Anthropic
+ * Connectors Directory invariants in CI:
+ *   - every tool has a `title` and a readOnlyHint/destructiveHint
+ *   - tool names are ≤ 64 characters
+ *   - no tool forwards both safe and unsafe HTTP methods
+ *   - freeform-path tools name/link the target API in their description
+ */
+
+export interface FgacToolDef {
+  name: string;
+  title: string;
+  description: string;
+  /** true → readOnlyHint: true; false → destructiveHint must be set */
+  readOnly: boolean;
+  /** Only meaningful when readOnly is false. */
+  destructive?: boolean;
+  /** Tool interacts with entities outside the user's accounts (e.g. sends email). */
+  openWorld?: boolean;
+  /** HTTP methods a freeform-path tool forwards. Lint forbids mixing GET with writes. */
+  freeformMethods?: readonly string[];
+}
+
+export const TOOL_DEFS = {
+  list_accounts: {
+    name: 'list_accounts',
+    title: 'List accessible email accounts',
+    description: 'Lists the email accounts this connection can access through FGAC.',
+    readOnly: true,
+  },
+  gmail_list: {
+    name: 'gmail_list',
+    title: 'List Gmail messages',
+    description: 'List recent Gmail message IDs, optionally filtered by a Gmail search query (e.g. "is:unread").',
+    readOnly: true,
+  },
+  gmail_read: {
+    name: 'gmail_read',
+    title: 'Read a Gmail message',
+    description: 'Read a Gmail message by ID. Returns parsed headers, body text, and attachment metadata. Reads are evaluated against the user\'s FGAC access rules.',
+    readOnly: true,
+  },
+  gmail_get_attachment: {
+    name: 'gmail_get_attachment',
+    title: 'Download a Gmail attachment',
+    description: 'Retrieve an email attachment by message ID and attachment ID. The parent message must pass the user\'s FGAC read rules.',
+    readOnly: true,
+  },
+  gmail_send: {
+    name: 'gmail_send',
+    title: 'Send an email',
+    description: 'Send a plain-text email from the selected account. Recipients must match the user\'s FGAC send whitelist.',
+    readOnly: false,
+    destructive: true,
+    openWorld: true,
+  },
+  gmail_labels: {
+    name: 'gmail_labels',
+    title: 'List Gmail labels',
+    description: 'List all Gmail labels for an accessible account.',
+    readOnly: true,
+  },
+  sheets_get_spreadsheet: {
+    name: 'sheets_get_spreadsheet',
+    title: 'Get spreadsheet metadata',
+    description: 'Get metadata and sheet tabs for a Google Spreadsheet exposed by the user\'s FGAC rules.',
+    readOnly: true,
+  },
+  sheets_read_range: {
+    name: 'sheets_read_range',
+    title: 'Read spreadsheet cells',
+    description: 'Read cell values from a sheet tab or range in a Google Spreadsheet exposed by the user\'s FGAC rules.',
+    readOnly: true,
+  },
+  sheets_update_range: {
+    name: 'sheets_update_range',
+    title: 'Update spreadsheet cells',
+    description: 'Overwrite cell values in a range of a Google Spreadsheet. Requires a Read & Write FGAC rule for the spreadsheet.',
+    readOnly: false,
+    destructive: true,
+  },
+  sheets_append_rows: {
+    name: 'sheets_append_rows',
+    title: 'Append spreadsheet rows',
+    description: 'Append rows to a sheet in a Google Spreadsheet without modifying existing cells. Requires a Read & Write FGAC rule for the spreadsheet.',
+    readOnly: false,
+    destructive: false,
+  },
+  google_api_get: {
+    name: 'google_api_get',
+    title: 'Raw Google API read',
+    description: 'Perform a read-only GET request against any endpoint of the Gmail API (https://developers.google.com/gmail/api/reference/rest) or Google Sheets API (https://developers.google.com/sheets/api/reference/rest). Every response is evaluated against the user\'s FGAC access rules before it is returned; other Google APIs and batch endpoints are denied.',
+    readOnly: true,
+    freeformMethods: ['GET'],
+  },
+  google_api_modify: {
+    name: 'google_api_modify',
+    title: 'Raw Google API write',
+    description: 'Perform a POST, PUT, or PATCH request against supported write endpoints of the Gmail API (https://developers.google.com/gmail/api/reference/rest) or Google Sheets API (https://developers.google.com/sheets/api/reference/rest). Allowed writes: Gmail messages/send (recipients are checked against the user\'s FGAC send whitelist) and Sheets value updates/appends on spreadsheets with Read & Write rules. All other write endpoints are denied. DELETE is never available through FGAC.',
+    readOnly: false,
+    destructive: true,
+    openWorld: true,
+    freeformMethods: ['POST', 'PUT', 'PATCH'],
+  },
+  get_my_permissions: {
+    name: 'get_my_permissions',
+    title: 'Show my permissions',
+    description: 'Shows the access rules, accessible accounts, and proxy key that apply to this connection.',
+    readOnly: true,
+  },
+} as const satisfies Record<string, FgacToolDef>;
+
+export type ToolName = keyof typeof TOOL_DEFS;
+
+/** MCP ToolAnnotations for a definition. */
+export function toolAnnotations(def: FgacToolDef) {
+  return {
+    title: def.title,
+    ...(def.readOnly
+      ? { readOnlyHint: true as const }
+      : { destructiveHint: def.destructive ?? true }),
+    ...(def.openWorld !== undefined ? { openWorldHint: def.openWorld } : {}),
+  };
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -73,7 +73,7 @@ export default function PrivacyPolicy() {
             <h2 className="text-xl font-bold text-gray-900 mb-3">7. Contact Us</h2>
             <p>
               If you have any questions or concerns about this privacy policy, or want to exercise your rights over your data, contact us at{' '}
-              <a href="mailto:support@fgac.ai" className="text-blue-600 hover:text-blue-800 underline">support@fgac.ai</a>.
+              <a href="mailto:fgac-ai@googlegroups.com" className="text-blue-600 hover:text-blue-800 underline">fgac-ai@googlegroups.com</a>.
             </p>
           </section>
         </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -53,16 +53,27 @@ export default function PrivacyPolicy() {
           </section>
 
           <section>
-            <h2 className="text-xl font-bold text-gray-900 mb-3">5. Deletion of Data</h2>
+            <h2 className="text-xl font-bold text-gray-900 mb-3">5. Data Retention and Deletion</h2>
             <p>
-              You can revoke FGAC.ai's access to your Google account at any time via your Google Account Security settings. If you delete your FGAC.ai account, all associated API keys, defined security rules, access logs, and metadata will be permanently deleted from our databases.
+              We retain the account information, API keys, and security rules described in Section 4 for as long as your account is active, because they are required to operate the service. Request metadata shown in your dashboard logs (timestamps, matched rule names, success/failure status — never message content) is retained for up to 90 days and then deleted automatically.
+            </p>
+            <p className="mt-4">
+              You can revoke FGAC.ai's access to your Google account at any time via your Google Account Security settings. If you delete your FGAC.ai account, all associated API keys, defined security rules, access logs, and metadata will be permanently deleted from our databases within 30 days.
             </p>
           </section>
 
           <section>
-            <h2 className="text-xl font-bold text-gray-900 mb-3">6. Contact Us</h2>
+            <h2 className="text-xl font-bold text-gray-900 mb-3">6. Third-Party Sharing</h2>
             <p>
-              If you have any questions or concerns about this privacy policy, please contact support.
+              We do not sell your data or share it with third parties for their own purposes. Data is processed only by the infrastructure providers we use to run the service — Clerk (authentication and OAuth token management), Neon (database hosting), and Vercel (application hosting) — each acting on our behalf under their own data processing terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-bold text-gray-900 mb-3">7. Contact Us</h2>
+            <p>
+              If you have any questions or concerns about this privacy policy, or want to exercise your rights over your data, contact us at{' '}
+              <a href="mailto:support@fgac.ai" className="text-blue-600 hover:text-blue-800 underline">support@fgac.ai</a>.
             </p>
           </section>
         </div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -72,6 +72,14 @@ export default function TermsOfService() {
               We reserve the right to modify these terms at any time. We will provide notice of significant changes by updating the date at the top of this page. Your continued use of the Service after such changes constitutes your acceptance of the new Terms of Service.
             </p>
           </section>
+
+          <section>
+            <h2 className="text-xl font-bold text-gray-900 mb-3">9. Contact</h2>
+            <p>
+              Questions about these terms or the Service can be sent to{' '}
+              <a href="mailto:support@fgac.ai" className="text-blue-600 hover:text-blue-800 underline">support@fgac.ai</a>.
+            </p>
+          </section>
         </div>
         
         <div className="mt-12 pt-8 border-t border-gray-100">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -77,7 +77,7 @@ export default function TermsOfService() {
             <h2 className="text-xl font-bold text-gray-900 mb-3">9. Contact</h2>
             <p>
               Questions about these terms or the Service can be sent to{' '}
-              <a href="mailto:support@fgac.ai" className="text-blue-600 hover:text-blue-800 underline">support@fgac.ai</a>.
+              <a href="mailto:fgac-ai@googlegroups.com" className="text-blue-600 hover:text-blue-800 underline">fgac-ai@googlegroups.com</a>.
             </p>
           </section>
         </div>


### PR DESCRIPTION
## Summary

Prepares the hosted MCP server for Anthropic Connectors Directory submission (plan: docs/implementation_plans/connector-approval-audit_v2.md).

- **Tool annotations**: all 13 tools registered via `registerTool` with `title` + `readOnlyHint`/`destructiveHint` (`openWorldHint` on senders), defined in a pure registry (`src/app/api/mcp/toolDefs.ts`)
- **Raw tool split**: `raw_google_api_call` (mixed-method catch-all — an automatic directory rejection) replaced by `google_api_get` (GET) and `google_api_modify` (POST/PUT/PATCH) with deny-by-default path classification (`googleApiPolicy.ts`): read-rule parity on raw Gmail reads, send-whitelist parity on raw sends (RFC 2822 recipient parsing, deny on parse failure), per-spreadsheet Sheets rules, batch endpoints/unknown APIs denied, DELETE never exposed
- **Auth hardening**: GET/DELETE wrapped in `experimental_withMcpAuth` (401 + `WWW-Authenticate` on every verb); JWT fallback pinned to our Clerk issuer; RFC 9728 `resource` now includes the `/api/mcp` path
- **Functional quality**: status-checked Google API calls with actionable errors (`isError` on upstream failures), parsed/trimmed `gmail_read`, ~150 KB attachment cap
- **CI gate**: `npm run mcp:lint` (registry lint + 22 policy unit tests) chained into `build` so post-listing deploys can't break directory invariants
- **Compliance content**: privacy policy (retention, third-party sharing, contact), terms contact, new QA capability doc for the raw pair

## Test plan

- [x] 22 policy unit tests + tool-registry lint (`npm run mcp:lint`)
- [x] `tsc --noEmit` clean; eslint clean on changed files
- [x] Local 401/`WWW-Authenticate` contract verified on GET/POST/DELETE; discovery metadata verified
- [x] Hosted-MCP QA: 61/61 assertions accounted — 54 pass, 2 pre-existing dashboard failures (key lifecycle UI, unrelated), 5 documented environment skips; adversarial coverage audit + targeted round-2 retest of read-blacklist and the new raw pair (all pass)
- [ ] Preview deployment validation (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)