### PR TITLE
Public /docs page + connector submission materials

### DIFF
--- a/docs/connector_submission/listing_copy.md
+++ b/docs/connector_submission/listing_copy.md
@@ -1,0 +1,128 @@
+# Connectors Directory — Listing Copy & Portal Answers
+
+Draft answers for every step of the submission portal
+(claude.ai/admin-settings/directory/submissions/new). Paste-ready; edit taste,
+not facts.
+
+## Listing step
+
+**Server name** (≤100 chars)
+> FGAC.ai
+
+**Tagline** (≤55 chars — pick one)
+> 1. `Gmail & Sheets for agents — on your terms` (41)
+> 2. `A permission layer for agents in your inbox` (43)
+> 3. `Deny-by-default Gmail & Sheets access for AI` (44)
+
+Recommended: #1 (leads with capability, ends with the differentiator).
+
+**Description** (≤2,000 chars)
+
+> FGAC.ai (Fine-Grained Access Control) lets AI agents work inside your Gmail
+> and Google Sheets without handing them your whole Google account.
+>
+> Connect once, then decide exactly what agents can do. Every request an agent
+> makes passes through FGAC's rule engine before it touches Google — deny by
+> default, allow on your terms:
+>
+> • **Read rules** hide sensitive mail from agents: block by Gmail label, or
+> by content patterns (2FA codes, password resets, financial alerts) — the
+> agent sees an "access restricted" notice, never the message.
+> • **Send whitelist** — agents can only email addresses and domains you
+> approve. No whitelist, no outbound mail. Deletion is never possible: no
+> FGAC tool can delete anything.
+> • **Per-spreadsheet grants** — expose individual Sheets read-only or
+> read-write; everything else is invisible.
+> • **Agent profiles** — bundle rules into scoped identities. Your research
+> agent and your inbox agent don't share permissions.
+> • **Pending approval** — every new agent connection starts inert until you
+> approve it from your dashboard.
+> • **Multi-account** — teammates can delegate their inboxes to your agent
+> with their own rules, revocable in one click. No password sharing.
+>
+> Under the hood, agents get read tools that run without friction
+> (annotated read-only), guarded write tools, and a rule-checked raw API
+> escape hatch covering the full Gmail and Sheets API surface. Your data is
+> never stored or used for training; see fgac.ai/privacy.
+>
+> Free for personal use. Connected in under a minute.
+
+(~1,450 chars — room to grow.)
+
+**Categories** (1-5): Productivity; Email; Spreadsheets/Data; Developer Tools
+(pick what the portal's actual taxonomy offers — Productivity first).
+
+**Documentation URL**: `https://fgac.ai/docs`
+**Privacy policy URL**: `https://fgac.ai/privacy`
+**Support contact**: `fgac-ai@googlegroups.com`
+
+**Icon**: square PNG. `public/logo-square.png` is currently 376×379 — crop to
+exactly square and export at 512×512 before uploading.
+
+**URL slug** (PERMANENT — cannot change after publication)
+> Recommended: `fgac` (short, matches domain). Alternative: `fgac-ai`.
+
+## Connection step
+
+- Server URL: `https://fgac.ai/api/mcp` (https ✓)
+- Transport: **Streamable HTTP**
+- Same URL for every user: **Yes**
+
+## Use cases step
+
+- Primary use cases: inbox triage and summarization with sensitive mail
+  shielded; guarded email sending (whitelisted recipients only); reading and
+  updating exposed spreadsheets; delegated multi-inbox workflows for teams.
+- What users need first: a Google account (Gmail); sign-in happens during
+  OAuth. To grant access they visit their FGAC dashboard once to approve the
+  connection and set rules. Free tier — no plan required.
+- Reads data, writes data, or both: **Both** (reads mail/sheets; writes are
+  limited to whitelisted sends and Read & Write spreadsheets).
+
+## Company step
+
+- Company: FGAC.ai — website `https://fgac.ai`
+- Contact: pre-filled from the submitting account.
+
+## Authentication step
+
+- **OAuth with Dynamic Client Registration** (`oauth_dcr`) — our authorization
+  server is Clerk at `clerk.fgac.ai`; DCR + PKCE S256 supported out of the box;
+  discovery at `/.well-known/oauth-authorization-server` and
+  `/.well-known/oauth-protected-resource/mcp` (resource includes the
+  `/api/mcp` path).
+- Note for later: if directory traffic makes DCR client accumulation a
+  problem, migrate to CIMD or Anthropic-held credentials
+  (mcp-review@anthropic.com), per docs/implementation_plans/connector-approval-audit_v2.md.
+
+## Data handling step
+
+- The API called is **our own first-party service** (fgac.ai), which proxies
+  Google's Gmail/Sheets APIs strictly on the user's own OAuth grant, applying
+  the user's access rules. MCP domain (fgac.ai) = service domain.
+- Personal health data: **No**. Sponsored content: **No**.
+
+## Test & launch step
+
+- Use docs/connector_submission/reviewer_runbook.md Part 2 verbatim, with real
+  credentials filled in from 1Password.
+- Attestation "you have run every tool yourself": true — QA runs exercised all
+  13 tools through the MCP endpoint (docs/QA_Acceptance_Test/qa-results.json);
+  do one final custom-connector pass from Claude.ai before submitting.
+
+## Compliance step (7 acknowledgments)
+
+All seven apply cleanly: directory guidelines ✓; first-party API ✓; no
+financial transactions ✓; no AI media generation ✓; no prompt-injection
+patterns in tool descriptions (linted in CI) ✓; no conversation-data
+collection beyond tool needs ✓; public documentation live at fgac.ai/docs ✓.
+
+## Pre-submission checklist (final pass)
+
+- [ ] Google Group accepts posts from non-members (tested with an outside email)
+- [ ] fgac.ai/docs live in production
+- [ ] Reviewer account built + dry-run (reviewer_runbook.md Part 1, step 5)
+- [ ] Icon cropped square, 512×512 PNG
+- [ ] No Vercel firewall/challenge rules blocking 160.79.104.0/21
+- [ ] Final custom-connector smoke test from Claude.ai (all tools listed with
+      annotations; one read, one denied read, one send, one denied send)

--- a/docs/connector_submission/reviewer_runbook.md
+++ b/docs/connector_submission/reviewer_runbook.md
@@ -1,0 +1,97 @@
+# Reviewer Test Account — Build Runbook & Portal Instructions
+
+Two parts: (1) how WE build the reviewer account before submitting, and (2) the
+text to paste into the portal's **Test & launch** step so an Anthropic reviewer
+can go end-to-end in ~10 minutes.
+
+> **Public repo notice**: never commit the real reviewer credentials to this
+> file. `<REVIEWER_EMAIL>` / `<REVIEWER_PASSWORD>` are placeholders — real
+> values go only into the submission portal.
+
+---
+
+## Part 1 — Building the account (us, before submission)
+
+### 1. Create the Google account (human step — not automatable)
+
+- Fresh Gmail account, e.g. `fgac.reviewer@gmail.com` (any available name).
+- Password stored in 1Password (vault `FGAC`, item `connector-reviewer`).
+- Turn OFF 2-step verification (reviewers can't complete our 2FA), or use an
+  account where it's not enforced. No recovery phone tied to personal numbers.
+
+### 2. Populate the inbox (fixtures)
+
+Send the account ~8-10 emails so every demo prompt has something to find:
+
+| Fixture | Purpose |
+|---|---|
+| 3-4 ordinary emails (meeting notes, a newsletter, a shipping notice) | `gmail_list` / `gmail_read` happy path |
+| One email with subject "Your verification code is 482913" | blocked by the content rule (demo denial) |
+| One email labeled `Confidential` | blocked by the label blacklist (demo denial) |
+| One email with a small PDF attachment (< 100 KB) | `gmail_get_attachment` |
+| Gmail labels: create `Confidential` and `AI-Allowed` | label rules reference these |
+
+### 3. Create the spreadsheet fixture
+
+- One Google Sheet named **"Team Budget (Demo)"** owned by the reviewer
+  account, two tabs: `Budget` (a small table of categories × months) and
+  `Tracking` (a header row for appended entries).
+
+### 4. Configure FGAC (through the dashboard UI, signed in as the reviewer account)
+
+1. Sign in at `https://fgac.ai/dashboard` with Google (this account).
+2. Default profile → **+ Expose a sheet** → pick "Team Budget (Demo)" → set
+   **Read & Write**.
+3. Rules (create on the profile):
+   - **Send whitelist**: pattern `fgac-ai@googlegroups.com` (so a reviewer can
+     send exactly one place — us; everything else demonstrates the deny).
+   - **Content read blacklist**: rule name `Block verification codes`, pattern
+     `verification code` (blocks the 2FA fixture).
+   - **Label blacklist**: label `Confidential`.
+4. Do NOT pre-approve a connection — the Pending → Approve flow is part of
+   what the reviewer should see (it's our core product moment).
+
+### 5. Dry-run before submitting
+
+Run the whole Part 2 script ourselves from a clean Claude.ai account:
+connect → approve → all 5 prompts → confirm outcomes match. Fix any drift
+between this doc and reality before submission day.
+
+---
+
+## Part 2 — Paste into the portal's "Test & launch" step
+
+> **Credentials**: Google account `<REVIEWER_EMAIL>` / password
+> `<REVIEWER_PASSWORD>` (no 2FA). This account is pre-loaded with email
+> fixtures, two Gmail labels, one Google Sheet, and pre-configured FGAC rules.
+
+**Setup (~3 min)**
+
+1. In Claude, add the connector (or as a custom connector:
+   `https://fgac.ai/api/mcp`). When the OAuth window opens, choose
+   **Sign in with Google** and use the credentials above.
+2. Ask Claude: *"List my email accounts."* — Expected: a notice that the
+   connection is **awaiting approval**, with a dashboard link. This is
+   deliberate: agents get no access until the user approves them.
+3. Open `https://fgac.ai/dashboard` (same Google sign-in). A yellow **pending
+   connection** card is visible. Attach it to the **Default Profile**.
+4. Re-ask Claude: *"List my email accounts."* — Expected: the account list.
+
+**Functional tests (~7 min)**
+
+| # | Prompt | Expected outcome |
+|---|---|---|
+| 1 | "Summarize my unread email." | Summaries of the ordinary fixtures. The message whose subject contains a verification code, and the one labeled Confidential, are NOT readable — Claude reports an "Access restricted" notice for them. |
+| 2 | "Read the email about my verification code." | Denied: `🚫 Access restricted: Content blocked by rule 'Block verification codes'`. |
+| 3 | "Email fgac-ai@googlegroups.com that the review test succeeded." | Sends successfully (that address is whitelisted); Claude returns the Gmail message id. |
+| 4 | "Email anyone@example.com hello." | Denied: unauthorized recipient, with instructions that the user must whitelist it. Nothing is sent. |
+| 5 | "What's in the Budget tab of the Team Budget spreadsheet?" then "Append a row to the Tracking tab: today, 42." | Both succeed (sheet is exposed Read & Write). |
+
+**Notes for the reviewer**
+
+- Read-only tools carry `readOnlyHint`; write tools carry `destructiveHint`.
+- `google_api_get` / `google_api_modify` accept freeform Gmail/Sheets API
+  paths; try `google_api_get` with `drive/v3/files` to see the deny-by-default
+  behavior (unsupported APIs are refused server-side).
+- Public docs: `https://fgac.ai/docs` · Privacy: `https://fgac.ai/privacy`
+- Support / questions: `fgac-ai@googlegroups.com`

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,291 @@
+import Link from "next/link";
+import { ArrowRight, BookOpen, Eye, PenLine } from "lucide-react";
+
+export const metadata = {
+  title: "Documentation | fgac.ai",
+  description:
+    "How to use FGAC with Claude and other MCP clients: tools, example prompts, expected outcomes, limitations, and support.",
+};
+
+/* ─── Public product documentation ──────────────────────────────────────
+   This page is the documentation URL for the Anthropic Connectors
+   Directory listing: product summary, example prompts with expected
+   outcomes, tool reference, limitations, and support contact.
+   Connect steps live on /setup. Design tokens only — no raw hex. */
+
+const READ_TOOLS: Array<[string, string]> = [
+  ["list_accounts", "Lists the inboxes this connection can reach"],
+  ["gmail_list", "Lists recent messages, with optional Gmail search query"],
+  ["gmail_read", "Reads one message: headers, body text, attachment list"],
+  ["gmail_get_attachment", "Downloads an attachment (up to ~150 KB)"],
+  ["gmail_labels", "Lists the account's Gmail labels"],
+  ["sheets_get_spreadsheet", "Spreadsheet metadata and sheet tabs"],
+  ["sheets_read_range", "Reads cell values from a range"],
+  ["get_my_permissions", "Shows the rules that govern this connection"],
+  ["google_api_get", "Any Gmail/Sheets read endpoint, rule-checked"],
+];
+
+const WRITE_TOOLS: Array<[string, string]> = [
+  ["gmail_send", "Sends mail — recipients must be on your send whitelist"],
+  ["sheets_update_range", "Overwrites cells — needs Read & Write on the sheet"],
+  ["sheets_append_rows", "Appends rows — needs Read & Write on the sheet"],
+  ["google_api_modify", "Supported Gmail/Sheets write endpoints, rule-checked"],
+];
+
+const EXAMPLES: Array<{
+  prompt: string;
+  outcome: string;
+  denied?: boolean;
+}> = [
+  {
+    prompt: "Summarize my unread email.",
+    outcome:
+      "Claude lists and reads recent unread messages and summarizes them. Any message blocked by your rules (a blacklisted label, or content matching a block pattern like a 2FA code) is withheld — Claude sees an “Access restricted” notice instead of the message.",
+  },
+  {
+    prompt: "Read the latest message from my bank.",
+    denied: true,
+    outcome:
+      "If your rules block financial mail (by label or content pattern), Claude receives “🚫 Access restricted: Content blocked by rule …” and tells you it can't read that message. The denial names the rule so you know which grant to change if you actually wanted access.",
+  },
+  {
+    prompt: "Email alex@example.com a short status update.",
+    outcome:
+      "If alex@example.com matches your send whitelist, the mail is sent and Claude confirms with the Gmail message id. If not, nothing is sent — Claude is told the recipient isn't whitelisted and to ask you to add it in the dashboard.",
+  },
+  {
+    prompt: "What's in the Budget tab of my planning spreadsheet?",
+    outcome:
+      "Claude reads the exposed spreadsheet and reports the cell values. Spreadsheets you haven't exposed on the agent's profile are denied by default — Claude is told the sheet isn't exposed rather than seeing any data.",
+  },
+  {
+    prompt: "Log today's totals as a new row in the tracking sheet.",
+    outcome:
+      "With Read & Write enabled on that spreadsheet, Claude appends the row and confirms the updated range. If the sheet is read-only, the write is refused with a clear read-only message and no data changes.",
+  },
+];
+
+function ToolTable({
+  icon,
+  title,
+  note,
+  tools,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  note: string;
+  tools: Array<[string, string]>;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="flex items-center gap-2.5 border-b border-border px-5 py-4">
+        {icon}
+        <h3 className="font-semibold text-foreground">{title}</h3>
+        <span className="ml-auto hidden text-xs text-subtle sm:block">{note}</span>
+      </div>
+      <ul className="m-0 list-none p-0">
+        {tools.map(([name, desc]) => (
+          <li
+            key={name}
+            className="flex flex-col gap-0.5 border-b border-border px-5 py-3 last:border-b-0 sm:flex-row sm:items-baseline sm:gap-4"
+          >
+            <code className="shrink-0 font-mono text-[13px] font-semibold text-primary sm:w-52">
+              {name}
+            </code>
+            <span className="text-[13px] leading-relaxed text-muted-foreground">
+              {desc}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function DocsPage() {
+  return (
+    <div className="pb-24">
+      {/* ── Hero ──────────────────────────────────────────────────────── */}
+      <div className="border-b border-border bg-card px-6 py-16 sm:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 text-[13px] font-semibold text-muted-foreground">
+            <BookOpen className="h-3.5 w-3.5" />
+            Documentation
+          </div>
+          <h1 className="mb-3.5 text-[34px] font-extrabold leading-[1.1] tracking-[-0.03em] text-foreground sm:text-[44px]">
+            Using FGAC with your agent
+          </h1>
+          <p className="mx-auto max-w-[620px] text-[17px] leading-relaxed text-muted-foreground">
+            FGAC.ai is a permission layer between AI agents and your Google
+            account. Agents connect once over MCP; every Gmail and Sheets
+            request they make is checked against rules you control — deny by
+            default, allow on your terms.
+          </p>
+          <p className="mt-5 text-sm text-muted-foreground">
+            Not connected yet?{" "}
+            <Link href="/setup" className="text-primary underline underline-offset-2">
+              Follow the three-step setup guide
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+
+      <div className="mx-auto mt-14 flex max-w-3xl flex-col gap-14 px-6 sm:px-8">
+        {/* ── Example prompts ─────────────────────────────────────────── */}
+        <section className="flex flex-col gap-5">
+          <div>
+            <h2 className="text-2xl font-bold tracking-[-0.01em] text-foreground">
+              Example prompts
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              What to say to Claude (or any MCP agent), and what to expect —
+              including what a denial looks like.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            {EXAMPLES.map((ex) => (
+              <div
+                key={ex.prompt}
+                className="rounded-lg border border-border bg-card p-5"
+              >
+                <div className="mb-2.5 flex flex-wrap items-center gap-2">
+                  <span className="rounded-sm bg-surface-inverse px-3 py-1.5 font-mono text-[13px] text-surface-inverse-foreground">
+                    “{ex.prompt}”
+                  </span>
+                  {ex.denied && (
+                    <span className="rounded-full border border-warning-foreground bg-warning px-2.5 py-0.5 text-xs font-bold text-warning-foreground">
+                      shows a denial
+                    </span>
+                  )}
+                </div>
+                <p className="text-[13px] leading-relaxed text-muted-foreground">
+                  {ex.outcome}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Tool reference ──────────────────────────────────────────── */}
+        <section className="flex flex-col gap-5">
+          <div>
+            <h2 className="text-2xl font-bold tracking-[-0.01em] text-foreground">
+              Tool reference
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Read-only tools can run without per-call confirmation in Claude;
+              write tools always ask first. Every tool is additionally checked
+              against your FGAC rules on our servers.
+            </p>
+          </div>
+
+          <ToolTable
+            icon={<Eye className="h-4 w-4 text-foreground" />}
+            title="Read-only tools"
+            note="run without confirmation prompts"
+            tools={READ_TOOLS}
+          />
+          <ToolTable
+            icon={<PenLine className="h-4 w-4 text-foreground" />}
+            title="Write tools"
+            note="Claude asks before each call"
+            tools={WRITE_TOOLS}
+          />
+
+          <p className="text-[13px] leading-relaxed text-muted-foreground">
+            <code className="font-mono text-xs text-primary">google_api_get</code>{" "}
+            and{" "}
+            <code className="font-mono text-xs text-primary">
+              google_api_modify
+            </code>{" "}
+            cover the long tail of the{" "}
+            <a
+              href="https://developers.google.com/gmail/api/reference/rest"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline underline-offset-2"
+            >
+              Gmail API
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://developers.google.com/sheets/api/reference/rest"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline underline-offset-2"
+            >
+              Sheets API
+            </a>{" "}
+            without loosening anything: raw reads pass the same read rules, the
+            only raw Gmail write is <em>send</em> (whitelist-checked), and
+            unrecognized endpoints are denied.
+          </p>
+        </section>
+
+        {/* ── Limitations ─────────────────────────────────────────────── */}
+        <section className="flex flex-col gap-5">
+          <div>
+            <h2 className="text-2xl font-bold tracking-[-0.01em] text-foreground">
+              Limitations
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Most of these are safety guarantees, not gaps.
+            </p>
+          </div>
+
+          <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
+            {[
+              ["Gmail and Google Sheets only.", "Other Google services (Drive, Calendar, Docs) are denied — support arrives service by service, each behind its own rules."],
+              ["Agents can never delete.", "No tool exposes DELETE. Trash, empty-trash, and destructive Gmail settings are refused regardless of your rules."],
+              ["Sending requires a whitelist.", "With no send-whitelist rule configured, all outbound mail is refused. That's the default."],
+              ["New connections start Pending.", "An agent that connects can do nothing until you attach it to a profile in the dashboard."],
+              ["Attachments cap at ~150 KB", "through MCP responses. Larger files must be fetched from Gmail directly."],
+              ["Delegated inboxes need an explicit delegation", "created by the inbox owner from their own FGAC account, revocable any time."],
+            ].map(([lead, rest]) => (
+              <li
+                key={lead}
+                className="rounded-md border border-border bg-card px-4 py-3 text-[13px] leading-relaxed text-muted-foreground"
+              >
+                <strong className="text-foreground">{lead}</strong> {rest}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ── Support ─────────────────────────────────────────────────── */}
+        <section className="rounded-lg border border-border bg-card p-6 text-center sm:p-8">
+          <h2 className="mb-1.5 text-xl font-bold tracking-[-0.01em] text-foreground">
+            Support
+          </h2>
+          <p className="mx-auto mb-4 max-w-md text-sm leading-relaxed text-muted-foreground">
+            Questions, bug reports, or access issues — email{" "}
+            <a
+              href="mailto:fgac-ai@googlegroups.com"
+              className="text-primary underline underline-offset-2"
+            >
+              fgac-ai@googlegroups.com
+            </a>
+            . See also the{" "}
+            <Link href="/privacy" className="text-primary underline underline-offset-2">
+              Privacy Policy
+            </Link>{" "}
+            and{" "}
+            <Link href="/terms" className="text-primary underline underline-offset-2">
+              Terms of Service
+            </Link>
+            .
+          </p>
+          <Link
+            href="/setup"
+            className="inline-flex items-center gap-2 rounded-sm bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+          >
+            Get connected
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,6 +57,7 @@ export default function RootLayout({
                         </div>
                       </Show>
                       <NavLink href="/setup">Setup Guide</NavLink>
+                      <NavLink href="/docs">Docs</NavLink>
                     </div>
                   </div>
 
@@ -88,6 +89,7 @@ export default function RootLayout({
                     </div>
                   </Show>
                   <NavLink href="/setup">Setup Guide</NavLink>
+                  <NavLink href="/docs">Docs</NavLink>
                 </div>
               </div>
             </nav>
@@ -103,6 +105,7 @@ export default function RootLayout({
               <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8 flex flex-col sm:flex-row justify-between items-center text-sm text-muted-foreground gap-4 sm:gap-0">
                 <p>&copy; {new Date().getFullYear()} FGAC.ai. All rights reserved.</p>
                 <div className="flex space-x-8">
+                  <Link href="/docs" className="hover:text-foreground">Docs</Link>
                   <Link href="/privacy" className="hover:text-foreground">Privacy Policy</Link>
                   <Link href="/terms" className="hover:text-foreground">Terms of Service</Link>
                 </div>


### PR DESCRIPTION
## Summary

Closes out the buildable pre-submission items for the Anthropic Connectors Directory (plan: docs/implementation_plans/connector-approval-audit_v2.md, Phase 2):

- **`/docs`** — public documentation page: product summary, 5 example prompts with expected outcomes (two demonstrate denials), read/write tool reference, limitations, support contact. This is the listing's documentation URL. Linked from the nav (desktop + mobile) and footer.
- **`docs/connector_submission/reviewer_runbook.md`** — how to build the reviewer test account (fixtures, labels, sheet, rules) plus paste-ready portal "Test & launch" instructions. Credential placeholders only.
- **`docs/connector_submission/listing_copy.md`** — tagline options, ≤2,000-char description, categories, permanent-slug recommendation, per-portal-step answers, and the final pre-submission checklist.

## Test plan

- [x] `tsc --noEmit` and eslint clean
- [x] `/docs` renders on the dev server (200, visual check, nav active state)
- [ ] Preview deployment validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)