### PR TITLE
feat(analytics): consolidate PostHog/Clerk identity, instrument MCP + proxy usage, sign-up funnel

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,67 @@
+# Product Analytics (PostHog)
+
+How FGAC.ai instruments usage, how PostHog persons map to Clerk users, and how to
+keep internal/QA traffic out of the numbers.
+
+## Identity model
+
+- **Distinct id = Clerk user id, everywhere.** The dashboard calls
+  `posthog.identify(clerkUserId)` on sign-in (`src/app/PostHogIdentify.tsx`); the
+  MCP server, API proxy, and Clerk webhook capture server-side events with the
+  same id (`src/lib/posthogServer.ts`). One PostHog person per Clerk user, with
+  `email`/`name` person properties.
+- Signed-out visitors stay anonymous (`person_profiles: 'identified_only'`).
+  `posthog.reset()` runs on sign-out so shared browsers don't cross-link users.
+
+## Event catalog
+
+| Event | Source | Key properties |
+| --- | --- | --- |
+| `$pageview` | client (`PostHogPageView.tsx`) | `$current_url` |
+| `sign_up_started` | client (`SignUpCta.tsx`, all sign-up CTAs) | `cta_location`: nav / hero / bottom_cta |
+| `sign_up_completed` | server (Clerk webhook, `user.created`) | `$set.email` |
+| `mcp_tool_call` | server (`/api/mcp`, every tool) | `tool`, `client_id`, `outcome`, `duration_ms` |
+| `proxy_request` | server (`/api/proxy/[...path]`) | `service` (gmail/sheets/drive), `method`, `status`, `outcome`, `duration_ms`, `proxy_key_id` |
+
+`mcp_tool_call.outcome`: `success`, `denied_by_policy` (🚫 FGAC rule), `pending_approval`
+(⏳ connection not yet approved), `failed` (❌ auth/input problems), `error`
+(upstream Google failure), `exception`.
+Unauthenticated calls attribute to the `anonymous-mcp` / `anonymous-proxy` persons.
+
+Every event (client and server) carries an `environment` property:
+`development` (localhost), `preview` (`*.vercel.app`), or `production` — all three
+Vercel environments share one PostHog project, so filter on it.
+
+## Sign-up funnel / abandoned sign-ups
+
+Create a PostHog funnel insight: `sign_up_started` → `sign_up_completed`
+(conversion window ~1 hour). Drop-off = people who opened the Clerk modal but never
+finished (the modal + Google OAuth steps in between are Clerk-internal and not
+individually observable). The anonymous click merges into the identified person
+once the new user's first signed-in page load calls `identify`.
+
+**Required Clerk dashboard config** (both dev and prod instances): the webhook
+endpoint `/api/webhooks/clerk` must be subscribed to `user.created` in addition to
+`user.deleted`.
+
+## Separating QA/internal traffic from genuine traffic
+
+1. **Filter every insight to `environment = production`.** This removes all local
+   dev-server and preview-deployment traffic (the bulk of QA volume).
+2. **Create a cohort "Internal / QA"**: persons where `email` is any of the QA test
+   accounts or founder accounts (the emails live in 1Password /
+   `.qa_test_emails.json`; they are deliberately not listed in this public repo).
+   Exclude the cohort from dashboards. This catches QA runs against production.
+3. **Historical events (before this instrumentation)** are anonymous and cannot be
+   retro-identified. To triage a past traffic spike, break `$pageview` down by
+   `$host`: `localhost:3000` and `*.vercel.app` volume is QA by definition; only
+   the production-domain remainder is potentially genuine.
+
+## Implementation notes
+
+- Server capture is fire-and-forget: `captureServerEvent()` no-ops when
+  `NEXT_PUBLIC_POSTHOG_KEY`/`_HOST` are unset and flushes via Next's `after()` so
+  serverless responses aren't delayed and events aren't dropped.
+- MCP instrumentation wraps `server.registerTool` once (see `/api/mcp/route.ts`),
+  so newly added tools are instrumented automatically.
+- The proxy records `proxy_key_id` (the row's UUID) — never the `sk_proxy_` secret.

--- a/docs/implementation_plans/mcp-analytics-instrumentation_v1.md
+++ b/docs/implementation_plans/mcp-analytics-instrumentation_v1.md
@@ -1,0 +1,100 @@
+# Analytics Instrumentation: MCP/Proxy Usage + Clerk↔PostHog Consolidation
+
+Branch: `claude/mcp-analytics-instrumentation-d51eff`
+
+## Problem
+
+PostHog shows a traffic jump and we cannot tell genuine new traffic from internal QA
+testing. Additional ask: measure MCP server / API pass-through usage, and capture
+abandoned sign-up flows.
+
+## Review findings (current state)
+
+1. **PostHog is client-side pageviews only.** `providers.tsx` inits `posthog-js`
+   (`person_profiles: 'identified_only'`), `PostHogPageView.tsx` captures `$pageview`.
+   That is the entire integration.
+2. **`posthog.identify()` is never called.** Every visitor — including the QA test
+   accounts — is an anonymous device. PostHog persons cannot be joined to Clerk users,
+   which is exactly why QA traffic is indistinguishable from real traffic.
+3. **All three Vercel environments share one PostHog project.**
+   `NEXT_PUBLIC_POSTHOG_KEY/HOST` are set for Development, Preview, AND Production.
+   Local QA dev servers and preview deployments report into the same project as
+   production. QA runs generate heavy dashboard pageview volume → this is the most
+   likely source of the "jump".
+   - *Immediate diagnostic (no code needed):* `$pageview` events carry
+     `$current_url`/`$host`. Breaking the spike down by `$host` shows how much is
+     `localhost:3000` / `*.vercel.app` vs the production domain.
+4. **The MCP server (`/api/mcp`) and the raw API proxy (`/api/proxy/[...path]`) emit
+   zero analytics.** The traffic jump cannot be MCP/proxy usage — that layer is
+   invisible to PostHog today.
+5. **No sign-up funnel.** Clerk's `<SignUpButton mode="modal">` is used in 3 places
+   (nav, hero, bottom CTA); no events on click, no completion event. The Clerk webhook
+   handles only `user.deleted`.
+
+## Design
+
+### A. Identity consolidation (client)
+
+- New `PostHogIdentify` client component (mounted in `layout.tsx` inside both
+  providers): on signed-in, `posthog.identify(clerkUserId, { email, name })`; on
+  signed-out, `posthog.reset()`. Distinct id = **Clerk user id** everywhere.
+- `providers.tsx` registers a super property `environment` on every client event,
+  derived from hostname (`localhost*` → development, `*.vercel.app` → preview, else
+  production). Hostname beats env vars here — it needs no Vercel system-var exposure.
+
+### B. Server-side capture (`src/lib/posthogServer.ts`)
+
+- `posthog-node` singleton (`flushAt: 1, flushInterval: 0`), no-op when
+  `NEXT_PUBLIC_POSTHOG_KEY` is unset, flushed via `after()` so serverless doesn't
+  drop events. All events tagged `environment: VERCEL_ENV ?? 'development'`.
+- Server events use the same Clerk user id as distinct id, so they merge into the
+  same PostHog person the client identified.
+
+### C. MCP instrumentation (`/api/mcp`)
+
+- `withAnalytics(toolName, handler)` wraps each of the 12 `registerTool` handlers.
+- Event `mcp_tool_call`: `tool`, `client_id`, `outcome`, `duration_ms`,
+  `connection status` context where cheap. Outcome classified from the result the
+  tool already returns (`isError` → error; leading `⏳` → pending_approval; `🚫` →
+  denied_by_rule; `❌` → failed; else success) — matching the response conventions
+  documented in the route.
+- Distinct id: `authInfo.extra.userId` (Clerk id) or `anonymous-mcp`.
+
+### D. Proxy instrumentation (`/api/proxy/[...path]`)
+
+- `handleProxyRequest` gains a mutable `telemetry` param it populates as identity
+  resolves (clerk user id, proxy key id, email). A single wrapper used by all five
+  HTTP method exports captures `proxy_request`: `service` (gmail/sheets/drive),
+  `method`, `status`, `outcome` (success / denied / auth_failed / error),
+  `duration_ms`, `proxy_key_id` (row id, never the secret).
+
+### E. Sign-up funnel
+
+- New `SignUpCta` client component wrapping Clerk's `SignUpButton`, capturing
+  `sign_up_started` with `cta_location` (nav / hero / bottom_cta) on click. Replaces
+  the three inline usages.
+- Clerk webhook handles `user.created`: server-side `identify` (email person
+  property) + `sign_up_completed` capture with distinct id = Clerk user id. Because
+  the click event's anonymous device id gets merged when the client later calls
+  `identify` with the same Clerk id, PostHog funnels connect the two.
+- **Abandoned sign-ups = funnel drop-off**: PostHog funnel insight
+  `sign_up_started` → `sign_up_completed`. Everything in between happens inside
+  Clerk's modal + Google OAuth, which we cannot instrument step-by-step; the
+  start/complete pair is the actionable signal.
+- ⚠️ Operator action: subscribe the Clerk webhook endpoint to `user.created`
+  (currently only `user.deleted`) in the Clerk dashboard, both instances.
+
+### F. Separating QA from genuine traffic (dashboard practice, documented in
+`docs/analytics.md`)
+
+1. Filter insights to `environment = production`.
+2. Create a cohort "Internal/QA" of persons whose email matches the QA/founder
+   accounts (emails live in PostHog, not in this public repo) and exclude it.
+3. Historical (pre-identify) events: break down by `$host` to strip localhost/preview
+   noise; anonymous production-host events from the QA period remain ambiguous —
+   accept and annotate.
+
+## Out of scope
+
+- No schema changes. No new env vars. No PII beyond what PostHog already holds
+  (emails as person properties on identified users).

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "pg": "^8.20.0",
         "playwright": "^1.60.0",
         "posthog-js": "^1.360.2",
+        "posthog-node": "^5.21.2",
         "react": "^19.2.3",
         "react-dom": "19.2.3",
         "safe-regex": "^2.1.1",
@@ -8195,6 +8196,27 @@
         "preact": "^10.28.2",
         "query-selector-shadow-dom": "^1.0.1",
         "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
+      "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.10.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/posthog-node/node_modules/@posthog/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
       }
     },
     "node_modules/preact": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pg": "^8.20.0",
     "playwright": "^1.60.0",
     "posthog-js": "^1.360.2",
+    "posthog-node": "^5.21.2",
     "react": "^19.2.3",
     "react-dom": "19.2.3",
     "safe-regex": "^2.1.1",

--- a/src/app/PostHogIdentify.tsx
+++ b/src/app/PostHogIdentify.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useUser } from '@clerk/nextjs'
+import { usePostHog } from 'posthog-js/react'
+
+/**
+ * Ties PostHog persons to Clerk users: the PostHog distinct id for a signed-in
+ * visitor is their Clerk user id, with email/name as person properties. This is
+ * what lets dashboards separate QA/internal accounts from genuine traffic.
+ * On sign-out the device is reset so the next visitor gets a fresh anonymous id.
+ */
+export default function PostHogIdentify() {
+  const { isLoaded, isSignedIn, user } = useUser()
+  const posthog = usePostHog()
+
+  useEffect(() => {
+    if (!isLoaded || !posthog) return
+    if (isSignedIn && user) {
+      if (posthog.get_distinct_id() !== user.id) {
+        posthog.identify(user.id, {
+          email: user.primaryEmailAddress?.emailAddress,
+          name: user.fullName ?? undefined,
+        })
+      }
+    } else if (posthog._isIdentified()) {
+      posthog.reset()
+    }
+  }, [isLoaded, isSignedIn, user, posthog])
+
+  return null
+}

--- a/src/app/SignUpCta.tsx
+++ b/src/app/SignUpCta.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { SignUpButton } from '@clerk/nextjs'
+import posthog from 'posthog-js'
+
+/**
+ * Clerk sign-up button with funnel instrumentation: clicking any sign-up CTA
+ * captures `sign_up_started`; the Clerk `user.created` webhook captures
+ * `sign_up_completed`. The drop-off between the two is the abandoned-sign-up
+ * rate (the modal + Google OAuth steps in between are Clerk-internal and not
+ * individually observable).
+ */
+export function SignUpCta({
+  location,
+  className,
+  children,
+}: {
+  location: 'nav' | 'hero' | 'bottom_cta'
+  className: string
+  children: React.ReactNode
+}) {
+  return (
+    <SignUpButton mode="modal" fallbackRedirectUrl="/dashboard" signInFallbackRedirectUrl="/dashboard">
+      <button
+        className={className}
+        onClick={() => posthog.capture('sign_up_started', { cta_location: location })}
+      >
+        {children}
+      </button>
+    </SignUpButton>
+  )
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -26,6 +26,7 @@ import { filterLiveDelegatedAccess } from '@/db/delegationQueries';
 import { clerkClient } from '@clerk/nextjs/server';
 import safeRegex from 'safe-regex';
 import { resolveDbUser } from '@/db/userHelpers';
+import { captureServerEvent } from '@/lib/posthogServer';
 import { TOOL_DEFS, toolAnnotations, type FgacToolDef } from './toolDefs';
 import {
   classifyGoogleApiCall, extractSendRecipients, collectLabelIds,
@@ -504,6 +505,53 @@ async function requireApproval(authInfo: AuthInfo | undefined): Promise<Connecti
   return result;
 }
 
+// ─── Analytics Instrumentation ──────────────────────────────────────────────
+
+type ToolAnalyticsResult = { isError?: boolean; content?: Array<{ type?: string; text?: string }> };
+
+/**
+ * Tool responses follow a strict convention (textResult/errorResult above):
+ * isError marks upstream/auth failures, and policy outcomes carry a leading
+ * ⏳ (pending approval), 🚫 (denied by FGAC policy), or ❌/⚠️ (failed).
+ */
+function classifyToolOutcome(result: ToolAnalyticsResult): string {
+  if (result.isError) return 'error';
+  const text = result.content?.[0]?.text ?? '';
+  if (text.startsWith('⏳')) return 'pending_approval';
+  if (text.startsWith('🚫')) return 'denied_by_policy';
+  if (text.startsWith('❌') || text.startsWith('⚠️')) return 'failed';
+  return 'success';
+}
+
+function withToolAnalytics<R extends ToolAnalyticsResult>(
+  tool: string,
+  fn: (params: unknown, extra: { authInfo?: AuthInfo }) => Promise<R> | R,
+) {
+  return async (params: unknown, extra: { authInfo?: AuthInfo }): Promise<R> => {
+    const started = Date.now();
+    // Distinct id = the caller's Clerk user id, matching the dashboard's
+    // identify() — MCP usage lands on the same PostHog person.
+    const track = (outcome: string) => captureServerEvent(
+      extra?.authInfo?.extra?.userId ?? 'anonymous-mcp',
+      'mcp_tool_call',
+      {
+        tool,
+        client_id: extra?.authInfo?.clientId,
+        outcome,
+        duration_ms: Date.now() - started,
+      },
+    );
+    try {
+      const result = await fn(params, extra);
+      track(classifyToolOutcome(result));
+      return result;
+    } catch (err) {
+      track('exception');
+      throw err;
+    }
+  };
+}
+
 type ResolvedAccount = { targetEmail: string; token: string; proxyKeyId: string };
 type ResolvedError = { error: string };
 
@@ -600,6 +648,15 @@ function toolConfig<S extends z.ZodRawShape>(def: FgacToolDef, inputSchema: S) {
 
 const handler = createMcpHandler(
   (server) => {
+    // Every registered tool is wrapped with a PostHog `mcp_tool_call` capture.
+    // Patching registerTool here keeps the registrations below untouched (their
+    // schema-inferred param types intact) and instruments future tools too.
+    const rawRegisterTool = server.registerTool.bind(server) as (
+      name: string, config: unknown, cb: unknown,
+    ) => ReturnType<typeof server.registerTool>;
+    server.registerTool = ((name: string, config: unknown, cb: unknown) =>
+      rawRegisterTool(name, config, withToolAnalytics(name, cb as Parameters<typeof withToolAnalytics>[1]))
+    ) as unknown as typeof server.registerTool;
 
     // ── list_accounts ─────────────────────────────────────────────────
     server.registerTool(

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -4,29 +4,66 @@ import { users, proxyKeys, emailDelegations, keyEmailAccess, accessRules, keyRul
 import { eq, and } from 'drizzle-orm';
 import { clerkClient } from '@clerk/nextjs/server';
 import safeRegex from 'safe-regex';
+import { captureServerEvent } from '@/lib/posthogServer';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
-  return handleProxyRequest(request, await params);
+  return trackedProxyRequest(request, await params);
 }
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
-  return handleProxyRequest(request, await params);
+  return trackedProxyRequest(request, await params);
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
-  return handleProxyRequest(request, await params);
+  return trackedProxyRequest(request, await params);
 }
 
 // Sheets values:update and batchUpdate are PUT/PATCH-shaped; without these
 // exports Next.js answers 405 before FGAC's rules ever run.
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
-  return handleProxyRequest(request, await params);
+  return trackedProxyRequest(request, await params);
 }
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
-  return handleProxyRequest(request, await params);
+  return trackedProxyRequest(request, await params);
+}
+
+/** Identity resolved inside handleProxyRequest, reported back for analytics. */
+type ProxyTelemetry = { clerkUserId?: string; proxyKeyId?: string };
+
+/**
+ * Captures one `proxy_request` PostHog event per pass-through call. Distinct id
+ * is the key owner's Clerk user id (same id the dashboard identifies), so API
+ * usage merges into the same PostHog person as their web activity. A 403 can be
+ * either an FGAC denial or an upstream Google 403 — the status is recorded
+ * as-is; the key/user attribution is what matters for usage analytics.
+ */
+async function trackedProxyRequest(request: NextRequest, params: { path: string[] }) {
+  const telemetry: ProxyTelemetry = {};
+  const started = Date.now();
+  const response = await handleProxyRequest(request, params, telemetry);
+
+  const fullPath = params.path.join('/');
+  const service = fullPath.includes('spreadsheets') ? 'sheets'
+    : /^drive\/v[23]\//.test(fullPath) ? 'drive'
+    : 'gmail';
+  const outcome = response.status < 400 ? 'success'
+    : response.status === 401 ? 'auth_failed'
+    : response.status === 403 ? 'denied'
+    : 'error';
+
+  captureServerEvent(telemetry.clerkUserId ?? 'anonymous-proxy', 'proxy_request', {
+    service,
+    method: request.method,
+    status: response.status,
+    outcome,
+    duration_ms: Date.now() - started,
+    proxy_key_id: telemetry.proxyKeyId,
+  });
+
+  return response;
 }
 
 /**
@@ -44,7 +81,7 @@ function extractSheetsSpreadsheetId(fullPath: string): string | null {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-async function handleProxyRequest(request: NextRequest, params: { path: string[] }) {
+async function handleProxyRequest(request: NextRequest, params: { path: string[] }, telemetry: ProxyTelemetry) {
   try {
     const authHeader = request.headers.get('authorization');
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -87,6 +124,9 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
     if (!dbUser) {
       return NextResponse.json({ error: 'User not found.' }, { status: 401 });
     }
+
+    telemetry.proxyKeyId = dbKey.id;
+    telemetry.clerkUserId = dbUser.clerkUserId;
 
     // ─── GOOGLE DRIVE PER-FILE ACCESS GUARD ──────────────────────────────────
     // Policy: never override Google's native API behavior for discovery —

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { db } from '@/db';
 import { users } from '@/db/schema';
 import { tombstoneUser } from '@/db/tombstoneUser';
+import { captureServerEvent } from '@/lib/posthogServer';
 
 /**
  * Clerk webhook receiver.
@@ -14,8 +15,13 @@ import { tombstoneUser } from '@/db/tombstoneUser';
  * and delegations behind, owned by an identity that no longer exists — and the
  * next sign-up with that address could inherit them.
  *
+ * Handles `user.created` by capturing `sign_up_completed` in PostHog — the
+ * completion side of the sign-up funnel (`sign_up_started` fires client-side on
+ * CTA click; the drop-off between the two is the abandoned-sign-up rate).
+ *
  * Configure in the Clerk dashboard: endpoint `/api/webhooks/clerk`, subscribed
- * to `user.deleted`, with the signing secret in CLERK_WEBHOOK_SIGNING_SECRET.
+ * to `user.deleted` AND `user.created`, with the signing secret in
+ * CLERK_WEBHOOK_SIGNING_SECRET.
  */
 export async function POST(req: NextRequest) {
   const secret = process.env.CLERK_WEBHOOK_SIGNING_SECRET;
@@ -33,12 +39,26 @@ export async function POST(req: NextRequest) {
 
   // Verify before trusting anything in the body — this endpoint is public and
   // an unverified `user.deleted` would be a free way to revoke someone's access.
-  let event: { type: string; data: { id?: string } };
+  let event: {
+    type: string;
+    data: { id?: string; email_addresses?: Array<{ email_address?: string }> };
+  };
   try {
     event = new Webhook(secret).verify(payload, headers) as typeof event;
   } catch (err) {
     console.error('[clerk-webhook] Signature verification failed:', err);
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  if (event.type === 'user.created') {
+    const newUserId = event.data?.id;
+    if (newUserId) {
+      const email = event.data?.email_addresses?.[0]?.email_address;
+      // Distinct id = Clerk user id, same as the dashboard's identify() call,
+      // so this merges into the same PostHog person and closes the funnel.
+      captureServerEvent(newUserId, 'sign_up_completed', email ? { $set: { email } } : {});
+    }
+    return NextResponse.json({ ok: true });
   }
 
   if (event.type !== 'user.deleted') {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import {
   ClerkProvider,
-  SignUpButton,
   Show,
   UserButton
 } from '@clerk/nextjs';
@@ -10,6 +9,8 @@ import './globals.css';
 import Link from 'next/link';
 import { PostHogProviderWrapper } from './providers';
 import SuspendedPostHogPageView from './PostHogPageView';
+import PostHogIdentify from './PostHogIdentify';
+import { SignUpCta } from './SignUpCta';
 import { NavLink } from './NavLink';
 
 const geist = Geist({
@@ -62,9 +63,7 @@ export default function RootLayout({
 
                   <div className="flex items-center gap-4 shrink-0">
                     <Show when="signed-out">
-                      <SignUpButton mode="modal" fallbackRedirectUrl="/dashboard" signInFallbackRedirectUrl="/dashboard">
-                        <button className="rounded-sm bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90">Sign Up</button>
-                      </SignUpButton>
+                      <SignUpCta location="nav" className="rounded-sm bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90">Sign Up</SignUpCta>
                     </Show>
                     <Show when="signed-in">
                       <UserButton
@@ -95,6 +94,7 @@ export default function RootLayout({
             <main className="flex-1">
               <PostHogProviderWrapper>
                 <SuspendedPostHogPageView />
+                <PostHogIdentify />
                 {children}
               </PostHogProviderWrapper>
             </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
-import { SignUpButton, Show } from '@clerk/nextjs';
+import { Show } from '@clerk/nextjs';
 import Link from 'next/link';
+import { SignUpCta } from './SignUpCta';
 import { Shield } from 'lucide-react';
 
 /* ─── Landing ─────────────────────────────────────────────────────────────
@@ -40,13 +41,7 @@ export default async function LandingPage() {
 
           <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:justify-center">
             <Show when="signed-out">
-              <SignUpButton
-                mode="modal"
-                fallbackRedirectUrl="/dashboard"
-                signInFallbackRedirectUrl="/dashboard"
-              >
-                <button className={heroCta}>Get Started — it&apos;s free</button>
-              </SignUpButton>
+              <SignUpCta location="hero" className={heroCta}>Get Started — it&apos;s free</SignUpCta>
             </Show>
             <Show when="signed-in">
               <Link href="/dashboard" className={`${heroCta} inline-block`}>
@@ -258,15 +253,12 @@ export default async function LandingPage() {
           Free for personal use. Connected in under a minute.
         </p>
         <Show when="signed-out">
-          <SignUpButton
-            mode="modal"
-            fallbackRedirectUrl="/dashboard"
-            signInFallbackRedirectUrl="/dashboard"
+          <SignUpCta
+            location="bottom_cta"
+            className="rounded-sm bg-primary px-8 py-3.5 text-[15px] font-semibold text-primary-foreground hover:opacity-90"
           >
-            <button className="rounded-sm bg-primary px-8 py-3.5 text-[15px] font-semibold text-primary-foreground hover:opacity-90">
-              Get Started
-            </button>
-          </SignUpButton>
+            Get Started
+          </SignUpCta>
         </Show>
         <Show when="signed-in">
           <Link

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -9,6 +9,19 @@ if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY && proc
     person_profiles: 'identified_only',
     capture_pageview: false // Disable automatic pageview capture, as we capture manually
   })
+
+  // All three Vercel environments report into the same PostHog project, so every
+  // event is tagged with its deployment tier — dashboards filter on
+  // environment = production to exclude local/preview QA traffic.
+  const hostname = window.location.hostname
+  posthog.register({
+    environment:
+      hostname === 'localhost' || hostname === '127.0.0.1'
+        ? 'development'
+        : hostname.endsWith('.vercel.app')
+          ? 'preview'
+          : 'production',
+  })
 }
 
 export function PostHogProviderWrapper({ children }: { children: React.ReactNode }) {

--- a/src/lib/posthogServer.ts
+++ b/src/lib/posthogServer.ts
@@ -1,0 +1,41 @@
+import { PostHog } from 'posthog-node';
+import { after } from 'next/server';
+
+let client: PostHog | null | undefined;
+
+function getClient(): PostHog | null {
+  if (client !== undefined) return client;
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  client = key && host ? new PostHog(key, { host, flushAt: 1, flushInterval: 0 }) : null;
+  return client;
+}
+
+/**
+ * Fire-and-forget server-side PostHog capture. Pass the Clerk user id as
+ * distinctId whenever one is known — the dashboard identifies with the same id,
+ * so server events merge into the same PostHog person. No-ops when PostHog is
+ * not configured (e.g. CI).
+ */
+export function captureServerEvent(
+  distinctId: string,
+  event: string,
+  properties: Record<string, unknown> = {},
+): void {
+  const ph = getClient();
+  if (!ph) return;
+  ph.capture({
+    distinctId,
+    event,
+    properties: {
+      environment: process.env.VERCEL_ENV ?? 'development',
+      ...properties,
+    },
+  });
+  try {
+    after(() => ph.flush().catch(() => {}));
+  } catch {
+    // No request scope (scripts, build) — flush best-effort instead.
+    void ph.flush().catch(() => {});
+  }
+}


### PR DESCRIPTION
## Why

PostHog showed a traffic jump that couldn't be attributed — every visitor was anonymous (no `identify()`), all three Vercel environments report into one PostHog project, and the MCP/proxy layer emitted no analytics at all.

## What

- **Identity consolidation**: `posthog.identify(clerkUserId)` on sign-in, `reset()` on sign-out (`PostHogIdentify.tsx`). PostHog persons now map 1:1 to Clerk users, so internal/QA accounts can be excluded via a cohort.
- **Environment tagging**: every client + server event carries `environment` (development / preview / production), so dashboards can filter out local and preview QA traffic.
- **MCP instrumentation**: `mcp_tool_call` event on every tool invocation (tool, client_id, outcome incl. policy denials, duration) via a single `registerTool` wrapper — future tools instrument automatically.
- **Proxy instrumentation**: `proxy_request` event per pass-through call (service, method, status, outcome, proxy key row id — never the secret).
- **Sign-up funnel**: `sign_up_started` on all sign-up CTAs (`SignUpCta.tsx`) + `sign_up_completed` from the Clerk `user.created` webhook. Funnel drop-off = abandoned sign-ups.
- **Docs**: `docs/analytics.md` — event catalog + playbook for separating QA from genuine traffic; implementation plan in `docs/implementation_plans/`.

## Operator follow-ups (post-merge)

1. Clerk dashboard (both instances): subscribe the `/api/webhooks/clerk` endpoint to `user.created`.
2. PostHog: create the "Internal / QA" cohort (QA + founder emails) and add `environment = production` filters to dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)