### PR TITLE
feat(marketing): rebuild landing and setup pages on the new design

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,77 +1,282 @@
-import { SignInButton, SignUpButton, Show } from '@clerk/nextjs';
+import { SignUpButton, Show } from '@clerk/nextjs';
 import Link from 'next/link';
+import { Shield } from 'lucide-react';
+
+/* ─── Landing ─────────────────────────────────────────────────────────────
+   Nav and footer come from the root layout, so this file is the page body
+   only. All colors are design tokens (globals.css) — no raw hex. */
+
+const heroCta =
+  'rounded-sm bg-primary px-7 py-3 text-[15px] font-semibold text-primary-foreground hover:opacity-90';
 
 export default async function LandingPage() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-64px)] p-8">
-      <div className="max-w-3xl text-center space-y-8">
-        <h1 className="text-5xl font-extrabold tracking-tight sm:text-7xl bg-clip-text text-transparent bg-gradient-to-r from-brand-purple to-brand-glow">
-          Agent Security, Solved.
-        </h1>
-        <p className="text-xl text-gray-800 max-w-2xl mx-auto">
-          Give your AI agents access to Google APIs safely. 
-          Use standard Google SDKs while strictly controlling their read, write, and delete permissions.
-        </p>
-        
-        <div className="flex gap-4 justify-center pt-8">
-          <Show when="signed-out">
-            <SignUpButton mode="modal" fallbackRedirectUrl="/dashboard" signInFallbackRedirectUrl="/dashboard">
-              <button className="rounded-full bg-brand-purple px-8 py-3.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-purple transition-all">
-                Get Started
-              </button>
-            </SignUpButton>
-          </Show>
-          <Show when="signed-in">
+    <>
+      {/* ── Hero ──────────────────────────────────────────────────────── */}
+      <section className="px-6 pt-16 pb-16 text-center sm:px-8 sm:pt-20">
+        <div className="mx-auto flex max-w-[880px] flex-col items-center gap-6">
+          <div className="flex flex-wrap justify-center gap-2.5">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-gmail-border bg-gmail-bg px-3 py-1 text-[13px] font-semibold text-gmail">
+              <span className="h-[7px] w-[7px] rounded-full bg-gmail" />
+              Gmail
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-sheets-border bg-sheets-bg px-3 py-1 text-[13px] font-semibold text-sheets">
+              <span className="h-[7px] w-[7px] rounded-full bg-sheets" />
+              Google Sheets — new
+            </span>
+          </div>
+
+          <h1 className="text-[40px] font-extrabold leading-[1.05] tracking-[-0.03em] text-foreground sm:text-[60px]">
+            Your agents can work your{' '}
+            <span className="text-primary">Sheets and Gmail.</span>
+            <br />
+            You hold the keys.
+          </h1>
+
+          <p className="mx-auto max-w-[640px] text-[17px] leading-[1.55] text-muted-foreground sm:text-[19px]">
+            Read and write Google Sheets. Send email from Gmail — even across
+            multiple accounts. Every request passes through your rules first.
+          </p>
+
+          <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:justify-center">
+            <Show when="signed-out">
+              <SignUpButton
+                mode="modal"
+                fallbackRedirectUrl="/dashboard"
+                signInFallbackRedirectUrl="/dashboard"
+              >
+                <button className={heroCta}>Get Started — it&apos;s free</button>
+              </SignUpButton>
+            </Show>
+            <Show when="signed-in">
+              <Link href="/dashboard" className={`${heroCta} inline-block`}>
+                Go to Dashboard
+              </Link>
+            </Show>
             <Link
-              href="/dashboard"
-              className="rounded-full bg-brand-purple px-8 py-3.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-purple transition-all"
+              href="/setup"
+              className="rounded-sm border border-border bg-card px-7 py-3 text-[15px] font-semibold text-foreground hover:border-ring"
             >
-              Go to Dashboard
+              Setup Guide
             </Link>
-          </Show>
-          <Link href="/setup" className="rounded-full px-8 py-3.5 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-brand-purple/20 hover:ring-brand-purple/40">
-            Setup Guide
-          </Link>
-        </div>
+          </div>
 
-        <div className="mt-16 grid grid-cols-1 gap-8 sm:grid-cols-3 text-left">
-          <div className="bg-white p-6 rounded-2xl shadow-sm border border-gray-100">
-            <h3 className="font-semibold text-gray-900 mb-2">Standard Google SDKs</h3>
-            <p className="text-sm text-gray-800">Works with official Python and Node.js Google SDKs. Just point the endpoint at your proxy and go.</p>
-          </div>
-          <div className="bg-white p-6 rounded-2xl shadow-sm border border-gray-100">
-            <h3 className="font-semibold text-gray-900 mb-2">Content Filtering</h3>
-            <p className="text-sm text-gray-800">Use regular expressions to block agents from reading sensitive emails like 2FA or Password Resets.</p>
-          </div>
-          <div className="bg-white p-6 rounded-2xl shadow-sm border border-gray-100">
-            <h3 className="font-semibold text-gray-900 mb-2">Deletion Safeguards</h3>
-            <p className="text-sm text-gray-800">Whitelist specific domains for deletion and globally block &quot;Empty Trash&quot; commands.</p>
-          </div>
-        </div>
-
-        {/* Google Data Usage Section */}
-        <div className="mt-16 bg-brand-purple/5 border border-brand-purple/20 p-8 rounded-3xl text-left shadow-sm">
-          <div className="flex items-start gap-4">
-            <div className="bg-brand-purple/10 p-3 rounded-2xl">
-              <svg className="w-6 h-6 text-brand-purple" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
+          {/* Demo video, framed as a browser window */}
+          <div className="mt-6 w-full max-w-[800px] rounded-lg border border-border bg-card p-2.5 shadow-lg">
+            <div className="flex items-center gap-1.5 px-1.5 pb-2.5 pt-0.5">
+              <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
+              <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
+              <span className="h-2.5 w-2.5 rounded-full bg-secondary" />
+              <span className="flex-1 text-center font-mono text-[12px] text-subtle">
+                FGAC × Google Sheets — demo
+              </span>
             </div>
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">How we use Google Data</h3>
-              <p className="text-gray-600 mb-4 leading-relaxed">
-              FGAC.ai requires access to your Gmail account (via scopes like <code className="bg-brand-purple/10 px-1.5 py-0.5 rounded text-brand-purple text-sm">gmail.readonly</code>, <code className="bg-brand-purple/10 px-1.5 py-0.5 rounded text-brand-purple text-sm">gmail.send</code>, and <code className="bg-brand-purple/10 px-1.5 py-0.5 rounded text-brand-purple text-sm">gmail.modify</code>) to act as a secure proxy between your inbox and your AI agents.
+            <div className="relative aspect-video w-full overflow-hidden rounded-sm bg-surface-inverse">
+              <iframe
+                src="https://share.descript.com/embed/Fv9pwXugLUa"
+                title="FGAC Google Sheets demo"
+                allowFullScreen
+                className="absolute inset-0 h-full w-full border-0"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── What it does ──────────────────────────────────────────────── */}
+      <section className="px-6 pb-16 pt-4 sm:px-8">
+        <div className="mx-auto grid max-w-[1120px] gap-5 md:grid-cols-3">
+          <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-7">
+            <span className="self-start rounded-full border border-sheets-border bg-sheets-bg px-2.5 py-0.5 text-[12px] font-semibold text-sheets">
+              Sheets
+            </span>
+            <h3 className="text-[19px] font-bold tracking-[-0.01em] text-foreground">
+              Read &amp; write Sheets — only the ones you pick
+            </h3>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Expose individual spreadsheets with the Google Picker. Grant
+              read-only or read/write per sheet, per agent. Everything else stays
+              invisible.
+            </p>
+            <div className="mt-auto flex flex-wrap items-center gap-2 rounded-sm bg-surface-inverse px-3.5 py-3 font-mono text-[13px] text-surface-inverse-foreground">
+              <span className="font-semibold text-primary">sheets_write</span>
+              <span>Q3 Pipeline</span>
+              <span className="rounded-xs bg-success px-1.5 py-px text-[11px] text-success-foreground">
+                ✓ allowed
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-7">
+            <span className="self-start rounded-full border border-gmail-border bg-gmail-bg px-2.5 py-0.5 text-[12px] font-semibold text-gmail">
+              Gmail
+            </span>
+            <h3 className="text-[19px] font-bold tracking-[-0.01em] text-foreground">
+              Send with Gmail — to an allowlist you control
+            </h3>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Agents send real email from your address, but only to recipients
+              and domains you approve. 2FA codes and password resets are never
+              readable.
+            </p>
+            <div className="mt-auto flex flex-wrap items-center gap-2 rounded-sm bg-surface-inverse px-3.5 py-3 font-mono text-[13px] text-surface-inverse-foreground">
+              <span className="font-semibold text-primary">gmail_send</span>
+              <span>→ intern@evil.co</span>
+              <span className="rounded-xs bg-error px-1.5 py-px text-[11px] text-error-foreground">
+                ✕ blocked
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-7">
+            <span className="self-start rounded-full border border-brand-purple/25 bg-brand-purple/10 px-2.5 py-0.5 text-[12px] font-semibold text-brand-purple">
+              Multi-account
+            </span>
+            <h3 className="text-[19px] font-bold tracking-[-0.01em] text-foreground">
+              Many inboxes, one agent
+            </h3>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Family or teammates delegate their Gmail from their own dashboard.
+              Your agent switches inboxes with a single parameter — each under
+              its own rules.
+            </p>
+            <div className="mt-auto flex flex-wrap items-center gap-2 rounded-sm bg-surface-inverse px-3.5 py-3 font-mono text-[13px] text-surface-inverse-foreground">
+              <span className="font-semibold text-primary">gmail_list</span>
+              <span>account=mom@gmail.com</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Three steps ───────────────────────────────────────────────── */}
+      <section className="border-y border-border bg-card px-6 py-16 sm:px-8">
+        <div className="mx-auto max-w-[1120px]">
+          <h2 className="mb-10 text-center text-[28px] font-extrabold tracking-[-0.02em] text-foreground">
+            Live in three steps
+          </h2>
+          <div className="grid gap-8 md:grid-cols-3">
+            <div className="flex flex-col gap-2.5">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-muted text-sm font-bold text-primary">
+                1
+              </span>
+              <h3 className="text-base font-bold text-foreground">
+                Add one MCP URL
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Claude Code, Cursor, Windsurf, Claude Desktop — same URL
+                everywhere:{' '}
+                <code className="rounded-xs border border-border bg-background px-1.5 py-0.5 font-mono text-xs">
+                  fgac.ai/api/mcp
+                </code>
               </p>
-              <p className="text-gray-600 leading-relaxed">
-              When your AI agent makes an API request, we strictly enforce your custom allowlists and blocklists before forwarding the exact request to the Google API. We never permanently store your email content, and your data is never used to train our AI models. No humans read your emails.
-            </p>
-            <p className="text-sm">
-              Our use of information received from Google APIs will adhere to the <Link href="/privacy" className="underline text-brand-purple hover:text-brand-purple/80">Google API Services User Data Policy</Link>, including the <strong>Limited Use</strong> requirements.
-            </p>
+            </div>
+            <div className="flex flex-col gap-2.5">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-muted text-sm font-bold text-primary">
+                2
+              </span>
+              <h3 className="text-base font-bold text-foreground">
+                Sign in with Google
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Your agent opens a browser to link your account. New connections
+                wait as pending until you approve them.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2.5">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-muted text-sm font-bold text-primary">
+                3
+              </span>
+              <h3 className="text-base font-bold text-foreground">
+                Set your rules
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Pick sheets to expose, allowlist send targets, block sensitive
+                reads. Rules are reusable across agent profiles.
+              </p>
             </div>
           </div>
         </div>
-      </div>
-    </div>
+      </section>
+
+      {/* ── Google data usage ─────────────────────────────────────────── */}
+      <section className="px-6 py-16 sm:px-8">
+        <div className="mx-auto max-w-[1120px]">
+          <div className="mb-9 text-center">
+            <div className="mb-3.5 inline-flex h-11 w-11 items-center justify-center rounded-md bg-primary-muted">
+              <Shield className="h-[22px] w-[22px] text-primary" />
+            </div>
+            <h2 className="mb-2.5 text-[28px] font-extrabold tracking-[-0.02em] text-foreground">
+              How we use Google Data
+            </h2>
+            <p className="mx-auto max-w-[720px] text-[15px] leading-[1.65] text-muted-foreground">
+              FGAC.ai requests Gmail and Sheets scopes to act as a secure proxy
+              between Google and your AI agents. Every request is checked against
+              your rules before it is forwarded — verbatim — to Google.
+            </p>
+          </div>
+          <div className="grid gap-5 md:grid-cols-3">
+            <div className="rounded-lg border border-border bg-card p-6">
+              <h3 className="mb-1.5 text-[15px] font-bold text-foreground">
+                Nothing stored
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                We never permanently store your email or spreadsheet content.
+                Requests pass through; your data doesn&apos;t stay.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-6">
+              <h3 className="mb-1.5 text-[15px] font-bold text-foreground">
+                Never trained on
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Your data is never used to train AI models, and no humans read
+                your mail or sheets. Ever.
+              </p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-6">
+              <h3 className="mb-1.5 text-[15px] font-bold text-foreground">
+                Limited Use compliant
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Our use of Google API data adheres to the{' '}
+                <Link href="/privacy" className="text-primary underline">
+                  Google API Services User Data Policy
+                </Link>
+                , including the Limited Use requirements.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Closing CTA ───────────────────────────────────────────────── */}
+      <section className="px-6 pb-20 pt-2 text-center sm:px-8">
+        <h2 className="mb-2 text-[30px] font-extrabold tracking-[-0.02em] text-foreground">
+          Deny by default. Allow on your terms.
+        </h2>
+        <p className="mb-6 text-base text-muted-foreground">
+          Free for personal use. Connected in under a minute.
+        </p>
+        <Show when="signed-out">
+          <SignUpButton
+            mode="modal"
+            fallbackRedirectUrl="/dashboard"
+            signInFallbackRedirectUrl="/dashboard"
+          >
+            <button className="rounded-sm bg-primary px-8 py-3.5 text-[15px] font-semibold text-primary-foreground hover:opacity-90">
+              Get Started
+            </button>
+          </SignUpButton>
+        </Show>
+        <Show when="signed-in">
+          <Link
+            href="/dashboard"
+            className="inline-block rounded-sm bg-primary px-8 py-3.5 text-[15px] font-semibold text-primary-foreground hover:opacity-90"
+          >
+            Go to Dashboard
+          </Link>
+        </Show>
+      </section>
+    </>
   );
 }

--- a/src/app/setup/CopyButton.tsx
+++ b/src/app/setup/CopyButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+/**
+ * Copy-to-clipboard affordance for the setup guide's URL pill and command
+ * block. The setup page is otherwise a server component — this is the only
+ * interactive bit, so it stays small and self-contained.
+ */
+export function CopyButton({
+  value,
+  label,
+  className = '',
+}: {
+  value: string;
+  label: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <button
+      type="button"
+      title="Copy to clipboard"
+      aria-label={label}
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          // Clipboard permission denied — the text is on screen to select.
+        }
+      }}
+      className={`shrink-0 cursor-pointer ${className}`}
+    >
+      {copied ? (
+        <Check className="h-4 w-4" aria-hidden />
+      ) : (
+        <Copy className="h-4 w-4" aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,16 +1,7 @@
 import React from "react";
 import Link from "next/link";
-import {
-  Terminal,
-  Shield,
-  CheckCircle,
-  ChevronRight,
-  Zap,
-  ArrowRight,
-  Copy,
-  Key,
-  Box,
-} from "lucide-react";
+import { Terminal, ChevronRight, ArrowRight } from "lucide-react";
+import { CopyButton } from "./CopyButton";
 
 export const metadata = {
   title: "Setup & Integration | fgac.ai",
@@ -18,262 +9,271 @@ export const metadata = {
     "Connect your AI agents to fgac.ai in one command. Setup guides for Claude Code, Cursor, Windsurf, and Claude Desktop.",
 };
 
-/* ─── Page ───────────────────────────────────────────────────────────────── */
+const MCP_URL = "https://fgac.ai/api/mcp";
+const CLAUDE_CODE_CMD = `claude mcp add \\
+  --transport http \\
+  fgac https://fgac.ai/api/mcp`;
+
+/* ─── Page ───────────────────────────────────────────────────────────────
+   Nav and footer come from the root layout; this file is the page body only.
+   All colors are design tokens (globals.css) — no raw hex. */
+
+function StepHeading({
+  number,
+  title,
+  subtitle,
+}: {
+  number: string;
+  title: React.ReactNode;
+  subtitle: string;
+}) {
+  return (
+    <div className="flex items-start gap-4">
+      <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-base font-bold text-primary-foreground">
+        {number}
+      </span>
+      <div>
+        <h2 className="text-2xl font-bold tracking-[-0.01em] text-foreground">
+          {title}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+      </div>
+    </div>
+  );
+}
 
 export default function SetupPage() {
   return (
-    <div className="min-h-screen bg-slate-50 text-gray-600 selection:bg-indigo-500/30 font-sans pb-24">
+    <div className="pb-24">
       {/* ── Hero ──────────────────────────────────────────────────────── */}
-      <div className="relative border-b border-gray-200 bg-white/80 backdrop-blur-xl overflow-hidden py-16 sm:py-24">
-        <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80">
-          <div className="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-[#ff80b5] to-[#9089fc] opacity-20 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"></div>
-        </div>
-        <div className="max-w-3xl mx-auto px-6 lg:px-8 text-center">
-          <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 text-sm font-medium px-4 py-1.5 rounded-full border border-indigo-100 mb-6">
-            <Zap className="w-4 h-4" />
-            Works with any MCP client
+      <div className="border-b border-border bg-card px-6 py-16 sm:px-8 sm:py-[72px]">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="mb-6 flex flex-wrap justify-center gap-2.5">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-gmail-border bg-gmail-bg px-3 py-1 text-[13px] font-semibold text-gmail">
+              <span className="h-[7px] w-[7px] rounded-full bg-gmail" />
+              Gmail
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-sheets-border bg-sheets-bg px-3 py-1 text-[13px] font-semibold text-sheets">
+              <span className="h-[7px] w-[7px] rounded-full bg-sheets" />
+              Google Sheets
+            </span>
           </div>
-          <h1 className="text-3xl sm:text-5xl font-extrabold tracking-tight text-gray-900 mb-4">
-            Secure Gmail access for your AI agents
+
+          <h1 className="mb-3.5 text-[34px] font-extrabold leading-[1.1] tracking-[-0.03em] text-foreground sm:text-[44px]">
+            Connected in three steps
           </h1>
-          <p className="text-base sm:text-lg text-gray-600 max-w-xl mx-auto leading-relaxed">
-            Add FGAC as an MCP server, sign in with Google, and control exactly
-            what your agents can read, send, and delete.
+          <p className="mx-auto mb-6 max-w-[560px] text-[17px] leading-relaxed text-muted-foreground">
+            Add FGAC as an MCP server, sign in with Google, and decide exactly
+            what your agents can read, write, and send.
+          </p>
+
+          <div className="inline-flex items-center gap-2.5 rounded-sm bg-surface-inverse px-4 py-2.5 font-mono text-sm text-surface-inverse-foreground">
+            {MCP_URL}
+            <CopyButton
+              value={MCP_URL}
+              label="Copy MCP server URL"
+              className="text-muted-foreground hover:text-surface-inverse-foreground"
+            />
+          </div>
+          <p className="mt-3 text-xs text-subtle">
+            Works with any MCP client — one URL everywhere.
           </p>
         </div>
       </div>
 
-      <main className="max-w-3xl mx-auto px-6 lg:px-8 mt-12 sm:mt-16 space-y-16 sm:space-y-20">
-        {/* ────────────────────────────────────────────────────────────── */}
-        {/* STEP 1                                                        */}
-        {/* ────────────────────────────────────────────────────────────── */}
-        <section className="space-y-8">
-          <div className="flex items-start gap-4">
-            <span className="bg-indigo-600 text-white w-9 h-9 rounded-full flex items-center justify-center text-base font-bold shadow-md shrink-0 mt-0.5">
-              1
-            </span>
-            <div>
-              <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
-                Add the MCP server
-              </h2>
-              <p className="text-gray-500 text-sm mt-1">
-                Every tool uses the same URL:{" "}
-                <code className="bg-gray-100 px-1.5 py-0.5 rounded text-gray-800 text-xs font-mono">
-                  https://fgac.ai/api/mcp
-                </code>
-              </p>
-            </div>
-          </div>
+      <div className="mx-auto mt-14 flex max-w-3xl flex-col gap-14 px-6 sm:px-8">
+        {/* ── Step 1 ──────────────────────────────────────────────────── */}
+        <section className="flex flex-col gap-6">
+          <StepHeading
+            number="1"
+            title="Add the MCP server"
+            subtitle="Pick your client — the URL is the same in all of them."
+          />
 
-          {/* Claude Code — hero command */}
-          <div className="bg-white border border-orange-200 rounded-2xl p-5 sm:p-6 shadow-sm">
-            <div className="flex items-center gap-2.5 mb-4">
-              <div className="w-8 h-8 bg-orange-50 rounded-lg flex items-center justify-center border border-orange-100">
-                <Terminal className="w-4 h-4 text-orange-600" />
+          <div className="rounded-lg border border-border bg-card p-6">
+            <div className="mb-3.5 flex items-center gap-2.5">
+              <div className="flex h-8 w-8 items-center justify-center rounded-sm border border-border bg-background">
+                <Terminal className="h-4 w-4 text-foreground" />
               </div>
-              <h3 className="font-semibold text-gray-900">Claude Code</h3>
+              <h3 className="font-semibold text-foreground">Claude Code</h3>
             </div>
-            <div className="bg-gray-950 text-gray-100 rounded-xl p-4 font-mono text-sm border border-gray-800 overflow-x-auto">
-              <div className="flex items-center justify-between gap-4 min-w-0">
-                <code className="text-emerald-400 whitespace-pre">
-                  {`claude mcp add \\
-  --transport http \\
-  fgac https://fgac.ai/api/mcp`}
+            <div className="overflow-x-auto rounded-sm bg-surface-inverse p-4 font-mono text-sm text-surface-inverse-foreground">
+              <div className="flex min-w-0 items-center justify-between gap-4">
+                <code className="whitespace-pre text-primary">
+                  {CLAUDE_CODE_CMD}
                 </code>
-                <button
-                  className="shrink-0 p-1.5 rounded-lg bg-white/10 text-gray-400 hover:text-white hover:bg-white/20 transition-colors"
-                  title="Copy to clipboard"
-                  aria-label="Copy Claude Code command"
-                >
-                  <Copy className="w-4 h-4" />
-                </button>
+                <CopyButton
+                  value={CLAUDE_CODE_CMD}
+                  label="Copy Claude Code command"
+                  className="rounded-sm bg-foreground/10 p-1.5 text-muted-foreground hover:text-surface-inverse-foreground"
+                />
               </div>
             </div>
-            <p className="text-xs text-gray-500 mt-3">
-              Run this in any project directory. The server persists across sessions.
+            <p className="mt-3 text-xs text-subtle">
+              Run this in any project directory. The server persists across
+              sessions.
             </p>
           </div>
 
-          {/* Other tools — text instructions, no fake command blocks */}
-          <div className="grid sm:grid-cols-3 gap-4">
-            <div className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm">
-              <h4 className="font-semibold text-gray-900 text-sm mb-2">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-md border border-border bg-card p-5">
+              <h4 className="mb-2 text-sm font-semibold text-foreground">
                 Cursor
               </h4>
-              <p className="text-xs text-gray-600 leading-relaxed">
+              <p className="text-xs leading-relaxed text-muted-foreground">
                 Open <strong>Settings → MCP Servers</strong>. Click{" "}
                 <strong>Add new HTTP server</strong>. Paste the URL above.
               </p>
             </div>
-            <div className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm">
-              <h4 className="font-semibold text-gray-900 text-sm mb-2">
+            <div className="rounded-md border border-border bg-card p-5">
+              <h4 className="mb-2 text-sm font-semibold text-foreground">
                 Windsurf
               </h4>
-              <p className="text-xs text-gray-600 leading-relaxed">
+              <p className="text-xs leading-relaxed text-muted-foreground">
                 Open <strong>Settings → MCP</strong>. Click{" "}
-                <strong>Add Server</strong>. Choose Streamable HTTP and paste
+                <strong>Add Server</strong>. Choose Streamable HTTP and paste the
+                URL above.
+              </p>
+            </div>
+            <div className="rounded-md border border-border bg-card p-5">
+              <h4 className="mb-2 text-sm font-semibold text-foreground">
+                Claude Desktop
+              </h4>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Open <strong>Settings → Developer → MCP Servers</strong>. Add a
+                new server with type <strong>&quot;url&quot;</strong> and paste
                 the URL above.
               </p>
             </div>
-            <div className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm">
-              <h4 className="font-semibold text-gray-900 text-sm mb-2">
-                Claude Desktop
-              </h4>
-              <p className="text-xs text-gray-600 leading-relaxed">
-                Open <strong>Settings → Developer → MCP Servers</strong>. Add a
-                new server with type <strong>&quot;url&quot;</strong> and paste the URL above.
-              </p>
-            </div>
           </div>
 
-          <p className="text-xs text-gray-500 text-center">
-            FGAC uses <strong>MCP Streamable HTTP</strong> with OAuth 2.1 (DCR + PKCE).
-            Your client handles authentication automatically.
+          <p className="text-center text-xs text-subtle">
+            FGAC uses <strong>MCP Streamable HTTP</strong> with OAuth 2.1 (DCR +
+            PKCE). Your client handles authentication automatically.
           </p>
         </section>
 
-        {/* ── Connector ─────────────────────────────────────────────── */}
-        <div className="flex justify-center">
-          <div className="w-px h-10 bg-gradient-to-b from-gray-200 to-gray-300 relative">
-            <ArrowRight className="w-4 h-4 text-gray-400 absolute -bottom-1.5 left-1/2 -translate-x-1/2 rotate-90" />
-          </div>
-        </div>
+        {/* ── Step 2 ──────────────────────────────────────────────────── */}
+        <section className="flex flex-col gap-6">
+          <StepHeading
+            number="2"
+            title={<>Sign in &amp; approve the connection</>}
+            subtitle="Your agent triggers an OAuth flow. Then approve it in your dashboard."
+          />
 
-        {/* ────────────────────────────────────────────────────────────── */}
-        {/* STEP 2                                                        */}
-        {/* ────────────────────────────────────────────────────────────── */}
-        <section className="space-y-6">
-          <div className="flex items-start gap-4">
-            <span className="bg-emerald-600 text-white w-9 h-9 rounded-full flex items-center justify-center text-base font-bold shadow-md shrink-0 mt-0.5">
-              2
-            </span>
-            <div>
-              <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
-                Sign in &amp; approve the connection
-              </h2>
-              <p className="text-gray-500 text-sm mt-1">
-                Your agent triggers an OAuth flow. Then approve it in your dashboard.
-              </p>
-            </div>
-          </div>
-
-          {/* Flow diagram */}
-          <div className="bg-white border border-gray-200 rounded-2xl p-5 sm:p-6 shadow-sm">
-            <ol className="space-y-4 text-sm text-gray-700">
+          <div className="rounded-lg border border-border bg-card p-6">
+            <ol className="flex list-none flex-col gap-4 p-0 text-sm text-foreground">
               <li className="flex items-start gap-3">
-                <span className="bg-emerald-50 text-emerald-700 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0 mt-0.5 border border-emerald-100">
+                <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary-muted text-xs font-bold text-primary">
                   A
                 </span>
                 <div>
-                  <strong className="text-gray-900">
-                    Your agent tries to use a tool
-                  </strong>
-                  <span className="text-gray-500">
-                    {" "}— a browser window opens asking you to sign in with Google.
-                    This links your agent to your FGAC account. No API keys needed.
+                  <strong>Your agent tries to use a tool</strong>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    — a browser window opens asking you to sign in with Google.
+                    This links your agent to your FGAC account. No API keys
+                    needed.
                   </span>
                 </div>
               </li>
               <li className="flex items-start gap-3">
-                <span className="bg-emerald-50 text-emerald-700 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0 mt-0.5 border border-emerald-100">
+                <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary-muted text-xs font-bold text-primary">
                   B
                 </span>
                 <div>
-                  <strong className="text-gray-900">
+                  <strong>
                     Approve in your{" "}
                     <Link
                       href="/dashboard"
-                      className="text-indigo-600 hover:text-indigo-700 underline underline-offset-2 decoration-indigo-300"
+                      className="text-primary underline underline-offset-2"
                     >
                       FGAC Dashboard
                     </Link>
                   </strong>
-                  <span className="text-gray-500">
-                    {" "}— new connections appear as <strong className="text-amber-600">⏳&nbsp;Pending</strong>.
-                    Click Approve and assign a Key Profile to grant access.
+                  <span className="text-muted-foreground">
+                    {" "}
+                    — new connections appear as{" "}
+                    <strong className="text-warning-foreground">Pending</strong>.
+                    Attach the connection to an agent profile to grant access.
                   </span>
                 </div>
               </li>
             </ol>
           </div>
 
-          {/* Compact visual flow */}
-          <div className="bg-gradient-to-r from-emerald-50 via-white to-indigo-50 border border-emerald-100 rounded-xl px-4 py-3">
-            <div className="flex items-center justify-center gap-2 flex-wrap text-xs font-medium">
-              <span className="bg-white border border-gray-200 px-3 py-1.5 rounded-lg text-gray-600 shadow-sm">
+          <div className="rounded-md border border-border bg-card px-4 py-3">
+            <div className="flex flex-wrap items-center justify-center gap-2 text-xs font-medium">
+              <span className="rounded-sm border border-border bg-background px-3 py-1.5 text-muted-foreground">
                 Agent connects
               </span>
-              <ChevronRight className="w-3 h-3 text-gray-400 shrink-0" />
-              <span className="bg-white border border-gray-200 px-3 py-1.5 rounded-lg text-gray-600 shadow-sm">
+              <ChevronRight className="h-3 w-3 shrink-0 text-subtle" />
+              <span className="rounded-sm border border-border bg-background px-3 py-1.5 text-muted-foreground">
                 OAuth sign-in
               </span>
-              <ChevronRight className="w-3 h-3 text-gray-400 shrink-0" />
-              <span className="bg-amber-50 border border-amber-200 px-3 py-1.5 rounded-lg text-amber-700 shadow-sm">
-                ⏳ Pending
+              <ChevronRight className="h-3 w-3 shrink-0 text-subtle" />
+              <span className="rounded-sm border border-warning-foreground bg-warning px-3 py-1.5 text-warning-foreground">
+                Pending
               </span>
-              <ChevronRight className="w-3 h-3 text-gray-400 shrink-0" />
-              <span className="bg-emerald-50 border border-emerald-200 px-3 py-1.5 rounded-lg text-emerald-700 shadow-sm">
+              <ChevronRight className="h-3 w-3 shrink-0 text-subtle" />
+              <span className="rounded-sm border border-success-foreground bg-success px-3 py-1.5 text-success-foreground">
                 ✓ Approved
               </span>
             </div>
           </div>
         </section>
 
-        {/* ── Connector ─────────────────────────────────────────────── */}
-        <div className="flex justify-center">
-          <div className="w-px h-10 bg-gradient-to-b from-gray-200 to-gray-300 relative">
-            <ArrowRight className="w-4 h-4 text-gray-400 absolute -bottom-1.5 left-1/2 -translate-x-1/2 rotate-90" />
-          </div>
-        </div>
+        {/* ── Step 3 ──────────────────────────────────────────────────── */}
+        <section className="flex flex-col gap-6">
+          <StepHeading
+            number="3"
+            title="Grant access, service by service"
+            subtitle="Everything is denied until you allow it. Grants live on reusable agent profiles."
+          />
 
-        {/* ────────────────────────────────────────────────────────────── */}
-        {/* STEP 3                                                        */}
-        {/* ────────────────────────────────────────────────────────────── */}
-        <section className="space-y-6">
-          <div className="flex items-start gap-4">
-            <span className="bg-brand-purple text-white w-9 h-9 rounded-full flex items-center justify-center text-base font-bold shadow-md shrink-0 mt-0.5">
-              3
-            </span>
-            <div>
-              <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
-                Set access rules
-              </h2>
-              <p className="text-gray-500 text-sm mt-1">
-                Control exactly what each agent can read, send, and delete.
-              </p>
-            </div>
-          </div>
-
-          <div className="bg-white border border-gray-200 rounded-2xl p-5 sm:p-6 shadow-sm space-y-4">
-            <div className="flex items-start gap-3">
-              <Shield className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
+          <div className="overflow-hidden rounded-lg border border-border bg-card">
+            <div className="flex items-start gap-3.5 border-b border-border px-6 py-5">
+              <span className="mt-px shrink-0 rounded-full border border-sheets-border bg-sheets-bg px-2.5 py-0.5 text-xs font-bold text-sheets">
+                Sheets
+              </span>
               <div>
-                <strong className="text-gray-900 text-sm">Read Blocklist</strong>
-                <p className="text-xs text-gray-500 mt-0.5">
-                  Block sensitive emails — 2FA codes, password resets, financial alerts.
-                  Uses regex pattern matching on subjects and senders.
+                <strong className="text-sm text-foreground">
+                  Expose spreadsheets with the Google Picker
+                </strong>
+                <p className="mt-0.5 text-[13px] leading-relaxed text-muted-foreground">
+                  Click <strong>+ Expose a sheet</strong> on a profile and pick
+                  files. Each sheet starts read-only; enable write access per
+                  sheet when the agent needs it.
                 </p>
               </div>
             </div>
-            <hr className="border-gray-100" />
-            <div className="flex items-start gap-3">
-              <CheckCircle className="w-5 h-5 text-emerald-500 shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3.5 border-b border-border px-6 py-5">
+              <span className="mt-px shrink-0 rounded-full border border-gmail-border bg-gmail-bg px-2.5 py-0.5 text-xs font-bold text-gmail">
+                Gmail
+              </span>
               <div>
-                <strong className="text-gray-900 text-sm">Send Whitelist</strong>
-                <p className="text-xs text-gray-500 mt-0.5">
-                  Only allow sending to approved domains or specific email addresses.
-                  Everything else is rejected.
+                <strong className="text-sm text-foreground">
+                  Read blocklist &amp; send whitelist
+                </strong>
+                <p className="mt-0.5 text-[13px] leading-relaxed text-muted-foreground">
+                  Regex rules hide sensitive mail — 2FA codes, password resets,
+                  financial alerts. Sending only works to addresses and domains
+                  you approve.
                 </p>
               </div>
             </div>
-            <hr className="border-gray-100" />
-            <div className="flex items-start gap-3">
-              <Key className="w-5 h-5 text-indigo-500 shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3.5 px-6 py-5">
+              <span className="mt-px shrink-0 rounded-full border border-border bg-background px-2.5 py-0.5 text-xs font-bold text-foreground">
+                Profiles
+              </span>
               <div>
-                <strong className="text-gray-900 text-sm">Per-Agent Profiles</strong>
-                <p className="text-xs text-gray-500 mt-0.5">
-                  Create separate profiles with different permissions.
-                  Assign each agent connection to the right one.
+                <strong className="text-sm text-foreground">
+                  One profile per agent
+                </strong>
+                <p className="mt-0.5 text-[13px] leading-relaxed text-muted-foreground">
+                  Profiles bundle rules and grants into a scoped identity. Your
+                  research agent and your inbox agent don&apos;t have to share
+                  permissions.
                 </p>
               </div>
             </div>
@@ -282,92 +282,94 @@ export default function SetupPage() {
           <div className="text-center">
             <Link
               href="/dashboard"
-              className="inline-flex items-center gap-2 bg-brand-purple text-white px-5 py-2.5 rounded-full text-sm font-medium hover:opacity-90 transition-all shadow-md"
+              className="inline-flex items-center gap-2 rounded-sm bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
             >
               Open Dashboard
-              <ArrowRight className="w-4 h-4" />
+              <ArrowRight className="h-4 w-4" />
             </Link>
           </div>
         </section>
 
-        {/* ────────────────────────────────────────────────────────────── */}
-        {/* Multiple accounts — collapsible info                          */}
-        {/* ────────────────────────────────────────────────────────────── */}
-        <section className="bg-gradient-to-br from-indigo-50 via-white to-purple-50 border border-indigo-100 rounded-2xl p-6 sm:p-8 relative overflow-hidden shadow-sm">
-          <div className="absolute top-0 right-0 w-48 h-48 bg-indigo-100 blur-3xl rounded-full translate-x-1/2 -translate-y-1/2"></div>
-          <div className="relative z-10">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="p-2.5 bg-indigo-100 rounded-xl">
-                <Box className="w-5 h-5 text-indigo-600" />
-              </div>
-              <h2 className="text-lg sm:text-xl font-bold text-gray-900">
-                Multiple email accounts
-              </h2>
+        {/* ── Multi-account ───────────────────────────────────────────── */}
+        <section className="rounded-lg border border-brand-purple/25 bg-brand-purple/5 p-6 sm:p-8">
+          <div className="mb-3.5 flex flex-wrap items-center gap-3">
+            <span className="rounded-full border border-brand-purple/25 bg-brand-purple/10 px-2.5 py-0.5 text-xs font-bold text-brand-purple">
+              Multi-account
+            </span>
+            <h2 className="text-xl font-bold tracking-[-0.01em] text-foreground">
+              Multiple Gmail accounts, one agent
+            </h2>
+          </div>
+          <p className="mb-4 max-w-[580px] text-sm leading-[1.65] text-foreground">
+            One agent connection can reach several inboxes. Other people delegate
+            access from their own FGAC dashboard — no password sharing — then
+            your agent targets an inbox with the{" "}
+            <code className="rounded-xs bg-brand-purple/10 px-1.5 py-0.5 font-mono text-xs text-brand-purple">
+              account
+            </code>{" "}
+            parameter. Every delegation keeps its own rules and is revocable in
+            one click.
+          </p>
+          <div className="flex flex-col gap-2.5">
+            <div className="rounded-sm border border-border bg-card px-3.5 py-3 font-mono text-[13px]">
+              <span className="mb-0.5 block text-[11px] text-subtle">
+                Your inbox
+              </span>
+              <span className="font-semibold text-primary">gmail_list</span>
+              <span className="text-subtle"> → returns your emails</span>
             </div>
-            <p className="text-sm text-gray-700 mb-4 leading-relaxed max-w-xl">
-              One agent connection can access multiple Gmail inboxes.
-              Other users delegate access from their own FGAC dashboard, then your agent
-              uses the <code className="bg-indigo-100 px-1.5 py-0.5 rounded text-indigo-700 text-xs font-mono">account</code> parameter
-              to specify which inbox.
-            </p>
-
-            <div className="bg-white/80 border border-gray-200 rounded-xl p-4 backdrop-blur-sm space-y-2.5">
-              <div className="bg-gray-50 rounded-lg p-3 border border-gray-200 font-mono text-sm">
-                <span className="text-gray-400 text-xs block mb-0.5">Your inbox</span>
-                <span className="text-emerald-600 font-semibold">gmail_list</span>
-                <span className="text-gray-400"> → returns your emails</span>
-              </div>
-              <div className="bg-gray-50 rounded-lg p-3 border border-gray-200 font-mono text-sm">
-                <span className="text-gray-400 text-xs block mb-0.5">Delegated inbox</span>
-                <span className="text-emerald-600 font-semibold">gmail_list</span>{" "}
-                <span className="text-gray-400">account=</span>
-                <span className="text-indigo-600 font-semibold">boss@company.com</span>
-              </div>
+            <div className="rounded-sm border border-border bg-card px-3.5 py-3 font-mono text-[13px]">
+              <span className="mb-0.5 block text-[11px] text-subtle">
+                Delegated inbox
+              </span>
+              <span className="font-semibold text-primary">gmail_list</span>{" "}
+              <span className="text-subtle">account=</span>
+              <span className="font-semibold text-brand-purple">
+                boss@company.com
+              </span>
             </div>
           </div>
         </section>
 
-        {/* ────────────────────────────────────────────────────────────── */}
-        {/* Advanced: Proxy Key                                           */}
-        {/* ────────────────────────────────────────────────────────────── */}
-        <section className="border-t border-gray-200 pt-12 space-y-5">
+        {/* ── Alternative: proxy key ──────────────────────────────────── */}
+        <section className="flex flex-col gap-5 border-t border-border pt-10">
           <div className="text-center">
-            <h2 className="text-base font-bold text-gray-900 mb-1">
+            <h2 className="mb-1 text-base font-bold text-foreground">
               Alternative: Direct Proxy Key
             </h2>
-            <p className="text-xs text-gray-500 max-w-md mx-auto">
+            <p className="mx-auto max-w-md text-xs text-subtle">
               For agents that don&apos;t support MCP, create a proxy API key and
               use our downloadable skill files.
             </p>
           </div>
 
-          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
             <Link
               href="/dashboard"
-              className="inline-flex items-center justify-center gap-1.5 text-sm text-gray-700 bg-white border border-gray-200 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors"
+              className="inline-flex items-center justify-center gap-1.5 rounded-sm border border-border bg-card px-4 py-2 text-sm text-foreground hover:border-ring"
             >
               Create Key in Dashboard
-              <ChevronRight className="w-3.5 h-3.5" />
+              <ChevronRight className="h-3.5 w-3.5" />
             </Link>
             <a
               href="/skills/claude-code/SKILL.md"
               target="_blank"
-              className="inline-flex items-center justify-center gap-1.5 text-sm text-gray-700 bg-white border border-gray-200 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors"
+              className="inline-flex items-center justify-center gap-1.5 rounded-sm border border-border bg-card px-4 py-2 text-sm text-foreground hover:border-ring"
             >
               Claude Code SKILL.md
-              <Terminal className="w-3.5 h-3.5" />
+              <Terminal className="h-3.5 w-3.5" />
             </a>
             <a
               href="/skills/open-claw/SKILL.md"
               target="_blank"
-              className="inline-flex items-center justify-center gap-1.5 text-sm text-gray-700 bg-white border border-gray-200 px-4 py-2 rounded-lg hover:bg-gray-50 transition-colors"
+              className="inline-flex items-center justify-center gap-1.5 rounded-sm border border-border bg-card px-4 py-2 text-sm text-foreground hover:border-ring"
             >
               Open Claw SKILL.md
-              <Terminal className="w-3.5 h-3.5" />
+              <Terminal className="h-3.5 w-3.5" />
             </a>
           </div>
         </section>
-      </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Landing A Showcase and Setup Guide v2 from the design project, ported to
the app's semantic tokens (no raw hex) so both pages theme with the rest
of the UI.

Landing: Sheets + Gmail hero with the demo video framed as a browser
window, three capability cards with allow/block examples, a three-step
band, and the Google data-usage disclosure split into three cards.

Setup: dark URL pill in the hero, step headings unified, step 3 reframed
as per-service grants (Sheets picker / Gmail rules / profiles), and the
multi-account section restyled. Both copy affordances are now real —
CopyButton is the only client component on the page.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
