### PR TITLE
Partner handoff + push notifications (third-party app integration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ test/qa-envs/hosted-mcp/playwright-auth.js
 # it up). Nothing auto-loads .secrets/; scripts must read it explicitly.
 .secrets/
 docs/QA_Acceptance_Test/qa-results.json
+qa-webhook-log.json
+qa-webhook-fail

--- a/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
+++ b/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
@@ -156,3 +156,50 @@ curl -s $BASE_URL/api/mcp -X POST \
 > Tested via browser agent — same for all agents. See capability doc.
 
 - [ ] Light mode enforced regardless of OS preference
+
+## Capability: Partner Handoff (→ capabilities/11_partner_handoff.md)
+
+> Primary runbook for this capability. Prereq: `setup/04_partner_app_registration.md`.
+
+- Build the authorize URL from `qa-test-agents.json` → `qa_partner` (client_id,
+  PKCE challenge, redirect_uri `http://localhost:3000/oauth/callback`).
+- A1: bogus client_id via browser agent → error page.
+- A2–A4: browser agent as USER_A — interstitial render, Deny round-trip,
+  Approve → callback lands with `code` (the QA `/oauth/callback` route
+  auto-exchanges and saves `qa-token-<client_id>.json`).
+- A5: token file has refresh_token; `curl /api/mcp` `list_accounts` with the
+  access token → data, no pending. Refresh grant against the Clerk token URL.
+- A6: `curl -X POST /api/auth/partner-token -H "Authorization: Bearer <at>"` →
+  `sk_proxy_...`; then `curl /gmail/v1/users/me/messages?maxResults=1` with it.
+- A7: use a plain DCR client (`scripts/qa-dcr-setup.ts`) driven straight at the
+  Clerk authorize URL → MCP call returns pending.
+- A8: `gmail_send` via MCP + `messages/send` via proxy with the partner key →
+  both 403/denied.
+- A9: browser agent — partner badge on the connection card; Detach; re-try MCP
+  + proxy calls → refused.
+- A10: re-run `register-partner-app.ts` with a changed manifest; verify
+  connection's pinned `manifestVersion` and rules unchanged.
+
+## Capability: Push Notifications (→ capabilities/12_push_notifications.md)
+
+> Server-side capability — run ONCE per QA cycle from this runbook. Prereqs:
+> setup/04 complete, receiver + bridge running, dev server restarted after
+> `setup-gmail-push.ts` wrote env vars.
+
+- A1: after the cap-11 Approve, query the dashboard/DB state via
+  `get_my_permissions` + `qa-webhook-log.json` baseline; subscription active.
+- A2/A3: `gmail_send` a self-email to USER_A (whitelist it first or send via
+  Gmail API using the vaulted token per spike method); bridge drains; assert
+  the receiver log entry (signature_valid=true, ids-only payload).
+- A4: add label blacklist rule via dashboard; labeled email → no ping;
+  unlabeled control email → ping.
+- A5: re-run `setup-gmail-push.ts --apply` (re-arms nothing) or re-arm watch;
+  assert `enqueued=0` behavior on the arm-time notification.
+- A6: re-POST the last drained envelope with the bridge secret → `enqueued: 0`.
+- A7/A8: touch `qa-webhook-fail`; email; drain; call
+  `/api/cron/deliver-webhooks` to walk the ladder; verify dead + suspension;
+  remove flag, re-enable, verify recovery.
+- A9: age `watchExpiresAt`; GET `/api/cron/renew-watches`; verify advance.
+- A10: Detach via browser agent; email again → silence.
+- A11: unauthenticated POST to `/api/webhooks/gmail` → 401.
+- A12: `setup-gmail-push.ts --project dev-fgac-ai` dry run → all ✔.

--- a/docs/QA_Acceptance_Test/agents/02_claude_code_mcp.md
+++ b/docs/QA_Acceptance_Test/agents/02_claude_code_mcp.md
@@ -161,3 +161,14 @@ tmux send-keys -t fgac-qa "List my emails" Enter
 ```bash
 tmux kill-session -t fgac-qa
 ```
+
+## Capability: Partner Handoff (→ capabilities/11_partner_handoff.md)
+
+> Channel-inapplicable here: the handoff is a browser + REST surface, executed
+> once per cycle via agents/01_hosted_mcp.md. Record as skip with reason
+> "runs in hosted-mcp runbook".
+
+## Capability: Push Notifications (→ capabilities/12_push_notifications.md)
+
+> Channel-inapplicable here: server-side pipeline, executed once per cycle via
+> agents/01_hosted_mcp.md. Record as skip with reason "runs in hosted-mcp runbook".

--- a/docs/QA_Acceptance_Test/agents/03_claude_code_cli.md
+++ b/docs/QA_Acceptance_Test/agents/03_claude_code_cli.md
@@ -148,3 +148,14 @@ claude -p "Using the fgac skill, what email accounts can I access?" \
 ## Cleanup
 
 No tmux sessions to clean up. Results are saved to `test/qa-envs/cc-cli/evals/results/`.
+
+## Capability: Partner Handoff (→ capabilities/11_partner_handoff.md)
+
+> Channel-inapplicable here: the handoff is a browser + REST surface, executed
+> once per cycle via agents/01_hosted_mcp.md. Record as skip with reason
+> "runs in hosted-mcp runbook".
+
+## Capability: Push Notifications (→ capabilities/12_push_notifications.md)
+
+> Channel-inapplicable here: server-side pipeline, executed once per cycle via
+> agents/01_hosted_mcp.md. Record as skip with reason "runs in hosted-mcp runbook".

--- a/docs/QA_Acceptance_Test/agents/04_openclaw.md
+++ b/docs/QA_Acceptance_Test/agents/04_openclaw.md
@@ -119,6 +119,18 @@ curl -X POST http://localhost:18790/api/chat \
 
 > Tested via browser agent — same for all agents.
 
+## Capability: Partner Handoff (→ capabilities/11_partner_handoff.md)
+
+> Channel-inapplicable here: the handoff is a browser + REST surface, executed
+> once per cycle via agents/01_hosted_mcp.md. Record as skip with reason
+> "runs in hosted-mcp runbook".
+
+## Capability: Push Notifications (→ capabilities/12_push_notifications.md)
+
+> Channel-inapplicable here: server-side pipeline, executed once per cycle via
+> agents/01_hosted_mcp.md. Record as skip with reason "runs in hosted-mcp runbook".
+
+
 ---
 
 ## Cleanup

--- a/docs/QA_Acceptance_Test/capabilities/11_partner_handoff.md
+++ b/docs/QA_Acceptance_Test/capabilities/11_partner_handoff.md
@@ -1,0 +1,83 @@
+# Capability: Partner Handoff
+
+> Third-party apps registered in `partner_apps` hand their signed-in users to
+> FGAC's `/oauth/authorize` consent interstitial, receive OAuth credentials via
+> Clerk, and exchange them for the connection's proxy key. Implemented on branch
+> `claude/third-party-handoff-permissions-81dc96`; design in
+> `docs/implementation_plans/third-party-handoff-permissions_v6.md`.
+>
+> **Setup**: requires `setup/04_partner_app_registration.md` (registers the QA
+> partner app and records its credentials in `qa-test-agents.json`).
+>
+> **Channels**: A2–A4 and A9 are browser-agent assertions; the rest run via
+> curl. Primary runbook: `agents/01_hosted_mcp.md`. The other agent runbooks
+> mark this capability channel-inapplicable (the handoff is a browser + REST
+> surface, not an agent-runtime surface).
+
+## Assertions
+
+### A1: Unknown client_id rejected
+- GET `/oauth/authorize?client_id=bogus&redirect_uri=https://example.com/cb` (signed in)
+- **Expected**: "Unknown application" error page. No key, rule, or connection
+  row created; no redirect to the given redirect_uri.
+
+### A2: Consent interstitial renders registry data
+- GET `/oauth/authorize` with the QA partner app's client_id + registered
+  redirect_uri, signed in as USER_A
+- **Expected**: page shows partner name, permission summary derived from the
+  manifest (read-only email + notifications lines), a mailbox picker
+  defaulting to USER_A's address, Approve and Deny buttons. Nothing from the
+  query string is echoed except through registry validation.
+
+### A3: Deny provisions nothing
+- Click **Deny**
+- **Expected**: 303 to the partner redirect_uri with `error=access_denied` and
+  the original `state`. No proxy key, no rules, no connection row.
+
+### A4: Approve provisions everything in one step
+- Re-open the authorize URL, click **Approve**
+- **Expected**: browser lands on the partner redirect_uri with `code` + `state`
+  (Clerk's consent screen NEVER appears — the app is registered with
+  `consent_screen_enabled=false`). Dashboard/DB now show: a proxy key labeled
+  with the partner name; `key_email_access` for the selected mailbox; an
+  `agent_connections` row `approved`, bound to that key, with `partnerAppId`
+  and `manifestVersion` set.
+
+### A5: Code exchange yields working tokens immediately
+- Exchange the code at Clerk's token endpoint (PKCE verifier from setup)
+- **Expected**: access + refresh tokens returned; an MCP `list_accounts` call
+  with the access token returns data with NO pending-approval step; the
+  refresh_token grant returns a fresh (rotated) pair.
+
+### A6: Partner token exchange returns the proxy key
+- POST `/api/auth/partner-token` with `Authorization: Bearer <access token>`
+- **Expected**: `status: approved`, `sk_proxy_...` key, the selected mailbox in
+  `emails`. A REST proxy `gmail/v1/users/me/messages?maxResults=1` call with
+  that key succeeds.
+
+### A7: Interstitial bypass fails safe
+- Using a DCR client (NOT the partner app), or the partner client_id driven
+  straight at Clerk's own `/oauth/authorize` URL for a user who never saw the
+  FGAC interstitial: obtain tokens, call an MCP tool
+- **Expected**: connection is created `pending`; tool calls return the
+  awaiting-approval message. Silent token issuance NEVER implies provisioned
+  access. (Spike 1 finding — must stay true forever.)
+
+### A8: Read-only default enforced
+- With the partner's proxy key (manifest `access: read_only`, no rule
+  templates): attempt `gmail_send` via MCP and `messages/send` via REST proxy
+- **Expected**: both denied (deny-by-default send whitelist), reads still work.
+
+### A9: Dashboard shows partner provenance; Detach kills both paths
+- Dashboard → Connected Agents: the partner connection card shows a
+  "Partner · <name>" badge. Click **Detach**, then retry (a) an MCP tool call
+  with the OAuth token and (b) a REST proxy call with the proxy key
+- **Expected**: badge visible before; after detach both calls are refused
+  (blocked/pending — the key binding is dropped).
+
+### A10: Manifest bump cannot widen an existing grant
+- Re-run `scripts/register-partner-app.ts` for the QA partner with a changed
+  manifest (bumps `manifestVersion` in the registry)
+- **Expected**: the existing connection's `manifestVersion` is unchanged (still
+  the consented version); its key/rules are untouched. Rules for the
+  connection only change after a fresh consent pass.

--- a/docs/QA_Acceptance_Test/capabilities/12_push_notifications.md
+++ b/docs/QA_Acceptance_Test/capabilities/12_push_notifications.md
@@ -1,0 +1,91 @@
+# Capability: Push Notifications
+
+> Gmail `users.watch` → Pub/Sub → `/api/webhooks/gmail` → rule filter →
+> `webhook_deliveries` outbox → HMAC-signed thin ping to the partner webhook.
+> Design: `docs/implementation_plans/third-party-handoff-permissions_v6.md`
+> (Spike 4 Expanded).
+>
+> **Setup**: capability 11 approved connection with notifications granted;
+> `scripts/setup-gmail-push.ts --project dev-fgac-ai --apply` run;
+> `scripts/qa-webhook-receiver.ts` listening (its URL registered as the QA
+> partner's webhook_url); `scripts/qa-pubsub-bridge.ts` draining the dev pull
+> subscription (Pub/Sub cannot push to localhost).
+>
+> **Channels**: server-side capability — run once per QA cycle from the
+> hosted-MCP runbook (curl + scripts + browser agent for A7/A10 dashboard
+> checks), not repeated per agent runtime.
+
+## Assertions
+
+### A1: Consent creates subscription and arms watch
+- After capability 11 A4 (Approve with notifications in the manifest)
+- **Expected**: `notification_subscriptions` row for (connection, mailbox),
+  status `active`, `watchExpiresAt` ≈ 7 days out, `lastHistoryId` set.
+
+### A2: New email produces a signed thin ping
+- Send a test email to the watched mailbox; let the bridge drain
+- **Expected**: within 60s the QA receiver logs a POST with body
+  `{event: "new_email", connection_id, account, message_ids: [...]}`, headers
+  `X-FGAC-Signature` (HMAC valid against the partner webhook_secret),
+  `X-FGAC-Timestamp`, `X-FGAC-Delivery-Id`. The message id matches the sent
+  email, retrievable through the proxy with the partner key.
+
+### A3: Payload is IDs-only
+- Inspect the A2 ping body
+- **Expected**: no subject, snippet, body content, or sender address anywhere
+  in the payload — message ids and account only. (Product invariant: content
+  stays behind the proxy where rules re-check at fetch.)
+
+### A4: Rule-filtered silence
+- Add a `label_blacklist` rule (reuse the capability 05 label baseline) bound
+  to the partner key; send an email that carries that label on arrival (label
+  applied via filter or self-labeled thread); drain
+- **Expected**: NO ping for that message (webhook_deliveries has no row for
+  it). A concurrently sent unlabeled email IS pinged — proving selective
+  filtering, not breakage.
+
+### A5: Zero-diff notifications are tolerated
+- Re-arm the watch (`users.watch` publishes a test notification at arm time)
+- **Expected**: receiver gets no ping; `/api/webhooks/gmail` returns 200 with
+  `enqueued=0`; no error logs.
+
+### A6: Pub/Sub duplicates do not double-ping
+- Re-POST the same drained envelope to `/api/webhooks/gmail` (bridge replay)
+- **Expected**: 200, `enqueued=0` (unique (subscription, messageId) absorbed
+  it); receiver log shows no second ping for those delivery ids.
+
+### A7: Retry, backoff, and suspension on a failing receiver
+- Create the `qa-webhook-fail` flag file (receiver returns 500); send a test
+  email; drain; run the delivery cron repeatedly (call
+  `/api/cron/deliver-webhooks` directly, adjusting `nextAttemptAt` in test to
+  step the ladder)
+- **Expected**: delivery row cycles pending→delivering→pending with
+  `attempts` incrementing and `nextAttemptAt` following the 1m/5m/15m/1h/6h/24h
+  ladder; after max attempts the row goes `dead`; after 3 dead groups the
+  subscription is `suspended` and no further pings are attempted.
+
+### A8: Re-enable resumes delivery
+- Remove the fail flag; re-activate the subscription; send a new email; drain
+- **Expected**: new pings flow again (consecutiveFailures reset).
+
+### A9: Renewal cron re-arms watches
+- Null out / age `watchExpiresAt` on the subscription; GET `/api/cron/renew-watches`
+- **Expected**: `watchExpiresAt` advances ≈ 7 days; `lastHistoryId` is NOT
+  regressed.
+
+### A10: Detach tears notifications down
+- Detach the partner connection in the dashboard; send another email; drain
+- **Expected**: subscription `cancelled`, Gmail watch stopped (no new Pub/Sub
+  notifications for the mailbox once the pipeline drains), receiver logs no
+  new pings.
+
+### A11: Unauthenticated receiver POST rejected
+- POST a valid-shaped envelope to `/api/webhooks/gmail` with no OIDC token and
+  no (or wrong) `x-qa-bridge-secret`
+- **Expected**: HTTP 401; nothing enqueued.
+
+### A12: Push preflight is green
+- Run the push preflight (topic project vs Google client project check —
+  `scripts/setup-gmail-push.ts --project dev-fgac-ai` dry run shows all ✔)
+- **Expected**: topic exists, gmail-api-push publisher binding present,
+  `GMAIL_PUBSUB_TOPIC` in the environment matches the token's `azp` project.

--- a/docs/QA_Acceptance_Test/capabilities/README.md
+++ b/docs/QA_Acceptance_Test/capabilities/README.md
@@ -22,3 +22,7 @@
 | 06 | `06_connection_lifecycle.md` | Pending → approve → block → unblock → nickname |
 | 07 | `07_key_lifecycle.md` | Revoke, roll, cross-user isolation |
 | 08 | `08_strict_light_mode.md` | No dark mode leaks regardless of OS preference |
+| 09 | `09_sheets_management.md` | Per-spreadsheet read/write/block rules |
+| 10 | `10_raw_google_api.md` | Deny-by-default raw Google API pair |
+| 11 | `11_partner_handoff.md` | Partner OAuth handoff, consent provisioning, bypass fail-safe |
+| 12 | `12_push_notifications.md` | Watch/PubSub pipeline, rule-filtered thin pings, retry/suspend |

--- a/docs/QA_Acceptance_Test/setup/04_partner_app_registration.md
+++ b/docs/QA_Acceptance_Test/setup/04_partner_app_registration.md
@@ -1,0 +1,74 @@
+# Setup 04: Partner App Registration
+
+> Registers the QA partner application used by capabilities 11 and 12.
+> Idempotent — re-running updates the existing registration. Part of
+> `/qa-setup` after 01–03.
+
+## Steps
+
+1. **Start the QA webhook receiver** (it must own a port before registration so
+   the webhook URL is real):
+
+   ```bash
+   npx tsx scripts/qa-webhook-receiver.ts --port 4571
+   ```
+
+   (Run it in the background for the QA session; secret comes in step 3.)
+
+2. **Register the partner app** against the dev Clerk instance + branch DB:
+
+   ```bash
+   npx tsx scripts/register-partner-app.ts \
+     --name "QA Spike Partner" \
+     --redirect-uri http://localhost:3000/oauth/callback \
+     --webhook-url http://localhost:4571/webhook \
+     --notifications
+   ```
+
+3. **Record the credentials** the script prints into `qa-test-agents.json`
+   (gitignored) under the key `qa_partner`, adding a PKCE pair (generate as in
+   `scripts/qa-dcr-setup.ts`):
+
+   ```json
+   {
+     "qa_partner": {
+       "client_id": "…",
+       "client_secret": "…",
+       "webhook_secret": "…",
+       "pkce": { "verifier": "…", "challenge": "…" }
+     }
+   }
+   ```
+
+   Restart the receiver with `FGAC_WEBHOOK_SECRET=<webhook_secret>` so it can
+   validate signatures.
+
+4. **Provision push infra** (idempotent; topic + binding already exist in dev):
+
+   ```bash
+   npx tsx scripts/setup-gmail-push.ts --project dev-fgac-ai --apply
+   ```
+
+   This also writes `GMAIL_PUBSUB_TOPIC` and `QA_BRIDGE_SECRET` into
+   `.env.local` (script-managed, like `db:branch`). **Restart the dev server**
+   afterwards so the new env vars load.
+
+5. **Start the Pub/Sub bridge** for the QA session:
+
+   ```bash
+   npx tsx scripts/qa-pubsub-bridge.ts
+   ```
+
+## Verification
+
+- `register-partner-app.ts` re-run prints "Updated partner app" (idempotent).
+- `setup-gmail-push.ts --project dev-fgac-ai` dry run shows all ✔.
+- `curl -s -X POST http://localhost:3000/api/webhooks/gmail` (no auth) → 401.
+
+## Teardown notes
+
+- The QA partner registration persists across cycles (dev Clerk + branch DB).
+  A fresh Neon branch loses the `partner_apps` row while the Clerk app
+  survives — step 2 handles that (it re-links by name).
+- Kill the receiver/bridge with the session; remove `qa-webhook-fail` if a
+  failure-injection test left it behind.

--- a/docs/distribution_architecture.md
+++ b/docs/distribution_architecture.md
@@ -14,6 +14,7 @@ We ship **4 distinct packages**, each designed for a different client and use ca
 | 2 | **OpenClaw Skill** | OAuth baked into local scripts | `SKILL.md` + local scripts (`auth.js`, `gmail.js`, etc.) | OpenClaw |
 | 3 | **Claude Code MCP Plugin** | OAuth (via hosted MCP server) | `claude mcp add` command | Claude Code (MCP users) |
 | 4 | **Claude Code CLI Plugin** | OAuth baked into local scripts (shared w/ #2) | `SKILL.md` + local scripts | Claude Code (CLI users) |
+| 5 | **Partner Handoff** | Pre-registered OAuth app → FGAC consent interstitial (consent-time provisioning, no pending step) | Nothing — `/oauth/authorize` + `/api/auth/partner-token`; optional signed webhooks | Third-party web apps with server-side agents |
 
 ## Key Design Principles
 
@@ -116,3 +117,31 @@ deny-by-default in `src/app/api/mcp/googleApiPolicy.ts`:
 | Dashboard connections | `src/app/dashboard/ConnectionsPanel.tsx` |
 | Connections API | `src/app/api/connections/route.ts` |
 
+
+## Partner Handoff (Package #5)
+
+Third-party apps registered in the `partner_apps` table (via
+`scripts/register-partner-app.ts`, per Clerk instance) hand signed-in users to
+FGAC's consent interstitial:
+
+```
+Partner site → fgac.ai/oauth/authorize?client_id=…
+  → [Clerk session check → sign-in if needed]
+  → FGAC consent (manifest-rendered permissions + mailbox picker)
+  → Approve = provisioning transaction (key + email access + rule copies +
+    approved connection pinned to manifestVersion [+ notification subscription])
+  → 303 into Clerk /oauth/authorize (consent_screen_enabled=false → silent code)
+  → partner callback → token exchange → optional /api/auth/partner-token → sk_proxy_
+```
+
+Bypassing the interstitial (driving Clerk's authorize directly) yields tokens
+whose connection is pending-by-default — tools refuse until dashboard approval.
+
+**Push notifications** (optional, manifest `notifications`): Gmail `users.watch`
+→ Pub/Sub (`GMAIL_PUBSUB_TOPIC`, same GCP project as the Google OAuth client —
+dev `dev-fgac-ai`, prod `fine-grain-access-control`) → `/api/webhooks/gmail`
+(OIDC-verified) → read-rule filter → `webhook_deliveries` outbox → HMAC-signed
+thin ping (message IDs only) → partner webhook. Crons: delivery drainer
+(per-minute) + watch renewal (daily) in `vercel.json`. Infra:
+`scripts/setup-gmail-push.ts`. Design + spike evidence:
+`docs/implementation_plans/third-party-handoff-permissions_v6.md`.

--- a/docs/implementation_plans/third-party-handoff-permissions_v1.md
+++ b/docs/implementation_plans/third-party-handoff-permissions_v1.md
@@ -1,0 +1,205 @@
+# Third-Party App Handoff: Auth, Default Permissions, and Push Notifications
+
+> Strategy for letting third-party websites/agents (canonical example: "Data Driven Job
+> Search", DDJS) hand their signed-in users off to FGAC, receive scoped credentials with
+> app-declared default permissions, and get push notifications for new emails.
+>
+> Branch: `claude/third-party-handoff-permissions-81dc96` — v1 (strategy, pre-implementation)
+
+## The Scenario
+
+DDJS runs a server-side agent that categorizes every new email a user receives into an
+interview stage and extracts action items. It needs:
+
+1. A signed-in DDJS user handed off to FGAC (account creation if needed) and back.
+2. FGAC-side **default permissions for the DDJS agent role** (read-only Gmail, no send,
+   no delete) applied without the user hand-assembling rules.
+3. Credentials returned to DDJS's **server** (not a browser/MCP client) that work with
+   the existing proxy/MCP surfaces.
+4. **Push notifications** to DDJS when new mail arrives, filtered by the same rules.
+
+## What Exists Today (and what's missing)
+
+| Need | Today | Gap |
+|------|-------|-----|
+| Third-party OAuth into FGAC | Clerk DCR + `agent_connections` pending-approval flow (built for MCP clients) | Approval is a *separate dashboard visit* where the user manually picks a proxy key; no inline consent, no way back to the app |
+| Default permissions per app | `access_rules` + `key_rule_assignments` exist, fully manual | No concept of a **registered app** with a declared permission manifest/template |
+| Server credentials | `sk_proxy_...` keys + REST proxy; `/api/auth/cli-token` already exchanges an OAuth token for a proxy key | No partner-facing token endpoint; keys are provisioned manually in the dashboard |
+| Push notifications | Nothing (no `users.watch`, no Pub/Sub, no webhook delivery) | Entire subsystem is net-new |
+
+The good news: 1–3 are mostly **recomposition of existing primitives**. Only 4 is a new
+subsystem.
+
+## Piece 1 — Partner App Registry with Permission Manifests ("Agent Roles")
+
+The core new concept. A third-party app registers with FGAC once (initially by us,
+manually — this is also the review/verification gate) and gets:
+
+- An OAuth `client_id` (Clerk OAuth application — same machinery the MCP DCR flow uses,
+  but pre-registered rather than dynamic).
+- A **permission manifest**: the app's requested "role", declared as a template of
+  `access_rules` plus capability flags. For DDJS:
+
+```jsonc
+{
+  "app": "Data Driven Job Search",
+  "logo_url": "...",
+  "requested": {
+    "services": ["gmail"],
+    "access": "read_only",            // template: block send + all mutations
+    "rule_templates": [
+      { "service": "gmail", "actionType": "send_whitelist", "regexPattern": "^$" } // send nothing
+    ],
+    "notifications": { "trigger": "new_email" }
+  },
+  "webhook_url": "https://api.ddjs.com/fgac/webhook",   // verified at registration
+  "redirect_uris": ["https://ddjs.com/fgac/callback"]
+}
+```
+
+**Consent-time provisioning**: when a user approves the app, FGAC auto-creates in one
+transaction what the user builds by hand today:
+
+1. A proxy key labeled `"Data Driven Job Search"`.
+2. `key_email_access` rows for the account(s) the user selected on the consent screen.
+3. Copies of the manifest's rule templates as `access_rules` bound to that key via
+   `key_rule_assignments` (copies, not references — the user can then tighten them per
+   normal, and a later manifest change by the app cannot silently widen existing grants).
+4. The `agent_connections` row, already `approved` and bound to the key.
+5. (If requested + granted) a `notification_subscriptions` row per account.
+
+Manifest changes that *broaden* access require re-consent: bump a `manifest_version`
+on the registry row; connections pinned to an older version keep old permissions until
+the user re-approves.
+
+New schema: `partner_apps` (clientId, name, manifest JSON, manifestVersion, webhookUrl,
+webhookSecret, status). Existing tables carry everything else.
+
+## Piece 2 — The Handoff Flow (lowest-friction path)
+
+Standard OAuth 2.0 authorization-code + PKCE, with Clerk as the identity/token layer
+(as today) and a new **FGAC consent interstitial** replacing the manual dashboard
+approval:
+
+```
+DDJS "Connect your Gmail" button
+  → https://fgac.ai/oauth/authorize?client_id=<ddjs>&state=...&code_challenge=...
+  → [no Clerk session] Clerk sign-in with Google → Google consent (Gmail scope)
+       ← this is the ONLY Google screen; FGAC becomes the token holder via Clerk
+  → FGAC consent page (server-renders partner_apps manifest):
+       "Data Driven Job Search wants to:
+          • Read email in [account picker: kenyesh@gmail.com ▾]  (read-only — cannot send or delete)
+          • Be notified when new email arrives
+        [Approve] [Deny]"
+  → Approve = one click → provisioning transaction (Piece 1) → redirect to
+    https://ddjs.com/fgac/callback?code=...&state=...
+  → DDJS server exchanges code at the token endpoint
+```
+
+Click count: **existing FGAC user = 1 screen** (consent). New user = Google account
+chooser + Google consent + FGAC consent ≈ 3 screens, all standard-feeling. No dashboard
+visit, no manual key creation, no rule configuration.
+
+Why keep Clerk underneath: the MCP flow already proves out Clerk DCR → token → userId
+resolution, discovery endpoints exist, and Google token custody stays exactly where it
+is (Clerk as token vault — the fake-token principle is preserved; DDJS never sees a
+Google credential).
+
+## Piece 3 — Credentials DDJS Receives
+
+Two-step, both reusing existing machinery:
+
+1. **Token endpoint** (Clerk's, as today): authorization code → access token + refresh
+   token. The MCP server already resolves `OAuth token → (userId, clientId) →
+   agent_connections → proxy_key`, so these tokens work against `/api/mcp` immediately.
+2. **Optional key exchange** for the REST proxy: a partner-facing sibling of the
+   existing `/api/auth/cli-token` — `POST /api/auth/partner-token` with the OAuth
+   token returns the connection's `sk_proxy_...` for direct
+   `gmail.fgac.ai/gmail/v1/...` calls with off-the-shelf Google SDKs (Prong 1).
+
+DDJS stores per-user: `{ refresh_token or proxy_key, connection_id }`. Revocation
+story is already built: user blocks the connection or revokes the key in the dashboard
+and both surfaces die.
+
+Recommendation: steer partners to the **OAuth-token path** as primary (rotatable,
+standard, auditable per-connection) and treat the raw proxy key as the escape hatch for
+SDK-endpoint-override users.
+
+## Piece 4 — Push Notifications (net-new subsystem)
+
+Gmail's push model: `users.watch` → Google Cloud **Pub/Sub topic** → HTTPS push to us →
+we fan out to partners. FGAC sits in the middle, which is precisely the product: the
+partner gets notified only about mail its rules let it see.
+
+```
+Gmail ── users.watch ──▶ Pub/Sub topic ── push ──▶ POST /api/webhooks/gmail  (verify OIDC token from Google)
+                                                        │  {emailAddress, historyId}
+                                                        ▼
+                                          history.list(since lastHistoryId)   [owner's Clerk Google token]
+                                                        │  new message IDs
+                                                        ▼
+                                          For each subscription on that account:
+                                            apply the bound key's READ RULES to each message
+                                            (label/sender blacklists — same code path as gmail_read)
+                                                        │  surviving IDs only
+                                                        ▼
+                                          POST partner webhook_url   (HMAC-signed, thin payload)
+                                          { connection_id, account, message_ids: [...], event: "new_email" }
+```
+
+Design decisions:
+
+- **Thin pings, not payloads.** The webhook carries message IDs only; DDJS fetches
+  content back through the proxy with its own credentials, where rules are enforced
+  again at read time. This keeps FGAC out of the business of pushing email bodies to
+  third parties, makes the webhook low-sensitivity, and means a mid-flight rule change
+  is honored at fetch.
+- **Rule-filtered notification.** If the user blacklists a label/sender, DDJS is not
+  even *told* those messages exist. This is the differentiating feature — notification
+  as an access-controlled surface, not a firehose.
+- **Watch lifecycle**: `users.watch` expires after 7 days → daily cron (Vercel cron)
+  re-arms all active subscriptions; store `lastHistoryId` per subscription;
+  `historyId` gaps (expired history) fall back to a `messages.list` reconciliation.
+- **Delivery semantics**: at-least-once, HMAC-SHA256 signature header with the app's
+  `webhookSecret`, exponential-backoff retries, auto-disable + dashboard flag after N
+  consecutive failures. `webhook_deliveries` table for the audit trail ("DDJS was
+  notified about 42 messages this week" belongs in the user's dashboard).
+- **One topic, many accounts**: a single Pub/Sub topic; the notification names the
+  account, we route by `emailAddress → notification_subscriptions`.
+
+New schema: `notification_subscriptions` (connectionId, targetEmail, lastHistoryId,
+watchExpiresAt, status), `webhook_deliveries` (subscriptionId, messageIds, status,
+attempts, timestamps).
+
+Prerequisite: a GCP project with Pub/Sub + granting `gmail-api-push@system.gserviceaccount.com`
+publish rights on the topic. Note `users.watch` must be called with the *user's* OAuth
+token (from Clerk) — scope-wise `gmail.readonly` suffices, which we already hold.
+
+## Security Notes
+
+- **Confused deputy / CSRF**: `state` + PKCE mandatory; consent page binds to the
+  authenticated Clerk session.
+- **No silent escalation**: manifest is copied at consent; broadening requires
+  re-consent (manifest_version pinning).
+- **Webhook SSRF/exfil**: webhook URLs are registered and verified at app registration
+  (challenge round-trip), never taken from runtime requests; reject private-range hosts.
+- **Fake-token principle intact**: partners receive FGAC credentials only; Google
+  tokens never leave Clerk custody.
+- **Registry as trust gate**: manual app registration doubles as app review; the
+  consent screen renders only registry data, never client-supplied strings.
+
+## Sequencing
+
+**Phase 1 — Handoff + default permissions** (recomposition, ~all existing infra):
+`partner_apps` table + manifest format → consent page (`/oauth/authorize` interstitial)
+→ provisioning transaction → partner token exchange endpoint → dashboard shows partner
+connections like agent connections today.
+*Fallback that works day one: DDJS polls `gmail_list` on an interval — notifications are
+an optimization, not a blocker for the integration.*
+
+**Phase 2 — Push notifications**: Pub/Sub topic + `/api/webhooks/gmail` receiver →
+subscription provisioning at consent → watch-renewal cron → HMAC webhook dispatcher
+with retries → delivery audit in dashboard.
+
+**Phase 3 — Self-serve registry** (later): partner-facing app registration UI with a
+review queue, once more than a handful of partners exist.

--- a/docs/implementation_plans/third-party-handoff-permissions_v2.md
+++ b/docs/implementation_plans/third-party-handoff-permissions_v2.md
@@ -1,0 +1,300 @@
+# Third-Party App Handoff: Auth, Default Permissions, and Push Notifications
+
+> Strategy for letting third-party websites/agents (canonical example: "Data Driven Job
+> Search", DDJS) hand their signed-in users off to FGAC, receive scoped credentials with
+> app-declared default permissions, and get push notifications for new emails.
+>
+> Branch: `claude/third-party-handoff-permissions-81dc96` — v2 (strategy, pre-implementation)
+>
+> **v2 changes:** added the De-risking Spikes section (top of doc); corrected the DDJS
+> manifest example — send is already deny-by-default when no `send_whitelist` rule
+> exists (`src/app/api/proxy/[...path]/route.ts` §5), so a read-only role needs no rule
+> templates at all.
+
+## De-risking Spikes (run before committing to this plan)
+
+Ranked by how much of the plan they can invalidate. Each is time-boxed and has a
+concrete pass/fail question.
+
+### Spike 1 — Can Clerk be the OAuth AS *and* let us own consent? (~1 day) — HIGHEST
+
+The plan's Piece 2 assumes we can put an FGAC consent interstitial inside a Clerk-issued
+OAuth flow. Nothing in the codebase proves this; the MCP flow uses Clerk's *own* consent
+screen and defers approval to a later dashboard visit. Unknowns:
+
+1. Can a pre-registered Clerk OAuth application have Clerk's consent screen **skipped or
+   customized**? If not, users see two consent screens (Clerk's generic one + ours) —
+   real friction, and possibly confusing enough to kill the UX claim of "1 screen for
+   existing users".
+2. If we front the flow (`fgac.ai/oauth/authorize` → our consent → redirect into Clerk's
+   authorize URL → Clerk redirects straight to the partner), does the **bypass fail
+   safe**? A partner (or attacker) hitting Clerk's authorize URL directly must end up
+   with a *pending* connection (today's MCP behavior), never a provisioned one. Verify
+   empirically.
+3. Do Clerk OAuth apps issue **refresh tokens** to confidential clients, and what are
+   the token lifetimes? (QA callback code suggests yes; confirm on a pre-registered app,
+   not just DCR.)
+4. Fallback decision if (1) fails: FGAC issues its own authorization codes and tokens
+   (we become the AS, Clerk is identity only). That changes MCP token validation
+   (`verifyClerkToken` in `src/app/api/mcp/route.ts`) and is a materially bigger build —
+   we need to know which world we're in before writing the implementation plan.
+
+**Method:** register a dummy OAuth app in the dev Clerk instance, wire a throwaway
+partner callback, walk the full flow with a QA account.
+**Pass:** one-consent-screen flow demonstrated end-to-end with refresh token issued and
+direct-authorize bypass landing in `pending`.
+
+### Spike 2 — Gmail `users.watch` + Pub/Sub with Clerk-vaulted tokens (~1 day) — HIGH
+
+Gmail push has a sharp, poorly-documented constraint: **the Pub/Sub topic must live in
+the same GCP project as the OAuth client that authorized the token** (watch calls fail
+with `Invalid topicName` otherwise). Consequences to verify:
+
+1. **Production**: prod Clerk uses our custom Google OAuth client → topic goes in that
+   GCP project. Confirm which project owns the prod client and that we can create the
+   topic + grant `gmail-api-push@system.gserviceaccount.com` publisher there.
+2. **Development**: if the dev Clerk instance uses Clerk's *shared* Google credentials,
+   `users.watch` cannot work against our topic at all — dev/QA would need custom Google
+   credentials configured in the dev Clerk instance first. Check what the dev instance
+   uses today; this gates all local/preview QA of Phase 2.
+3. End-to-end latency and shape: watch → send test email to USER_A → Pub/Sub push
+   arrives at a dev endpoint → `history.list(startHistoryId)` returns the new message.
+   Also probe `historyId` expiry behavior (Google only retains ~a week) to validate the
+   reconciliation-fallback design.
+
+**Method:** GCP topic + push subscription to a dev tunnel; pull USER_A's Google token
+via Clerk (the MCP `getGoogleToken` path); call watch; email the account.
+**Pass:** notification received and diffed to concrete message IDs using only
+Clerk-held tokens.
+
+### Spike 3 — Google verification posture: unverified-app screen + 100-user cap (~half day, research not code) — HIGH business risk
+
+`gmail.readonly` is a **restricted scope**. Until FGAC passes Google verification +
+CASA assessment: (a) every DDJS user hitting our Google consent sees the
+"Google hasn't verified this app" warning **inside the partner's onboarding funnel** —
+a conversion killer we'd be imposing on partners; (b) restricted-scope grants are
+capped at **100 users** — a hard scaling wall for a B2C partner. (The waitlist even
+asks `comfortable_with_unverified_app` — this risk is known for direct users, but a
+partner funnel raises the stakes.)
+
+**Answer before committing:** current verification status; CASA tier, lab cost, and
+realistic timeline; whether Phase 1 launches partner-facing before or after
+verification. This may resequence the roadmap (verification is weeks-to-months of lead
+time and should likely start *now*, in parallel, regardless).
+
+### Spike 4 — Webhook delivery mechanics on Vercel serverless (~half day, design) — MEDIUM
+
+The plan promises at-least-once delivery with exponential backoff and auto-disable.
+Vercel functions have no durable queue or long-running workers. Decide the mechanism
+before Phase 2 planning: DB-backed outbox drained by Vercel cron (fits existing stack;
+cron minimum granularity limits retry latency) vs. an external queue (QStash/Upstash —
+new dependency). Also settle idempotency: Pub/Sub is at-least-once, so the
+`webhook_deliveries` outbox needs dedup on `(subscription, historyId)`.
+**Pass:** a one-page decision with the retry/backoff/disable state machine mapped onto
+the chosen mechanism.
+
+### Verified during strategy review (no spike needed)
+
+- **Read-only role expressibility**: send is deny-by-default absent a whitelist rule
+  (proxy §5); `google_api_modify` exposes only `messages/send` and denies unparseable
+  recipients; DELETE isn't exposed on MCP and trash/emptyTrash are hard-blocked on the
+  proxy. A no-rules key is already read-only.
+- **Token→key resolution chain** for partner servers: `verifyClerkToken` → connection →
+  key already works (MCP), and `/api/auth/cli-token` proves the OAuth-token→proxy-key
+  exchange pattern.
+
+## The Scenario
+
+DDJS runs a server-side agent that categorizes every new email a user receives into an
+interview stage and extracts action items. It needs:
+
+1. A signed-in DDJS user handed off to FGAC (account creation if needed) and back.
+2. FGAC-side **default permissions for the DDJS agent role** (read-only Gmail, no send,
+   no delete) applied without the user hand-assembling rules.
+3. Credentials returned to DDJS's **server** (not a browser/MCP client) that work with
+   the existing proxy/MCP surfaces.
+4. **Push notifications** to DDJS when new mail arrives, filtered by the same rules.
+
+## What Exists Today (and what's missing)
+
+| Need | Today | Gap |
+|------|-------|-----|
+| Third-party OAuth into FGAC | Clerk DCR + `agent_connections` pending-approval flow (built for MCP clients) | Approval is a *separate dashboard visit* where the user manually picks a proxy key; no inline consent, no way back to the app |
+| Default permissions per app | `access_rules` + `key_rule_assignments` exist, fully manual | No concept of a **registered app** with a declared permission manifest/template |
+| Server credentials | `sk_proxy_...` keys + REST proxy; `/api/auth/cli-token` already exchanges an OAuth token for a proxy key | No partner-facing token endpoint; keys are provisioned manually in the dashboard |
+| Push notifications | Nothing (no `users.watch`, no Pub/Sub, no webhook delivery) | Entire subsystem is net-new |
+
+The good news: 1–3 are mostly **recomposition of existing primitives**. Only 4 is a new
+subsystem.
+
+## Piece 1 — Partner App Registry with Permission Manifests ("Agent Roles")
+
+The core new concept. A third-party app registers with FGAC once (initially by us,
+manually — this is also the review/verification gate) and gets:
+
+- An OAuth `client_id` (Clerk OAuth application — same machinery the MCP DCR flow uses,
+  but pre-registered rather than dynamic).
+- A **permission manifest**: the app's requested "role", declared as a template of
+  `access_rules` plus capability flags. For DDJS:
+
+```jsonc
+{
+  "app": "Data Driven Job Search",
+  "logo_url": "...",
+  "requested": {
+    "services": ["gmail"],
+    "access": "read_only",            // no send whitelist rule = send denied by default (proxy §5)
+    "rule_templates": [],             // read-only needs none; write-capable apps declare whitelists here
+    "notifications": { "trigger": "new_email" }
+  },
+  "webhook_url": "https://api.ddjs.com/fgac/webhook",   // verified at registration
+  "redirect_uris": ["https://ddjs.com/fgac/callback"]
+}
+```
+
+**Consent-time provisioning**: when a user approves the app, FGAC auto-creates in one
+transaction what the user builds by hand today:
+
+1. A proxy key labeled `"Data Driven Job Search"`.
+2. `key_email_access` rows for the account(s) the user selected on the consent screen.
+3. Copies of the manifest's rule templates as `access_rules` bound to that key via
+   `key_rule_assignments` (copies, not references — the user can then tighten them per
+   normal, and a later manifest change by the app cannot silently widen existing grants).
+4. The `agent_connections` row, already `approved` and bound to the key.
+5. (If requested + granted) a `notification_subscriptions` row per account.
+
+Manifest changes that *broaden* access require re-consent: bump a `manifest_version`
+on the registry row; connections pinned to an older version keep old permissions until
+the user re-approves.
+
+New schema: `partner_apps` (clientId, name, manifest JSON, manifestVersion, webhookUrl,
+webhookSecret, status). Existing tables carry everything else.
+
+## Piece 2 — The Handoff Flow (lowest-friction path)
+
+Standard OAuth 2.0 authorization-code + PKCE, with Clerk as the identity/token layer
+(as today) and a new **FGAC consent interstitial** replacing the manual dashboard
+approval:
+
+```
+DDJS "Connect your Gmail" button
+  → https://fgac.ai/oauth/authorize?client_id=<ddjs>&state=...&code_challenge=...
+  → [no Clerk session] Clerk sign-in with Google → Google consent (Gmail scope)
+       ← this is the ONLY Google screen; FGAC becomes the token holder via Clerk
+  → FGAC consent page (server-renders partner_apps manifest):
+       "Data Driven Job Search wants to:
+          • Read email in [account picker: kenyesh@gmail.com ▾]  (read-only — cannot send or delete)
+          • Be notified when new email arrives
+        [Approve] [Deny]"
+  → Approve = one click → provisioning transaction (Piece 1) → redirect to
+    https://ddjs.com/fgac/callback?code=...&state=...
+  → DDJS server exchanges code at the token endpoint
+```
+
+Click count: **existing FGAC user = 1 screen** (consent). New user = Google account
+chooser + Google consent + FGAC consent ≈ 3 screens, all standard-feeling. No dashboard
+visit, no manual key creation, no rule configuration.
+
+Why keep Clerk underneath: the MCP flow already proves out Clerk DCR → token → userId
+resolution, discovery endpoints exist, and Google token custody stays exactly where it
+is (Clerk as token vault — the fake-token principle is preserved; DDJS never sees a
+Google credential).
+
+## Piece 3 — Credentials DDJS Receives
+
+Two-step, both reusing existing machinery:
+
+1. **Token endpoint** (Clerk's, as today): authorization code → access token + refresh
+   token. The MCP server already resolves `OAuth token → (userId, clientId) →
+   agent_connections → proxy_key`, so these tokens work against `/api/mcp` immediately.
+2. **Optional key exchange** for the REST proxy: a partner-facing sibling of the
+   existing `/api/auth/cli-token` — `POST /api/auth/partner-token` with the OAuth
+   token returns the connection's `sk_proxy_...` for direct
+   `gmail.fgac.ai/gmail/v1/...` calls with off-the-shelf Google SDKs (Prong 1).
+
+DDJS stores per-user: `{ refresh_token or proxy_key, connection_id }`. Revocation
+story is already built: user blocks the connection or revokes the key in the dashboard
+and both surfaces die.
+
+Recommendation: steer partners to the **OAuth-token path** as primary (rotatable,
+standard, auditable per-connection) and treat the raw proxy key as the escape hatch for
+SDK-endpoint-override users.
+
+## Piece 4 — Push Notifications (net-new subsystem)
+
+Gmail's push model: `users.watch` → Google Cloud **Pub/Sub topic** → HTTPS push to us →
+we fan out to partners. FGAC sits in the middle, which is precisely the product: the
+partner gets notified only about mail its rules let it see.
+
+```
+Gmail ── users.watch ──▶ Pub/Sub topic ── push ──▶ POST /api/webhooks/gmail  (verify OIDC token from Google)
+                                                        │  {emailAddress, historyId}
+                                                        ▼
+                                          history.list(since lastHistoryId)   [owner's Clerk Google token]
+                                                        │  new message IDs
+                                                        ▼
+                                          For each subscription on that account:
+                                            apply the bound key's READ RULES to each message
+                                            (label/sender blacklists — same code path as gmail_read)
+                                                        │  surviving IDs only
+                                                        ▼
+                                          POST partner webhook_url   (HMAC-signed, thin payload)
+                                          { connection_id, account, message_ids: [...], event: "new_email" }
+```
+
+Design decisions:
+
+- **Thin pings, not payloads.** The webhook carries message IDs only; DDJS fetches
+  content back through the proxy with its own credentials, where rules are enforced
+  again at read time. This keeps FGAC out of the business of pushing email bodies to
+  third parties, makes the webhook low-sensitivity, and means a mid-flight rule change
+  is honored at fetch.
+- **Rule-filtered notification.** If the user blacklists a label/sender, DDJS is not
+  even *told* those messages exist. This is the differentiating feature — notification
+  as an access-controlled surface, not a firehose.
+- **Watch lifecycle**: `users.watch` expires after 7 days → daily cron (Vercel cron)
+  re-arms all active subscriptions; store `lastHistoryId` per subscription;
+  `historyId` gaps (expired history) fall back to a `messages.list` reconciliation.
+- **Delivery semantics**: at-least-once, HMAC-SHA256 signature header with the app's
+  `webhookSecret`, exponential-backoff retries, auto-disable + dashboard flag after N
+  consecutive failures. `webhook_deliveries` table for the audit trail ("DDJS was
+  notified about 42 messages this week" belongs in the user's dashboard).
+- **One topic, many accounts**: a single Pub/Sub topic; the notification names the
+  account, we route by `emailAddress → notification_subscriptions`.
+
+New schema: `notification_subscriptions` (connectionId, targetEmail, lastHistoryId,
+watchExpiresAt, status), `webhook_deliveries` (subscriptionId, messageIds, status,
+attempts, timestamps).
+
+Prerequisite: a GCP project with Pub/Sub + granting `gmail-api-push@system.gserviceaccount.com`
+publish rights on the topic. Note `users.watch` must be called with the *user's* OAuth
+token (from Clerk) — scope-wise `gmail.readonly` suffices, which we already hold.
+
+## Security Notes
+
+- **Confused deputy / CSRF**: `state` + PKCE mandatory; consent page binds to the
+  authenticated Clerk session.
+- **No silent escalation**: manifest is copied at consent; broadening requires
+  re-consent (manifest_version pinning).
+- **Webhook SSRF/exfil**: webhook URLs are registered and verified at app registration
+  (challenge round-trip), never taken from runtime requests; reject private-range hosts.
+- **Fake-token principle intact**: partners receive FGAC credentials only; Google
+  tokens never leave Clerk custody.
+- **Registry as trust gate**: manual app registration doubles as app review; the
+  consent screen renders only registry data, never client-supplied strings.
+
+## Sequencing
+
+**Phase 1 — Handoff + default permissions** (recomposition, ~all existing infra):
+`partner_apps` table + manifest format → consent page (`/oauth/authorize` interstitial)
+→ provisioning transaction → partner token exchange endpoint → dashboard shows partner
+connections like agent connections today.
+*Fallback that works day one: DDJS polls `gmail_list` on an interval — notifications are
+an optimization, not a blocker for the integration.*
+
+**Phase 2 — Push notifications**: Pub/Sub topic + `/api/webhooks/gmail` receiver →
+subscription provisioning at consent → watch-renewal cron → HMAC webhook dispatcher
+with retries → delivery audit in dashboard.
+
+**Phase 3 — Self-serve registry** (later): partner-facing app registration UI with a
+review queue, once more than a handful of partners exist.

--- a/docs/implementation_plans/third-party-handoff-permissions_v3.md
+++ b/docs/implementation_plans/third-party-handoff-permissions_v3.md
@@ -1,0 +1,369 @@
+# Third-Party App Handoff: Auth, Default Permissions, and Push Notifications
+
+> Strategy for letting third-party websites/agents (canonical example: "Data Driven Job
+> Search", DDJS) hand their signed-in users off to FGAC, receive scoped credentials with
+> app-declared default permissions, and get push notifications for new emails.
+>
+> Branch: `claude/third-party-handoff-permissions-81dc96` — v3 (strategy, spikes executed)
+>
+> **v3 changes:** Spikes 1 and 2 executed 2026-08-05 — results below. Spike 3 resolved
+> (FGAC has passed CASA Tier 2 for Gmail read). Spike 4 expanded from a question into a
+> concrete design recommendation (DB-backed outbox + cron).
+> **v2 changes:** added the De-risking Spikes section; corrected the DDJS manifest
+> example — send is already deny-by-default when no `send_whitelist` rule exists
+> (`src/app/api/proxy/[...path]/route.ts` §5), so a read-only role needs no rule
+> templates at all.
+
+## Spike Results (executed 2026-08-05, dev environment)
+
+### Spike 1 — Clerk as OAuth AS with FGAC-owned consent: **PASS** ✅
+
+Method: created a pre-registered OAuth application ("DDJS Spike Partner App") via the
+Clerk Backend API (`POST /v1/oauth_applications`), walked the full authorize flow in
+the browser as USER_A against the dev instance, exercised the token endpoint, and
+probed the bypass path against the local MCP server.
+
+| Question | Result |
+|----------|--------|
+| Can Clerk's consent screen be skipped per-app? | **Yes.** `consent_screen_enabled` is a per-app, API-writable boolean. `false` → authorize silently redirects with a code, no screen. `true` → consent shown on **every** authorize (no grant-memory skip), so the toggle is fully authoritative. |
+| Is Clerk's consent screen usable as FGAC consent? | No — it renders only identity scopes ("your email address, basic profile"), nothing about Gmail/FGAC permissions. Confirms the FGAC interstitial is required and Clerk's screen should be disabled for partner apps. |
+| Does the bypass fail safe? | **Yes.** With consent disabled, driving Clerk's authorize URL directly issues tokens silently — but calling `/api/mcp` with that token creates a `pending` connection and every tool call refuses with "awaiting user approval". Deny-by-default holds. |
+| Refresh tokens for pre-registered confidential clients? | **Yes.** `offline_access` is in default scopes; access tokens live 24h (`expires_in: 86399`); `refresh_token` grant works and **rotates** the refresh token. |
+| Do we need to become our own AS? | **No.** The fallback (FGAC-issued codes/tokens) is unnecessary. |
+
+Implications for the design: partner apps are created with `consent_screen_enabled:
+false`; the FGAC interstitial performs provisioning *before* redirecting into Clerk's
+authorize URL; the pending-by-default MCP behavior is the safety net for anyone who
+skips the interstitial. One consent screen total, as designed.
+
+### Spike 2 — Gmail `users.watch` + Pub/Sub with Clerk-vaulted tokens: **PASS (one step remains, gated on GCP access)** 🟡
+
+Method: pulled USER_A's Google token via the Clerk Backend API (the same path
+`getGoogleToken` uses), inspected it via tokeninfo, called `users.watch` with several
+topic names, and validated the `history.list` diff mechanic with a real send.
+
+| Question | Result |
+|----------|--------|
+| Does dev Clerk use shared or custom Google credentials? | **Custom.** Token `azp` = client `627660126377-…` in GCP project **`dev-fgac-ai`**. The feared dev blocker (Clerk shared creds) does not exist — dev/QA of Phase 2 is viable. |
+| Topic-project constraint real? | **Confirmed empirically.** Watch with any foreign topic → `400 Invalid topicName does not match projects/dev-fgac-ai/topics/*`. The topic must live in the OAuth client's project, and the error names it. |
+| Scope sufficient? | **Yes.** Vaulted tokens carry `gmail.modify`; watch calls authenticate and proceed to topic resolution. |
+| Watch → publish chain | Watch with a correctly-formed `projects/dev-fgac-ai/topics/…` name returns `404 Error sending test message to Cloud PubSub … Resource not found` — Gmail **publishes a test message at watch time**, so a single successful watch call will prove the publish grant end-to-end. |
+| `history.list` diff mechanic | **Validated.** Baseline `historyId` 4467334 → sent test email → `history.list(startHistoryId, historyTypes=messageAdded)` returned exactly the new message id and the next cursor (4467385). |
+
+**Remaining step (needs GCP console/gcloud, ~5 min, one-time):** in project
+`dev-fgac-ai`: create topic `fgac-gmail-watch`, grant
+`gmail-api-push@system.gserviceaccount.com` → `roles/pubsub.publisher` on it, then
+re-run watch (expect `{historyId, expiration}`) and attach a pull subscription to
+observe notifications. Same setup needed in the **production** client's GCP project
+before Phase 2 ships.
+
+### Spike 3 — Google verification: **RESOLVED** ✅
+
+FGAC has passed **CASA Tier 2 for Gmail read**. No unverified-app warning in partner
+funnels and no 100-user cap. (Keep in view: scope additions or new restricted scopes
+would trigger re-verification; annual CASA recertification applies.)
+
+### Spike 4 — Webhook delivery on Vercel: design decision (expanded)
+
+See the dedicated section below — recommendation is a **DB-backed outbox drained by
+Vercel cron**, with QStash as the documented escalation path.
+
+## Spike 4 Expanded — Webhook Delivery Mechanics on Vercel
+
+### Why this needs deciding at all
+
+Vercel functions are request-scoped: no resident workers, no in-memory queues that
+survive a response, no `setTimeout`-and-retry. Every delivery attempt must be triggered
+by an inbound HTTP request (a Pub/Sub push, a cron tick) and finish within the
+function's `maxDuration`. "Retry with exponential backoff" therefore has to be encoded
+as *durable state plus a scheduler*, not as code that waits.
+
+### The delivery chain and where each failure lands
+
+```
+Pub/Sub push → /api/webhooks/gmail          (ack fast: verify OIDC, enqueue, 200)
+                    │ write outbox row(s)
+                    ▼
+        webhook_deliveries (outbox table)   status: pending | delivering | delivered | failed | dead
+                    ▼
+Cron tick → /api/cron/deliver-webhooks      (drain due rows, POST to partners)
+                    │ success → delivered
+                    │ failure → attempts++, next_attempt_at = now + backoff(attempts)
+                    ▼
+        after N failures → dead + subscription flagged; dashboard shows it
+```
+
+Key separation: **ack Pub/Sub immediately** (do the `history.list` diff + rule filter +
+outbox insert, return 200), and let delivery to partners be async. Coupling Google's
+retry loop to partner availability is the failure mode to avoid — Pub/Sub's ack
+deadline is short, and an unacked backlog on a flaky partner would stall notifications
+for *everyone* on that subscription's topic.
+
+### Option A — DB-backed outbox + Vercel cron (recommended)
+
+- `webhook_deliveries` table is the queue: `(id, subscriptionId, payload, status,
+  attempts, nextAttemptAt, lastError, createdAt, deliveredAt)`.
+- A Vercel cron hits `/api/cron/deliver-webhooks` every minute (Pro plan floor). The
+  drainer claims due rows (`status='pending' AND nextAttemptAt <= now`) with
+  `UPDATE … SET status='delivering' … RETURNING` (skip-locked semantics) so overlapping
+  ticks never double-send, POSTs each with the HMAC signature, and writes back the
+  outcome.
+- Backoff schedule: 1m, 5m, 15m, 1h, 6h, 24h → `dead` (≈6 attempts over ~31h). With a
+  1-minute cron, sub-minute backoff is unachievable — acceptable, because the *first*
+  attempt is not cron-gated: the Pub/Sub handler fires one immediate best-effort
+  delivery inline after inserting the row (happy path stays real-time, measured
+  seconds from email arrival), and the cron only picks up failures.
+- Auto-disable: N consecutive `dead` deliveries on one subscription → subscription
+  `status='suspended'`, surfaced on the user dashboard and (optionally) emailed to the
+  partner's ops contact. Re-enable is a partner/dashboard action that also triggers a
+  reconciliation sweep (`messages.list` since last delivered `historyId`).
+
+**Pros:** zero new vendors; state lives next to the data it describes; the audit trail
+("DDJS was notified of 42 messages") is the queue table itself; trivially testable in
+QA (call the cron route directly). **Cons:** 1-minute retry granularity; drainer must
+respect `maxDuration` (cap batch size, let the next tick continue); Neon connection
+budget for a chatty cron (fine at this scale).
+
+### Option B — QStash (or similar HTTP task queue)
+
+Publish each delivery to QStash with the partner URL as target; QStash owns retries,
+backoff, and DLQ, and signs requests. **Pros:** less delivery code, second-granularity
+retries, built-in DLQ. **Cons:** new vendor dependency + cost; the audit trail and
+auto-disable logic still need our own table (so much of Option A gets built anyway);
+partner-visible requests originate from QStash IPs (harder allowlisting story);
+webhook secrets/HMAC handling shifts partially into a third party's custody, which is
+an awkward fit for a security-positioning product.
+
+### Option C — lean on Pub/Sub redelivery (rejected)
+
+Don't ack until the partner accepts. Rejected for the coupling reason above, plus:
+ack deadline ceiling (~600s) can't express multi-hour backoff, and one notification
+may fan out to multiple subscriptions with different outcomes — partial-failure
+acking is unexpressible.
+
+### Idempotency & ordering (applies to every option)
+
+- **Inbound dedup:** Pub/Sub is at-least-once. The `(subscription, historyId-range)`
+  work is naturally idempotent because the diff runs off our stored cursor: a duplicate
+  push re-diffs from the same `lastHistoryId` and upserts the same outbox rows —
+  enforce with a unique index on `(subscriptionId, messageId)`.
+- **Outbound idempotency:** every delivery carries an `X-FGAC-Delivery-Id` (the outbox
+  row id) so partners can dedup; document that retries reuse the id.
+- **Ordering:** not guaranteed and not promised — the payload's `historyId` cursor is
+  monotonic, and partners fetching via the proxy always see current state, so
+  out-of-order thin pings are harmless.
+
+### Recommendation
+
+**Option A** for Phase 2. The scale argument is decisive: at launch volume (tens of
+partners, thousands of notifications/day) a cron drainer is far below any limit, and
+the pieces Option B doesn't cover (audit, auto-disable, dashboard) are the majority of
+the work anyway. Revisit QStash only if retry-latency granularity or cron volume
+becomes a measured problem. Build the drainer behind an interface
+(`deliverPending(batch)`) so swapping the scheduler later is contained.
+
+### Verified during strategy review (no spike needed)
+
+- **Read-only role expressibility**: send is deny-by-default absent a whitelist rule
+  (proxy §5); `google_api_modify` exposes only `messages/send` and denies unparseable
+  recipients; DELETE isn't exposed on MCP and trash/emptyTrash are hard-blocked on the
+  proxy. A no-rules key is already read-only.
+- **Token→key resolution chain** for partner servers: `verifyClerkToken` → connection →
+  key already works (MCP), and `/api/auth/cli-token` proves the OAuth-token→proxy-key
+  exchange pattern.
+
+## The Scenario
+
+DDJS runs a server-side agent that categorizes every new email a user receives into an
+interview stage and extracts action items. It needs:
+
+1. A signed-in DDJS user handed off to FGAC (account creation if needed) and back.
+2. FGAC-side **default permissions for the DDJS agent role** (read-only Gmail, no send,
+   no delete) applied without the user hand-assembling rules.
+3. Credentials returned to DDJS's **server** (not a browser/MCP client) that work with
+   the existing proxy/MCP surfaces.
+4. **Push notifications** to DDJS when new mail arrives, filtered by the same rules.
+
+## What Exists Today (and what's missing)
+
+| Need | Today | Gap |
+|------|-------|-----|
+| Third-party OAuth into FGAC | Clerk DCR + `agent_connections` pending-approval flow (built for MCP clients) | Approval is a *separate dashboard visit* where the user manually picks a proxy key; no inline consent, no way back to the app |
+| Default permissions per app | `access_rules` + `key_rule_assignments` exist, fully manual | No concept of a **registered app** with a declared permission manifest/template |
+| Server credentials | `sk_proxy_...` keys + REST proxy; `/api/auth/cli-token` already exchanges an OAuth token for a proxy key | No partner-facing token endpoint; keys are provisioned manually in the dashboard |
+| Push notifications | Nothing (no `users.watch`, no Pub/Sub, no webhook delivery) | Entire subsystem is net-new |
+
+The good news: 1–3 are mostly **recomposition of existing primitives**. Only 4 is a new
+subsystem.
+
+## Piece 1 — Partner App Registry with Permission Manifests ("Agent Roles")
+
+The core new concept. A third-party app registers with FGAC once (initially by us,
+manually — this is also the review/verification gate) and gets:
+
+- An OAuth `client_id` (Clerk OAuth application — same machinery the MCP DCR flow uses,
+  but pre-registered rather than dynamic).
+- A **permission manifest**: the app's requested "role", declared as a template of
+  `access_rules` plus capability flags. For DDJS:
+
+```jsonc
+{
+  "app": "Data Driven Job Search",
+  "logo_url": "...",
+  "requested": {
+    "services": ["gmail"],
+    "access": "read_only",            // no send whitelist rule = send denied by default (proxy §5)
+    "rule_templates": [],             // read-only needs none; write-capable apps declare whitelists here
+    "notifications": { "trigger": "new_email" }
+  },
+  "webhook_url": "https://api.ddjs.com/fgac/webhook",   // verified at registration
+  "redirect_uris": ["https://ddjs.com/fgac/callback"]
+}
+```
+
+**Consent-time provisioning**: when a user approves the app, FGAC auto-creates in one
+transaction what the user builds by hand today:
+
+1. A proxy key labeled `"Data Driven Job Search"`.
+2. `key_email_access` rows for the account(s) the user selected on the consent screen.
+3. Copies of the manifest's rule templates as `access_rules` bound to that key via
+   `key_rule_assignments` (copies, not references — the user can then tighten them per
+   normal, and a later manifest change by the app cannot silently widen existing grants).
+4. The `agent_connections` row, already `approved` and bound to the key.
+5. (If requested + granted) a `notification_subscriptions` row per account.
+
+Manifest changes that *broaden* access require re-consent: bump a `manifest_version`
+on the registry row; connections pinned to an older version keep old permissions until
+the user re-approves.
+
+New schema: `partner_apps` (clientId, name, manifest JSON, manifestVersion, webhookUrl,
+webhookSecret, status). Existing tables carry everything else.
+
+## Piece 2 — The Handoff Flow (lowest-friction path)
+
+Standard OAuth 2.0 authorization-code + PKCE, with Clerk as the identity/token layer
+(as today) and a new **FGAC consent interstitial** replacing the manual dashboard
+approval:
+
+```
+DDJS "Connect your Gmail" button
+  → https://fgac.ai/oauth/authorize?client_id=<ddjs>&state=...&code_challenge=...
+  → [no Clerk session] Clerk sign-in with Google → Google consent (Gmail scope)
+       ← this is the ONLY Google screen; FGAC becomes the token holder via Clerk
+  → FGAC consent page (server-renders partner_apps manifest):
+       "Data Driven Job Search wants to:
+          • Read email in [account picker: kenyesh@gmail.com ▾]  (read-only — cannot send or delete)
+          • Be notified when new email arrives
+        [Approve] [Deny]"
+  → Approve = one click → provisioning transaction (Piece 1) → redirect to
+    https://ddjs.com/fgac/callback?code=...&state=...
+  → DDJS server exchanges code at the token endpoint
+```
+
+Click count: **existing FGAC user = 1 screen** (consent). New user = Google account
+chooser + Google consent + FGAC consent ≈ 3 screens, all standard-feeling. No dashboard
+visit, no manual key creation, no rule configuration.
+
+Why keep Clerk underneath: the MCP flow already proves out Clerk DCR → token → userId
+resolution, discovery endpoints exist, and Google token custody stays exactly where it
+is (Clerk as token vault — the fake-token principle is preserved; DDJS never sees a
+Google credential).
+
+## Piece 3 — Credentials DDJS Receives
+
+Two-step, both reusing existing machinery:
+
+1. **Token endpoint** (Clerk's, as today): authorization code → access token + refresh
+   token. The MCP server already resolves `OAuth token → (userId, clientId) →
+   agent_connections → proxy_key`, so these tokens work against `/api/mcp` immediately.
+2. **Optional key exchange** for the REST proxy: a partner-facing sibling of the
+   existing `/api/auth/cli-token` — `POST /api/auth/partner-token` with the OAuth
+   token returns the connection's `sk_proxy_...` for direct
+   `gmail.fgac.ai/gmail/v1/...` calls with off-the-shelf Google SDKs (Prong 1).
+
+DDJS stores per-user: `{ refresh_token or proxy_key, connection_id }`. Revocation
+story is already built: user blocks the connection or revokes the key in the dashboard
+and both surfaces die.
+
+Recommendation: steer partners to the **OAuth-token path** as primary (rotatable,
+standard, auditable per-connection) and treat the raw proxy key as the escape hatch for
+SDK-endpoint-override users.
+
+## Piece 4 — Push Notifications (net-new subsystem)
+
+Gmail's push model: `users.watch` → Google Cloud **Pub/Sub topic** → HTTPS push to us →
+we fan out to partners. FGAC sits in the middle, which is precisely the product: the
+partner gets notified only about mail its rules let it see.
+
+```
+Gmail ── users.watch ──▶ Pub/Sub topic ── push ──▶ POST /api/webhooks/gmail  (verify OIDC token from Google)
+                                                        │  {emailAddress, historyId}
+                                                        ▼
+                                          history.list(since lastHistoryId)   [owner's Clerk Google token]
+                                                        │  new message IDs
+                                                        ▼
+                                          For each subscription on that account:
+                                            apply the bound key's READ RULES to each message
+                                            (label/sender blacklists — same code path as gmail_read)
+                                                        │  surviving IDs only
+                                                        ▼
+                                          POST partner webhook_url   (HMAC-signed, thin payload)
+                                          { connection_id, account, message_ids: [...], event: "new_email" }
+```
+
+Design decisions:
+
+- **Thin pings, not payloads.** The webhook carries message IDs only; DDJS fetches
+  content back through the proxy with its own credentials, where rules are enforced
+  again at read time. This keeps FGAC out of the business of pushing email bodies to
+  third parties, makes the webhook low-sensitivity, and means a mid-flight rule change
+  is honored at fetch.
+- **Rule-filtered notification.** If the user blacklists a label/sender, DDJS is not
+  even *told* those messages exist. This is the differentiating feature — notification
+  as an access-controlled surface, not a firehose.
+- **Watch lifecycle**: `users.watch` expires after 7 days → daily cron (Vercel cron)
+  re-arms all active subscriptions; store `lastHistoryId` per subscription;
+  `historyId` gaps (expired history) fall back to a `messages.list` reconciliation.
+- **Delivery semantics**: at-least-once, HMAC-SHA256 signature header with the app's
+  `webhookSecret`, exponential-backoff retries, auto-disable + dashboard flag after N
+  consecutive failures. `webhook_deliveries` table for the audit trail ("DDJS was
+  notified about 42 messages this week" belongs in the user's dashboard).
+- **One topic, many accounts**: a single Pub/Sub topic; the notification names the
+  account, we route by `emailAddress → notification_subscriptions`.
+
+New schema: `notification_subscriptions` (connectionId, targetEmail, lastHistoryId,
+watchExpiresAt, status), `webhook_deliveries` (subscriptionId, messageIds, status,
+attempts, timestamps).
+
+Prerequisite: a GCP project with Pub/Sub + granting `gmail-api-push@system.gserviceaccount.com`
+publish rights on the topic. Note `users.watch` must be called with the *user's* OAuth
+token (from Clerk) — scope-wise `gmail.readonly` suffices, which we already hold.
+
+## Security Notes
+
+- **Confused deputy / CSRF**: `state` + PKCE mandatory; consent page binds to the
+  authenticated Clerk session.
+- **No silent escalation**: manifest is copied at consent; broadening requires
+  re-consent (manifest_version pinning).
+- **Webhook SSRF/exfil**: webhook URLs are registered and verified at app registration
+  (challenge round-trip), never taken from runtime requests; reject private-range hosts.
+- **Fake-token principle intact**: partners receive FGAC credentials only; Google
+  tokens never leave Clerk custody.
+- **Registry as trust gate**: manual app registration doubles as app review; the
+  consent screen renders only registry data, never client-supplied strings.
+
+## Sequencing
+
+**Phase 1 — Handoff + default permissions** (recomposition, ~all existing infra):
+`partner_apps` table + manifest format → consent page (`/oauth/authorize` interstitial)
+→ provisioning transaction → partner token exchange endpoint → dashboard shows partner
+connections like agent connections today.
+*Fallback that works day one: DDJS polls `gmail_list` on an interval — notifications are
+an optimization, not a blocker for the integration.*
+
+**Phase 2 — Push notifications**: Pub/Sub topic + `/api/webhooks/gmail` receiver →
+subscription provisioning at consent → watch-renewal cron → HMAC webhook dispatcher
+with retries → delivery audit in dashboard.
+
+**Phase 3 — Self-serve registry** (later): partner-facing app registration UI with a
+review queue, once more than a handful of partners exist.

--- a/docs/implementation_plans/third-party-handoff-permissions_v4.md
+++ b/docs/implementation_plans/third-party-handoff-permissions_v4.md
@@ -1,0 +1,415 @@
+# Third-Party App Handoff: Auth, Default Permissions, and Push Notifications
+
+> Strategy for letting third-party websites/agents (canonical example: "Data Driven Job
+> Search", DDJS) hand their signed-in users off to FGAC, receive scoped credentials with
+> app-declared default permissions, and get push notifications for new emails.
+>
+> Branch: `claude/third-party-handoff-permissions-81dc96` — v4 (all spikes closed)
+>
+> **v4 changes (2026-08-06):** Spike 2 closed end-to-end — topic
+> `projects/dev-fgac-ai/topics/fgac-gmail-watch` created with
+> `gmail-api-push@system.gserviceaccount.com` as publisher (durable dev infra, kept);
+> watch armed via Clerk-vaulted token (`{historyId: 4467423, expiration: +7d}`); test
+> email → Pub/Sub notification `{emailAddress, historyId}` in ~2s → `history.list`
+> diff resolved the exact message id. Watch stopped and spike pull subscription
+> deleted after the test. Added the Dev→Prod Infrastructure Sync section.
+> **v3 changes:** Spikes 1 and 2 executed 2026-08-05 — results below. Spike 3 resolved
+> (FGAC has passed CASA Tier 2 for Gmail read). Spike 4 expanded from a question into a
+> concrete design recommendation (DB-backed outbox + cron).
+> **v2 changes:** added the De-risking Spikes section; corrected the DDJS manifest
+> example — send is already deny-by-default when no `send_whitelist` rule exists
+> (`src/app/api/proxy/[...path]/route.ts` §5), so a read-only role needs no rule
+> templates at all.
+
+## Spike Results (executed 2026-08-05, dev environment)
+
+### Spike 1 — Clerk as OAuth AS with FGAC-owned consent: **PASS** ✅
+
+Method: created a pre-registered OAuth application ("DDJS Spike Partner App") via the
+Clerk Backend API (`POST /v1/oauth_applications`), walked the full authorize flow in
+the browser as USER_A against the dev instance, exercised the token endpoint, and
+probed the bypass path against the local MCP server.
+
+| Question | Result |
+|----------|--------|
+| Can Clerk's consent screen be skipped per-app? | **Yes.** `consent_screen_enabled` is a per-app, API-writable boolean. `false` → authorize silently redirects with a code, no screen. `true` → consent shown on **every** authorize (no grant-memory skip), so the toggle is fully authoritative. |
+| Is Clerk's consent screen usable as FGAC consent? | No — it renders only identity scopes ("your email address, basic profile"), nothing about Gmail/FGAC permissions. Confirms the FGAC interstitial is required and Clerk's screen should be disabled for partner apps. |
+| Does the bypass fail safe? | **Yes.** With consent disabled, driving Clerk's authorize URL directly issues tokens silently — but calling `/api/mcp` with that token creates a `pending` connection and every tool call refuses with "awaiting user approval". Deny-by-default holds. |
+| Refresh tokens for pre-registered confidential clients? | **Yes.** `offline_access` is in default scopes; access tokens live 24h (`expires_in: 86399`); `refresh_token` grant works and **rotates** the refresh token. |
+| Do we need to become our own AS? | **No.** The fallback (FGAC-issued codes/tokens) is unnecessary. |
+
+Implications for the design: partner apps are created with `consent_screen_enabled:
+false`; the FGAC interstitial performs provisioning *before* redirecting into Clerk's
+authorize URL; the pending-by-default MCP behavior is the safety net for anyone who
+skips the interstitial. One consent screen total, as designed.
+
+### Spike 2 — Gmail `users.watch` + Pub/Sub with Clerk-vaulted tokens: **PASS (one step remains, gated on GCP access)** 🟡
+
+Method: pulled USER_A's Google token via the Clerk Backend API (the same path
+`getGoogleToken` uses), inspected it via tokeninfo, called `users.watch` with several
+topic names, and validated the `history.list` diff mechanic with a real send.
+
+| Question | Result |
+|----------|--------|
+| Does dev Clerk use shared or custom Google credentials? | **Custom.** Token `azp` = client `627660126377-…` in GCP project **`dev-fgac-ai`**. The feared dev blocker (Clerk shared creds) does not exist — dev/QA of Phase 2 is viable. |
+| Topic-project constraint real? | **Confirmed empirically.** Watch with any foreign topic → `400 Invalid topicName does not match projects/dev-fgac-ai/topics/*`. The topic must live in the OAuth client's project, and the error names it. |
+| Scope sufficient? | **Yes.** Vaulted tokens carry `gmail.modify`; watch calls authenticate and proceed to topic resolution. |
+| Watch → publish chain | Watch with a correctly-formed `projects/dev-fgac-ai/topics/…` name returns `404 Error sending test message to Cloud PubSub … Resource not found` — Gmail **publishes a test message at watch time**, so a single successful watch call will prove the publish grant end-to-end. |
+| `history.list` diff mechanic | **Validated.** Baseline `historyId` 4467334 → sent test email → `history.list(startHistoryId, historyTypes=messageAdded)` returned exactly the new message id and the next cursor (4467385). |
+
+**CLOSED 2026-08-06:** topic + publisher grant created in `dev-fgac-ai`; watch armed
+(`{historyId: 4467423, expiration: +7 days}`); test email produced a Pub/Sub
+notification `{"emailAddress": "kenyesh2@gmail.com", "historyId": …}` within ~2
+seconds; `history.list(startHistoryId=<notification cursor>)` resolved to exactly the
+new message id. Note Gmail also publishes a notification *at watch time* (the arming
+test message) — the receiver must tolerate notifications that diff to zero new
+messages. Dev topic and IAM grant are kept as standing infra; the same setup is
+needed in the production client's GCP project before Phase 2 ships (see Dev→Prod
+Infrastructure Sync below).
+
+## Dev→Prod Infrastructure Sync
+
+The Pub/Sub resources live **outside** the repo/Vercel pipeline — nothing in
+`/deploy-pr-preview` or `/deploy-prod` creates them. Keep dev and prod in sync by
+construction, not by memory:
+
+1. **One idempotent setup script, checked in** — `scripts/setup-gmail-push.sh`
+   (Phase 2 deliverable). Takes `--project <id>`; creates the topic if missing, adds
+   the `gmail-api-push` publisher binding if missing, creates the push subscription
+   pointing at `https://<host>/api/webhooks/gmail` with OIDC auth. Follows the repo's
+   production-script convention: requires explicit `--prod --apply` to touch the prod
+   project, prints a diff-style plan without `--apply`. Running the same script in
+   both projects is what keeps them identical.
+2. **Topic name is an env var, never hardcoded** — `GMAIL_PUBSUB_TOPIC` set per Vercel
+   environment (development → `projects/dev-fgac-ai/topics/fgac-gmail-watch`,
+   production → the prod project's topic). Pasted into Vercel **without quotes**.
+   Code that arms watches reads only this var, so a missing/mismatched value fails
+   loudly instead of silently watching into the wrong project.
+3. **Preflight verification** — extend `env:check` (or add `npm run push:check`) to
+   assert: (a) `GMAIL_PUBSUB_TOPIC` is set and well-formed; (b) the topic's project
+   matches the GCP project of the Clerk instance's Google OAuth client (probe: pull
+   any vaulted token, compare `azp` client project vs. topic project — exactly the
+   mismatch class the spike surfaced); (c) the publisher binding exists. This makes
+   "is prod wired?" a command, not a memory.
+4. **Identify the prod OAuth client's project first** — run the azp probe against the
+   production Clerk instance (secret via `.secrets/prod.env`, diagnostics-only) or
+   read the Google client id off the Clerk dashboard's SSO connection. The prod topic
+   MUST live in that project; this is the one fact the script can't guess.
+5. **What does NOT need syncing**: watch registrations are runtime state, created
+   per-subscription by the app and re-armed by the renewal cron — they are never
+   provisioned by hand in either environment. Only topic + IAM binding + push
+   subscription + env var are infrastructure.
+6. **Prod checklist (before Phase 2 `/deploy-prod`)**: run the setup script with
+   `--prod --apply` against the prod project → add `GMAIL_PUBSUB_TOPIC` to Vercel
+   production env (user redeploys) → `push:check` green against prod config.
+
+### Spike 3 — Google verification: **RESOLVED** ✅
+
+FGAC has passed **CASA Tier 2 for Gmail read**. No unverified-app warning in partner
+funnels and no 100-user cap. (Keep in view: scope additions or new restricted scopes
+would trigger re-verification; annual CASA recertification applies.)
+
+### Spike 4 — Webhook delivery on Vercel: design decision (expanded)
+
+See the dedicated section below — recommendation is a **DB-backed outbox drained by
+Vercel cron**, with QStash as the documented escalation path.
+
+## Spike 4 Expanded — Webhook Delivery Mechanics on Vercel
+
+### Why this needs deciding at all
+
+Vercel functions are request-scoped: no resident workers, no in-memory queues that
+survive a response, no `setTimeout`-and-retry. Every delivery attempt must be triggered
+by an inbound HTTP request (a Pub/Sub push, a cron tick) and finish within the
+function's `maxDuration`. "Retry with exponential backoff" therefore has to be encoded
+as *durable state plus a scheduler*, not as code that waits.
+
+### The delivery chain and where each failure lands
+
+```
+Pub/Sub push → /api/webhooks/gmail          (ack fast: verify OIDC, enqueue, 200)
+                    │ write outbox row(s)
+                    ▼
+        webhook_deliveries (outbox table)   status: pending | delivering | delivered | failed | dead
+                    ▼
+Cron tick → /api/cron/deliver-webhooks      (drain due rows, POST to partners)
+                    │ success → delivered
+                    │ failure → attempts++, next_attempt_at = now + backoff(attempts)
+                    ▼
+        after N failures → dead + subscription flagged; dashboard shows it
+```
+
+Key separation: **ack Pub/Sub immediately** (do the `history.list` diff + rule filter +
+outbox insert, return 200), and let delivery to partners be async. Coupling Google's
+retry loop to partner availability is the failure mode to avoid — Pub/Sub's ack
+deadline is short, and an unacked backlog on a flaky partner would stall notifications
+for *everyone* on that subscription's topic.
+
+### Option A — DB-backed outbox + Vercel cron (recommended)
+
+- `webhook_deliveries` table is the queue: `(id, subscriptionId, payload, status,
+  attempts, nextAttemptAt, lastError, createdAt, deliveredAt)`.
+- A Vercel cron hits `/api/cron/deliver-webhooks` every minute (Pro plan floor). The
+  drainer claims due rows (`status='pending' AND nextAttemptAt <= now`) with
+  `UPDATE … SET status='delivering' … RETURNING` (skip-locked semantics) so overlapping
+  ticks never double-send, POSTs each with the HMAC signature, and writes back the
+  outcome.
+- Backoff schedule: 1m, 5m, 15m, 1h, 6h, 24h → `dead` (≈6 attempts over ~31h). With a
+  1-minute cron, sub-minute backoff is unachievable — acceptable, because the *first*
+  attempt is not cron-gated: the Pub/Sub handler fires one immediate best-effort
+  delivery inline after inserting the row (happy path stays real-time, measured
+  seconds from email arrival), and the cron only picks up failures.
+- Auto-disable: N consecutive `dead` deliveries on one subscription → subscription
+  `status='suspended'`, surfaced on the user dashboard and (optionally) emailed to the
+  partner's ops contact. Re-enable is a partner/dashboard action that also triggers a
+  reconciliation sweep (`messages.list` since last delivered `historyId`).
+
+**Pros:** zero new vendors; state lives next to the data it describes; the audit trail
+("DDJS was notified of 42 messages") is the queue table itself; trivially testable in
+QA (call the cron route directly). **Cons:** 1-minute retry granularity; drainer must
+respect `maxDuration` (cap batch size, let the next tick continue); Neon connection
+budget for a chatty cron (fine at this scale).
+
+### Option B — QStash (or similar HTTP task queue)
+
+Publish each delivery to QStash with the partner URL as target; QStash owns retries,
+backoff, and DLQ, and signs requests. **Pros:** less delivery code, second-granularity
+retries, built-in DLQ. **Cons:** new vendor dependency + cost; the audit trail and
+auto-disable logic still need our own table (so much of Option A gets built anyway);
+partner-visible requests originate from QStash IPs (harder allowlisting story);
+webhook secrets/HMAC handling shifts partially into a third party's custody, which is
+an awkward fit for a security-positioning product.
+
+### Option C — lean on Pub/Sub redelivery (rejected)
+
+Don't ack until the partner accepts. Rejected for the coupling reason above, plus:
+ack deadline ceiling (~600s) can't express multi-hour backoff, and one notification
+may fan out to multiple subscriptions with different outcomes — partial-failure
+acking is unexpressible.
+
+### Idempotency & ordering (applies to every option)
+
+- **Inbound dedup:** Pub/Sub is at-least-once. The `(subscription, historyId-range)`
+  work is naturally idempotent because the diff runs off our stored cursor: a duplicate
+  push re-diffs from the same `lastHistoryId` and upserts the same outbox rows —
+  enforce with a unique index on `(subscriptionId, messageId)`.
+- **Outbound idempotency:** every delivery carries an `X-FGAC-Delivery-Id` (the outbox
+  row id) so partners can dedup; document that retries reuse the id.
+- **Ordering:** not guaranteed and not promised — the payload's `historyId` cursor is
+  monotonic, and partners fetching via the proxy always see current state, so
+  out-of-order thin pings are harmless.
+
+### Recommendation
+
+**Option A** for Phase 2. The scale argument is decisive: at launch volume (tens of
+partners, thousands of notifications/day) a cron drainer is far below any limit, and
+the pieces Option B doesn't cover (audit, auto-disable, dashboard) are the majority of
+the work anyway. Revisit QStash only if retry-latency granularity or cron volume
+becomes a measured problem. Build the drainer behind an interface
+(`deliverPending(batch)`) so swapping the scheduler later is contained.
+
+### Verified during strategy review (no spike needed)
+
+- **Read-only role expressibility**: send is deny-by-default absent a whitelist rule
+  (proxy §5); `google_api_modify` exposes only `messages/send` and denies unparseable
+  recipients; DELETE isn't exposed on MCP and trash/emptyTrash are hard-blocked on the
+  proxy. A no-rules key is already read-only.
+- **Token→key resolution chain** for partner servers: `verifyClerkToken` → connection →
+  key already works (MCP), and `/api/auth/cli-token` proves the OAuth-token→proxy-key
+  exchange pattern.
+
+## The Scenario
+
+DDJS runs a server-side agent that categorizes every new email a user receives into an
+interview stage and extracts action items. It needs:
+
+1. A signed-in DDJS user handed off to FGAC (account creation if needed) and back.
+2. FGAC-side **default permissions for the DDJS agent role** (read-only Gmail, no send,
+   no delete) applied without the user hand-assembling rules.
+3. Credentials returned to DDJS's **server** (not a browser/MCP client) that work with
+   the existing proxy/MCP surfaces.
+4. **Push notifications** to DDJS when new mail arrives, filtered by the same rules.
+
+## What Exists Today (and what's missing)
+
+| Need | Today | Gap |
+|------|-------|-----|
+| Third-party OAuth into FGAC | Clerk DCR + `agent_connections` pending-approval flow (built for MCP clients) | Approval is a *separate dashboard visit* where the user manually picks a proxy key; no inline consent, no way back to the app |
+| Default permissions per app | `access_rules` + `key_rule_assignments` exist, fully manual | No concept of a **registered app** with a declared permission manifest/template |
+| Server credentials | `sk_proxy_...` keys + REST proxy; `/api/auth/cli-token` already exchanges an OAuth token for a proxy key | No partner-facing token endpoint; keys are provisioned manually in the dashboard |
+| Push notifications | Nothing (no `users.watch`, no Pub/Sub, no webhook delivery) | Entire subsystem is net-new |
+
+The good news: 1–3 are mostly **recomposition of existing primitives**. Only 4 is a new
+subsystem.
+
+## Piece 1 — Partner App Registry with Permission Manifests ("Agent Roles")
+
+The core new concept. A third-party app registers with FGAC once (initially by us,
+manually — this is also the review/verification gate) and gets:
+
+- An OAuth `client_id` (Clerk OAuth application — same machinery the MCP DCR flow uses,
+  but pre-registered rather than dynamic).
+- A **permission manifest**: the app's requested "role", declared as a template of
+  `access_rules` plus capability flags. For DDJS:
+
+```jsonc
+{
+  "app": "Data Driven Job Search",
+  "logo_url": "...",
+  "requested": {
+    "services": ["gmail"],
+    "access": "read_only",            // no send whitelist rule = send denied by default (proxy §5)
+    "rule_templates": [],             // read-only needs none; write-capable apps declare whitelists here
+    "notifications": { "trigger": "new_email" }
+  },
+  "webhook_url": "https://api.ddjs.com/fgac/webhook",   // verified at registration
+  "redirect_uris": ["https://ddjs.com/fgac/callback"]
+}
+```
+
+**Consent-time provisioning**: when a user approves the app, FGAC auto-creates in one
+transaction what the user builds by hand today:
+
+1. A proxy key labeled `"Data Driven Job Search"`.
+2. `key_email_access` rows for the account(s) the user selected on the consent screen.
+3. Copies of the manifest's rule templates as `access_rules` bound to that key via
+   `key_rule_assignments` (copies, not references — the user can then tighten them per
+   normal, and a later manifest change by the app cannot silently widen existing grants).
+4. The `agent_connections` row, already `approved` and bound to the key.
+5. (If requested + granted) a `notification_subscriptions` row per account.
+
+Manifest changes that *broaden* access require re-consent: bump a `manifest_version`
+on the registry row; connections pinned to an older version keep old permissions until
+the user re-approves.
+
+New schema: `partner_apps` (clientId, name, manifest JSON, manifestVersion, webhookUrl,
+webhookSecret, status). Existing tables carry everything else.
+
+## Piece 2 — The Handoff Flow (lowest-friction path)
+
+Standard OAuth 2.0 authorization-code + PKCE, with Clerk as the identity/token layer
+(as today) and a new **FGAC consent interstitial** replacing the manual dashboard
+approval:
+
+```
+DDJS "Connect your Gmail" button
+  → https://fgac.ai/oauth/authorize?client_id=<ddjs>&state=...&code_challenge=...
+  → [no Clerk session] Clerk sign-in with Google → Google consent (Gmail scope)
+       ← this is the ONLY Google screen; FGAC becomes the token holder via Clerk
+  → FGAC consent page (server-renders partner_apps manifest):
+       "Data Driven Job Search wants to:
+          • Read email in [account picker: kenyesh@gmail.com ▾]  (read-only — cannot send or delete)
+          • Be notified when new email arrives
+        [Approve] [Deny]"
+  → Approve = one click → provisioning transaction (Piece 1) → redirect to
+    https://ddjs.com/fgac/callback?code=...&state=...
+  → DDJS server exchanges code at the token endpoint
+```
+
+Click count: **existing FGAC user = 1 screen** (consent). New user = Google account
+chooser + Google consent + FGAC consent ≈ 3 screens, all standard-feeling. No dashboard
+visit, no manual key creation, no rule configuration.
+
+Why keep Clerk underneath: the MCP flow already proves out Clerk DCR → token → userId
+resolution, discovery endpoints exist, and Google token custody stays exactly where it
+is (Clerk as token vault — the fake-token principle is preserved; DDJS never sees a
+Google credential).
+
+## Piece 3 — Credentials DDJS Receives
+
+Two-step, both reusing existing machinery:
+
+1. **Token endpoint** (Clerk's, as today): authorization code → access token + refresh
+   token. The MCP server already resolves `OAuth token → (userId, clientId) →
+   agent_connections → proxy_key`, so these tokens work against `/api/mcp` immediately.
+2. **Optional key exchange** for the REST proxy: a partner-facing sibling of the
+   existing `/api/auth/cli-token` — `POST /api/auth/partner-token` with the OAuth
+   token returns the connection's `sk_proxy_...` for direct
+   `gmail.fgac.ai/gmail/v1/...` calls with off-the-shelf Google SDKs (Prong 1).
+
+DDJS stores per-user: `{ refresh_token or proxy_key, connection_id }`. Revocation
+story is already built: user blocks the connection or revokes the key in the dashboard
+and both surfaces die.
+
+Recommendation: steer partners to the **OAuth-token path** as primary (rotatable,
+standard, auditable per-connection) and treat the raw proxy key as the escape hatch for
+SDK-endpoint-override users.
+
+## Piece 4 — Push Notifications (net-new subsystem)
+
+Gmail's push model: `users.watch` → Google Cloud **Pub/Sub topic** → HTTPS push to us →
+we fan out to partners. FGAC sits in the middle, which is precisely the product: the
+partner gets notified only about mail its rules let it see.
+
+```
+Gmail ── users.watch ──▶ Pub/Sub topic ── push ──▶ POST /api/webhooks/gmail  (verify OIDC token from Google)
+                                                        │  {emailAddress, historyId}
+                                                        ▼
+                                          history.list(since lastHistoryId)   [owner's Clerk Google token]
+                                                        │  new message IDs
+                                                        ▼
+                                          For each subscription on that account:
+                                            apply the bound key's READ RULES to each message
+                                            (label/sender blacklists — same code path as gmail_read)
+                                                        │  surviving IDs only
+                                                        ▼
+                                          POST partner webhook_url   (HMAC-signed, thin payload)
+                                          { connection_id, account, message_ids: [...], event: "new_email" }
+```
+
+Design decisions:
+
+- **Thin pings, not payloads.** The webhook carries message IDs only; DDJS fetches
+  content back through the proxy with its own credentials, where rules are enforced
+  again at read time. This keeps FGAC out of the business of pushing email bodies to
+  third parties, makes the webhook low-sensitivity, and means a mid-flight rule change
+  is honored at fetch.
+- **Rule-filtered notification.** If the user blacklists a label/sender, DDJS is not
+  even *told* those messages exist. This is the differentiating feature — notification
+  as an access-controlled surface, not a firehose.
+- **Watch lifecycle**: `users.watch` expires after 7 days → daily cron (Vercel cron)
+  re-arms all active subscriptions; store `lastHistoryId` per subscription;
+  `historyId` gaps (expired history) fall back to a `messages.list` reconciliation.
+- **Delivery semantics**: at-least-once, HMAC-SHA256 signature header with the app's
+  `webhookSecret`, exponential-backoff retries, auto-disable + dashboard flag after N
+  consecutive failures. `webhook_deliveries` table for the audit trail ("DDJS was
+  notified about 42 messages this week" belongs in the user's dashboard).
+- **One topic, many accounts**: a single Pub/Sub topic; the notification names the
+  account, we route by `emailAddress → notification_subscriptions`.
+
+New schema: `notification_subscriptions` (connectionId, targetEmail, lastHistoryId,
+watchExpiresAt, status), `webhook_deliveries` (subscriptionId, messageIds, status,
+attempts, timestamps).
+
+Prerequisite: a GCP project with Pub/Sub + granting `gmail-api-push@system.gserviceaccount.com`
+publish rights on the topic. Note `users.watch` must be called with the *user's* OAuth
+token (from Clerk) — scope-wise `gmail.readonly` suffices, which we already hold.
+
+## Security Notes
+
+- **Confused deputy / CSRF**: `state` + PKCE mandatory; consent page binds to the
+  authenticated Clerk session.
+- **No silent escalation**: manifest is copied at consent; broadening requires
+  re-consent (manifest_version pinning).
+- **Webhook SSRF/exfil**: webhook URLs are registered and verified at app registration
+  (challenge round-trip), never taken from runtime requests; reject private-range hosts.
+- **Fake-token principle intact**: partners receive FGAC credentials only; Google
+  tokens never leave Clerk custody.
+- **Registry as trust gate**: manual app registration doubles as app review; the
+  consent screen renders only registry data, never client-supplied strings.
+
+## Sequencing
+
+**Phase 1 — Handoff + default permissions** (recomposition, ~all existing infra):
+`partner_apps` table + manifest format → consent page (`/oauth/authorize` interstitial)
+→ provisioning transaction → partner token exchange endpoint → dashboard shows partner
+connections like agent connections today.
+*Fallback that works day one: DDJS polls `gmail_list` on an interval — notifications are
+an optimization, not a blocker for the integration.*
+
+**Phase 2 — Push notifications**: Pub/Sub topic + `/api/webhooks/gmail` receiver →
+subscription provisioning at consent → watch-renewal cron → HMAC webhook dispatcher
+with retries → delivery audit in dashboard.
+
+**Phase 3 — Self-serve registry** (later): partner-facing app registration UI with a
+review queue, once more than a handful of partners exist.

--- a/docs/implementation_plans/third-party-handoff-permissions_v5.md
+++ b/docs/implementation_plans/third-party-handoff-permissions_v5.md
@@ -1,0 +1,422 @@
+# Third-Party App Handoff: Auth, Default Permissions, and Push Notifications
+
+> Strategy for letting third-party websites/agents (canonical example: "Data Driven Job
+> Search", DDJS) hand their signed-in users off to FGAC, receive scoped credentials with
+> app-declared default permissions, and get push notifications for new emails.
+>
+> Branch: `claude/third-party-handoff-permissions-81dc96` — v5 (all spikes closed, prod project identified)
+>
+> **v5 changes (2026-08-06):** Production GCP project confirmed as
+> **`fine-grain-access-control`** (project number 727876597677) — verified by reading
+> the `client_id` off the prod sign-in Google redirect
+> (`727876597677-mah85mt4es0j11hkbin5a0ira72lhqq4.apps.googleusercontent.com`), not by
+> name-matching. The Phase 2 prod topic must be created in that project
+> (`projects/fine-grain-access-control/topics/fgac-gmail-watch`).
+>
+> **v4 changes (2026-08-06):** Spike 2 closed end-to-end — topic
+> `projects/dev-fgac-ai/topics/fgac-gmail-watch` created with
+> `gmail-api-push@system.gserviceaccount.com` as publisher (durable dev infra, kept);
+> watch armed via Clerk-vaulted token (`{historyId: 4467423, expiration: +7d}`); test
+> email → Pub/Sub notification `{emailAddress, historyId}` in ~2s → `history.list`
+> diff resolved the exact message id. Watch stopped and spike pull subscription
+> deleted after the test. Added the Dev→Prod Infrastructure Sync section.
+> **v3 changes:** Spikes 1 and 2 executed 2026-08-05 — results below. Spike 3 resolved
+> (FGAC has passed CASA Tier 2 for Gmail read). Spike 4 expanded from a question into a
+> concrete design recommendation (DB-backed outbox + cron).
+> **v2 changes:** added the De-risking Spikes section; corrected the DDJS manifest
+> example — send is already deny-by-default when no `send_whitelist` rule exists
+> (`src/app/api/proxy/[...path]/route.ts` §5), so a read-only role needs no rule
+> templates at all.
+
+## Spike Results (executed 2026-08-05, dev environment)
+
+### Spike 1 — Clerk as OAuth AS with FGAC-owned consent: **PASS** ✅
+
+Method: created a pre-registered OAuth application ("DDJS Spike Partner App") via the
+Clerk Backend API (`POST /v1/oauth_applications`), walked the full authorize flow in
+the browser as USER_A against the dev instance, exercised the token endpoint, and
+probed the bypass path against the local MCP server.
+
+| Question | Result |
+|----------|--------|
+| Can Clerk's consent screen be skipped per-app? | **Yes.** `consent_screen_enabled` is a per-app, API-writable boolean. `false` → authorize silently redirects with a code, no screen. `true` → consent shown on **every** authorize (no grant-memory skip), so the toggle is fully authoritative. |
+| Is Clerk's consent screen usable as FGAC consent? | No — it renders only identity scopes ("your email address, basic profile"), nothing about Gmail/FGAC permissions. Confirms the FGAC interstitial is required and Clerk's screen should be disabled for partner apps. |
+| Does the bypass fail safe? | **Yes.** With consent disabled, driving Clerk's authorize URL directly issues tokens silently — but calling `/api/mcp` with that token creates a `pending` connection and every tool call refuses with "awaiting user approval". Deny-by-default holds. |
+| Refresh tokens for pre-registered confidential clients? | **Yes.** `offline_access` is in default scopes; access tokens live 24h (`expires_in: 86399`); `refresh_token` grant works and **rotates** the refresh token. |
+| Do we need to become our own AS? | **No.** The fallback (FGAC-issued codes/tokens) is unnecessary. |
+
+Implications for the design: partner apps are created with `consent_screen_enabled:
+false`; the FGAC interstitial performs provisioning *before* redirecting into Clerk's
+authorize URL; the pending-by-default MCP behavior is the safety net for anyone who
+skips the interstitial. One consent screen total, as designed.
+
+### Spike 2 — Gmail `users.watch` + Pub/Sub with Clerk-vaulted tokens: **PASS (one step remains, gated on GCP access)** 🟡
+
+Method: pulled USER_A's Google token via the Clerk Backend API (the same path
+`getGoogleToken` uses), inspected it via tokeninfo, called `users.watch` with several
+topic names, and validated the `history.list` diff mechanic with a real send.
+
+| Question | Result |
+|----------|--------|
+| Does dev Clerk use shared or custom Google credentials? | **Custom.** Token `azp` = client `627660126377-…` in GCP project **`dev-fgac-ai`**. The feared dev blocker (Clerk shared creds) does not exist — dev/QA of Phase 2 is viable. |
+| Topic-project constraint real? | **Confirmed empirically.** Watch with any foreign topic → `400 Invalid topicName does not match projects/dev-fgac-ai/topics/*`. The topic must live in the OAuth client's project, and the error names it. |
+| Scope sufficient? | **Yes.** Vaulted tokens carry `gmail.modify`; watch calls authenticate and proceed to topic resolution. |
+| Watch → publish chain | Watch with a correctly-formed `projects/dev-fgac-ai/topics/…` name returns `404 Error sending test message to Cloud PubSub … Resource not found` — Gmail **publishes a test message at watch time**, so a single successful watch call will prove the publish grant end-to-end. |
+| `history.list` diff mechanic | **Validated.** Baseline `historyId` 4467334 → sent test email → `history.list(startHistoryId, historyTypes=messageAdded)` returned exactly the new message id and the next cursor (4467385). |
+
+**CLOSED 2026-08-06:** topic + publisher grant created in `dev-fgac-ai`; watch armed
+(`{historyId: 4467423, expiration: +7 days}`); test email produced a Pub/Sub
+notification `{"emailAddress": "kenyesh2@gmail.com", "historyId": …}` within ~2
+seconds; `history.list(startHistoryId=<notification cursor>)` resolved to exactly the
+new message id. Note Gmail also publishes a notification *at watch time* (the arming
+test message) — the receiver must tolerate notifications that diff to zero new
+messages. Dev topic and IAM grant are kept as standing infra; the same setup is
+needed in the production client's GCP project before Phase 2 ships (see Dev→Prod
+Infrastructure Sync below).
+
+## Dev→Prod Infrastructure Sync
+
+The Pub/Sub resources live **outside** the repo/Vercel pipeline — nothing in
+`/deploy-pr-preview` or `/deploy-prod` creates them. Keep dev and prod in sync by
+construction, not by memory:
+
+1. **One idempotent setup script, checked in** — `scripts/setup-gmail-push.sh`
+   (Phase 2 deliverable). Takes `--project <id>`; creates the topic if missing, adds
+   the `gmail-api-push` publisher binding if missing, creates the push subscription
+   pointing at `https://<host>/api/webhooks/gmail` with OIDC auth. Follows the repo's
+   production-script convention: requires explicit `--prod --apply` to touch the prod
+   project, prints a diff-style plan without `--apply`. Running the same script in
+   both projects is what keeps them identical.
+2. **Topic name is an env var, never hardcoded** — `GMAIL_PUBSUB_TOPIC` set per Vercel
+   environment (development → `projects/dev-fgac-ai/topics/fgac-gmail-watch`,
+   production → the prod project's topic). Pasted into Vercel **without quotes**.
+   Code that arms watches reads only this var, so a missing/mismatched value fails
+   loudly instead of silently watching into the wrong project.
+3. **Preflight verification** — extend `env:check` (or add `npm run push:check`) to
+   assert: (a) `GMAIL_PUBSUB_TOPIC` is set and well-formed; (b) the topic's project
+   matches the GCP project of the Clerk instance's Google OAuth client (probe: pull
+   any vaulted token, compare `azp` client project vs. topic project — exactly the
+   mismatch class the spike surfaced); (c) the publisher binding exists. This makes
+   "is prod wired?" a command, not a memory.
+4. **Prod OAuth client's project: IDENTIFIED** — `fine-grain-access-control`
+   (727876597677), verified 2026-08-06 via the `client_id` on the prod sign-in Google
+   redirect. The prod topic goes there:
+   `projects/fine-grain-access-control/topics/fgac-gmail-watch`.
+5. **What does NOT need syncing**: watch registrations are runtime state, created
+   per-subscription by the app and re-armed by the renewal cron — they are never
+   provisioned by hand in either environment. Only topic + IAM binding + push
+   subscription + env var are infrastructure.
+6. **Prod checklist (before Phase 2 `/deploy-prod`)**: run the setup script with
+   `--prod --apply` against the prod project → add `GMAIL_PUBSUB_TOPIC` to Vercel
+   production env (user redeploys) → `push:check` green against prod config.
+
+### Spike 3 — Google verification: **RESOLVED** ✅
+
+FGAC has passed **CASA Tier 2 for Gmail read**. No unverified-app warning in partner
+funnels and no 100-user cap. (Keep in view: scope additions or new restricted scopes
+would trigger re-verification; annual CASA recertification applies.)
+
+### Spike 4 — Webhook delivery on Vercel: design decision (expanded)
+
+See the dedicated section below — recommendation is a **DB-backed outbox drained by
+Vercel cron**, with QStash as the documented escalation path.
+
+## Spike 4 Expanded — Webhook Delivery Mechanics on Vercel
+
+### Why this needs deciding at all
+
+Vercel functions are request-scoped: no resident workers, no in-memory queues that
+survive a response, no `setTimeout`-and-retry. Every delivery attempt must be triggered
+by an inbound HTTP request (a Pub/Sub push, a cron tick) and finish within the
+function's `maxDuration`. "Retry with exponential backoff" therefore has to be encoded
+as *durable state plus a scheduler*, not as code that waits.
+
+### The delivery chain and where each failure lands
+
+```
+Pub/Sub push → /api/webhooks/gmail          (ack fast: verify OIDC, enqueue, 200)
+                    │ write outbox row(s)
+                    ▼
+        webhook_deliveries (outbox table)   status: pending | delivering | delivered | failed | dead
+                    ▼
+Cron tick → /api/cron/deliver-webhooks      (drain due rows, POST to partners)
+                    │ success → delivered
+                    │ failure → attempts++, next_attempt_at = now + backoff(attempts)
+                    ▼
+        after N failures → dead + subscription flagged; dashboard shows it
+```
+
+Key separation: **ack Pub/Sub immediately** (do the `history.list` diff + rule filter +
+outbox insert, return 200), and let delivery to partners be async. Coupling Google's
+retry loop to partner availability is the failure mode to avoid — Pub/Sub's ack
+deadline is short, and an unacked backlog on a flaky partner would stall notifications
+for *everyone* on that subscription's topic.
+
+### Option A — DB-backed outbox + Vercel cron (recommended)
+
+- `webhook_deliveries` table is the queue: `(id, subscriptionId, payload, status,
+  attempts, nextAttemptAt, lastError, createdAt, deliveredAt)`.
+- A Vercel cron hits `/api/cron/deliver-webhooks` every minute (Pro plan floor). The
+  drainer claims due rows (`status='pending' AND nextAttemptAt <= now`) with
+  `UPDATE … SET status='delivering' … RETURNING` (skip-locked semantics) so overlapping
+  ticks never double-send, POSTs each with the HMAC signature, and writes back the
+  outcome.
+- Backoff schedule: 1m, 5m, 15m, 1h, 6h, 24h → `dead` (≈6 attempts over ~31h). With a
+  1-minute cron, sub-minute backoff is unachievable — acceptable, because the *first*
+  attempt is not cron-gated: the Pub/Sub handler fires one immediate best-effort
+  delivery inline after inserting the row (happy path stays real-time, measured
+  seconds from email arrival), and the cron only picks up failures.
+- Auto-disable: N consecutive `dead` deliveries on one subscription → subscription
+  `status='suspended'`, surfaced on the user dashboard and (optionally) emailed to the
+  partner's ops contact. Re-enable is a partner/dashboard action that also triggers a
+  reconciliation sweep (`messages.list` since last delivered `historyId`).
+
+**Pros:** zero new vendors; state lives next to the data it describes; the audit trail
+("DDJS was notified of 42 messages") is the queue table itself; trivially testable in
+QA (call the cron route directly). **Cons:** 1-minute retry granularity; drainer must
+respect `maxDuration` (cap batch size, let the next tick continue); Neon connection
+budget for a chatty cron (fine at this scale).
+
+### Option B — QStash (or similar HTTP task queue)
+
+Publish each delivery to QStash with the partner URL as target; QStash owns retries,
+backoff, and DLQ, and signs requests. **Pros:** less delivery code, second-granularity
+retries, built-in DLQ. **Cons:** new vendor dependency + cost; the audit trail and
+auto-disable logic still need our own table (so much of Option A gets built anyway);
+partner-visible requests originate from QStash IPs (harder allowlisting story);
+webhook secrets/HMAC handling shifts partially into a third party's custody, which is
+an awkward fit for a security-positioning product.
+
+### Option C — lean on Pub/Sub redelivery (rejected)
+
+Don't ack until the partner accepts. Rejected for the coupling reason above, plus:
+ack deadline ceiling (~600s) can't express multi-hour backoff, and one notification
+may fan out to multiple subscriptions with different outcomes — partial-failure
+acking is unexpressible.
+
+### Idempotency & ordering (applies to every option)
+
+- **Inbound dedup:** Pub/Sub is at-least-once. The `(subscription, historyId-range)`
+  work is naturally idempotent because the diff runs off our stored cursor: a duplicate
+  push re-diffs from the same `lastHistoryId` and upserts the same outbox rows —
+  enforce with a unique index on `(subscriptionId, messageId)`.
+- **Outbound idempotency:** every delivery carries an `X-FGAC-Delivery-Id` (the outbox
+  row id) so partners can dedup; document that retries reuse the id.
+- **Ordering:** not guaranteed and not promised — the payload's `historyId` cursor is
+  monotonic, and partners fetching via the proxy always see current state, so
+  out-of-order thin pings are harmless.
+
+### Recommendation
+
+**Option A** for Phase 2. The scale argument is decisive: at launch volume (tens of
+partners, thousands of notifications/day) a cron drainer is far below any limit, and
+the pieces Option B doesn't cover (audit, auto-disable, dashboard) are the majority of
+the work anyway. Revisit QStash only if retry-latency granularity or cron volume
+becomes a measured problem. Build the drainer behind an interface
+(`deliverPending(batch)`) so swapping the scheduler later is contained.
+
+### Verified during strategy review (no spike needed)
+
+- **Read-only role expressibility**: send is deny-by-default absent a whitelist rule
+  (proxy §5); `google_api_modify` exposes only `messages/send` and denies unparseable
+  recipients; DELETE isn't exposed on MCP and trash/emptyTrash are hard-blocked on the
+  proxy. A no-rules key is already read-only.
+- **Token→key resolution chain** for partner servers: `verifyClerkToken` → connection →
+  key already works (MCP), and `/api/auth/cli-token` proves the OAuth-token→proxy-key
+  exchange pattern.
+
+## The Scenario
+
+DDJS runs a server-side agent that categorizes every new email a user receives into an
+interview stage and extracts action items. It needs:
+
+1. A signed-in DDJS user handed off to FGAC (account creation if needed) and back.
+2. FGAC-side **default permissions for the DDJS agent role** (read-only Gmail, no send,
+   no delete) applied without the user hand-assembling rules.
+3. Credentials returned to DDJS's **server** (not a browser/MCP client) that work with
+   the existing proxy/MCP surfaces.
+4. **Push notifications** to DDJS when new mail arrives, filtered by the same rules.
+
+## What Exists Today (and what's missing)
+
+| Need | Today | Gap |
+|------|-------|-----|
+| Third-party OAuth into FGAC | Clerk DCR + `agent_connections` pending-approval flow (built for MCP clients) | Approval is a *separate dashboard visit* where the user manually picks a proxy key; no inline consent, no way back to the app |
+| Default permissions per app | `access_rules` + `key_rule_assignments` exist, fully manual | No concept of a **registered app** with a declared permission manifest/template |
+| Server credentials | `sk_proxy_...` keys + REST proxy; `/api/auth/cli-token` already exchanges an OAuth token for a proxy key | No partner-facing token endpoint; keys are provisioned manually in the dashboard |
+| Push notifications | Nothing (no `users.watch`, no Pub/Sub, no webhook delivery) | Entire subsystem is net-new |
+
+The good news: 1–3 are mostly **recomposition of existing primitives**. Only 4 is a new
+subsystem.
+
+## Piece 1 — Partner App Registry with Permission Manifests ("Agent Roles")
+
+The core new concept. A third-party app registers with FGAC once (initially by us,
+manually — this is also the review/verification gate) and gets:
+
+- An OAuth `client_id` (Clerk OAuth application — same machinery the MCP DCR flow uses,
+  but pre-registered rather than dynamic).
+- A **permission manifest**: the app's requested "role", declared as a template of
+  `access_rules` plus capability flags. For DDJS:
+
+```jsonc
+{
+  "app": "Data Driven Job Search",
+  "logo_url": "...",
+  "requested": {
+    "services": ["gmail"],
+    "access": "read_only",            // no send whitelist rule = send denied by default (proxy §5)
+    "rule_templates": [],             // read-only needs none; write-capable apps declare whitelists here
+    "notifications": { "trigger": "new_email" }
+  },
+  "webhook_url": "https://api.ddjs.com/fgac/webhook",   // verified at registration
+  "redirect_uris": ["https://ddjs.com/fgac/callback"]
+}
+```
+
+**Consent-time provisioning**: when a user approves the app, FGAC auto-creates in one
+transaction what the user builds by hand today:
+
+1. A proxy key labeled `"Data Driven Job Search"`.
+2. `key_email_access` rows for the account(s) the user selected on the consent screen.
+3. Copies of the manifest's rule templates as `access_rules` bound to that key via
+   `key_rule_assignments` (copies, not references — the user can then tighten them per
+   normal, and a later manifest change by the app cannot silently widen existing grants).
+4. The `agent_connections` row, already `approved` and bound to the key.
+5. (If requested + granted) a `notification_subscriptions` row per account.
+
+Manifest changes that *broaden* access require re-consent: bump a `manifest_version`
+on the registry row; connections pinned to an older version keep old permissions until
+the user re-approves.
+
+New schema: `partner_apps` (clientId, name, manifest JSON, manifestVersion, webhookUrl,
+webhookSecret, status). Existing tables carry everything else.
+
+## Piece 2 — The Handoff Flow (lowest-friction path)
+
+Standard OAuth 2.0 authorization-code + PKCE, with Clerk as the identity/token layer
+(as today) and a new **FGAC consent interstitial** replacing the manual dashboard
+approval:
+
+```
+DDJS "Connect your Gmail" button
+  → https://fgac.ai/oauth/authorize?client_id=<ddjs>&state=...&code_challenge=...
+  → [no Clerk session] Clerk sign-in with Google → Google consent (Gmail scope)
+       ← this is the ONLY Google screen; FGAC becomes the token holder via Clerk
+  → FGAC consent page (server-renders partner_apps manifest):
+       "Data Driven Job Search wants to:
+          • Read email in [account picker: kenyesh@gmail.com ▾]  (read-only — cannot send or delete)
+          • Be notified when new email arrives
+        [Approve] [Deny]"
+  → Approve = one click → provisioning transaction (Piece 1) → redirect to
+    https://ddjs.com/fgac/callback?code=...&state=...
+  → DDJS server exchanges code at the token endpoint
+```
+
+Click count: **existing FGAC user = 1 screen** (consent). New user = Google account
+chooser + Google consent + FGAC consent ≈ 3 screens, all standard-feeling. No dashboard
+visit, no manual key creation, no rule configuration.
+
+Why keep Clerk underneath: the MCP flow already proves out Clerk DCR → token → userId
+resolution, discovery endpoints exist, and Google token custody stays exactly where it
+is (Clerk as token vault — the fake-token principle is preserved; DDJS never sees a
+Google credential).
+
+## Piece 3 — Credentials DDJS Receives
+
+Two-step, both reusing existing machinery:
+
+1. **Token endpoint** (Clerk's, as today): authorization code → access token + refresh
+   token. The MCP server already resolves `OAuth token → (userId, clientId) →
+   agent_connections → proxy_key`, so these tokens work against `/api/mcp` immediately.
+2. **Optional key exchange** for the REST proxy: a partner-facing sibling of the
+   existing `/api/auth/cli-token` — `POST /api/auth/partner-token` with the OAuth
+   token returns the connection's `sk_proxy_...` for direct
+   `gmail.fgac.ai/gmail/v1/...` calls with off-the-shelf Google SDKs (Prong 1).
+
+DDJS stores per-user: `{ refresh_token or proxy_key, connection_id }`. Revocation
+story is already built: user blocks the connection or revokes the key in the dashboard
+and both surfaces die.
+
+Recommendation: steer partners to the **OAuth-token path** as primary (rotatable,
+standard, auditable per-connection) and treat the raw proxy key as the escape hatch for
+SDK-endpoint-override users.
+
+## Piece 4 — Push Notifications (net-new subsystem)
+
+Gmail's push model: `users.watch` → Google Cloud **Pub/Sub topic** → HTTPS push to us →
+we fan out to partners. FGAC sits in the middle, which is precisely the product: the
+partner gets notified only about mail its rules let it see.
+
+```
+Gmail ── users.watch ──▶ Pub/Sub topic ── push ──▶ POST /api/webhooks/gmail  (verify OIDC token from Google)
+                                                        │  {emailAddress, historyId}
+                                                        ▼
+                                          history.list(since lastHistoryId)   [owner's Clerk Google token]
+                                                        │  new message IDs
+                                                        ▼
+                                          For each subscription on that account:
+                                            apply the bound key's READ RULES to each message
+                                            (label/sender blacklists — same code path as gmail_read)
+                                                        │  surviving IDs only
+                                                        ▼
+                                          POST partner webhook_url   (HMAC-signed, thin payload)
+                                          { connection_id, account, message_ids: [...], event: "new_email" }
+```
+
+Design decisions:
+
+- **Thin pings, not payloads.** The webhook carries message IDs only; DDJS fetches
+  content back through the proxy with its own credentials, where rules are enforced
+  again at read time. This keeps FGAC out of the business of pushing email bodies to
+  third parties, makes the webhook low-sensitivity, and means a mid-flight rule change
+  is honored at fetch.
+- **Rule-filtered notification.** If the user blacklists a label/sender, DDJS is not
+  even *told* those messages exist. This is the differentiating feature — notification
+  as an access-controlled surface, not a firehose.
+- **Watch lifecycle**: `users.watch` expires after 7 days → daily cron (Vercel cron)
+  re-arms all active subscriptions; store `lastHistoryId` per subscription;
+  `historyId` gaps (expired history) fall back to a `messages.list` reconciliation.
+- **Delivery semantics**: at-least-once, HMAC-SHA256 signature header with the app's
+  `webhookSecret`, exponential-backoff retries, auto-disable + dashboard flag after N
+  consecutive failures. `webhook_deliveries` table for the audit trail ("DDJS was
+  notified about 42 messages this week" belongs in the user's dashboard).
+- **One topic, many accounts**: a single Pub/Sub topic; the notification names the
+  account, we route by `emailAddress → notification_subscriptions`.
+
+New schema: `notification_subscriptions` (connectionId, targetEmail, lastHistoryId,
+watchExpiresAt, status), `webhook_deliveries` (subscriptionId, messageIds, status,
+attempts, timestamps).
+
+Prerequisite: a GCP project with Pub/Sub + granting `gmail-api-push@system.gserviceaccount.com`
+publish rights on the topic. Note `users.watch` must be called with the *user's* OAuth
+token (from Clerk) — scope-wise `gmail.readonly` suffices, which we already hold.
+
+## Security Notes
+
+- **Confused deputy / CSRF**: `state` + PKCE mandatory; consent page binds to the
+  authenticated Clerk session.
+- **No silent escalation**: manifest is copied at consent; broadening requires
+  re-consent (manifest_version pinning).
+- **Webhook SSRF/exfil**: webhook URLs are registered and verified at app registration
+  (challenge round-trip), never taken from runtime requests; reject private-range hosts.
+- **Fake-token principle intact**: partners receive FGAC credentials only; Google
+  tokens never leave Clerk custody.
+- **Registry as trust gate**: manual app registration doubles as app review; the
+  consent screen renders only registry data, never client-supplied strings.
+
+## Sequencing
+
+**Phase 1 — Handoff + default permissions** (recomposition, ~all existing infra):
+`partner_apps` table + manifest format → consent page (`/oauth/authorize` interstitial)
+→ provisioning transaction → partner token exchange endpoint → dashboard shows partner
+connections like agent connections today.
+*Fallback that works day one: DDJS polls `gmail_list` on an interval — notifications are
+an optimization, not a blocker for the integration.*
+
+**Phase 2 — Push notifications**: Pub/Sub topic + `/api/webhooks/gmail` receiver →
+subscription provisioning at consent → watch-renewal cron → HMAC webhook dispatcher
+with retries → delivery audit in dashboard.
+
+**Phase 3 — Self-serve registry** (later): partner-facing app registration UI with a
+review queue, once more than a handful of partners exist.

--- a/docs/implementation_plans/third-party-handoff-permissions_v6.md
+++ b/docs/implementation_plans/third-party-handoff-permissions_v6.md
@@ -1,0 +1,598 @@
+# Third-Party App Handoff: Auth, Default Permissions, and Push Notifications
+
+> Strategy for letting third-party websites/agents (canonical example: "Data Driven Job
+> Search", DDJS) hand their signed-in users off to FGAC, receive scoped credentials with
+> app-declared default permissions, and get push notifications for new emails.
+>
+> Branch: `claude/third-party-handoff-permissions-81dc96` — v6 (deployment roadmap + QA additions)
+>
+> **v6 changes (2026-08-06):** added the Deployment Roadmap to Production and the QA
+> Acceptance Test Additions sections (new capability docs 11 & 12, setup doc 04, runbook
+> and harness changes).
+>
+> **v5 changes (2026-08-06):** Production GCP project confirmed as
+> **`fine-grain-access-control`** (project number 727876597677) — verified by reading
+> the `client_id` off the prod sign-in Google redirect
+> (`727876597677-mah85mt4es0j11hkbin5a0ira72lhqq4.apps.googleusercontent.com`), not by
+> name-matching. The Phase 2 prod topic must be created in that project
+> (`projects/fine-grain-access-control/topics/fgac-gmail-watch`).
+>
+> **v4 changes (2026-08-06):** Spike 2 closed end-to-end — topic
+> `projects/dev-fgac-ai/topics/fgac-gmail-watch` created with
+> `gmail-api-push@system.gserviceaccount.com` as publisher (durable dev infra, kept);
+> watch armed via Clerk-vaulted token (`{historyId: 4467423, expiration: +7d}`); test
+> email → Pub/Sub notification `{emailAddress, historyId}` in ~2s → `history.list`
+> diff resolved the exact message id. Watch stopped and spike pull subscription
+> deleted after the test. Added the Dev→Prod Infrastructure Sync section.
+> **v3 changes:** Spikes 1 and 2 executed 2026-08-05 — results below. Spike 3 resolved
+> (FGAC has passed CASA Tier 2 for Gmail read). Spike 4 expanded from a question into a
+> concrete design recommendation (DB-backed outbox + cron).
+> **v2 changes:** added the De-risking Spikes section; corrected the DDJS manifest
+> example — send is already deny-by-default when no `send_whitelist` rule exists
+> (`src/app/api/proxy/[...path]/route.ts` §5), so a read-only role needs no rule
+> templates at all.
+
+## Spike Results (executed 2026-08-05, dev environment)
+
+### Spike 1 — Clerk as OAuth AS with FGAC-owned consent: **PASS** ✅
+
+Method: created a pre-registered OAuth application ("DDJS Spike Partner App") via the
+Clerk Backend API (`POST /v1/oauth_applications`), walked the full authorize flow in
+the browser as USER_A against the dev instance, exercised the token endpoint, and
+probed the bypass path against the local MCP server.
+
+| Question | Result |
+|----------|--------|
+| Can Clerk's consent screen be skipped per-app? | **Yes.** `consent_screen_enabled` is a per-app, API-writable boolean. `false` → authorize silently redirects with a code, no screen. `true` → consent shown on **every** authorize (no grant-memory skip), so the toggle is fully authoritative. |
+| Is Clerk's consent screen usable as FGAC consent? | No — it renders only identity scopes ("your email address, basic profile"), nothing about Gmail/FGAC permissions. Confirms the FGAC interstitial is required and Clerk's screen should be disabled for partner apps. |
+| Does the bypass fail safe? | **Yes.** With consent disabled, driving Clerk's authorize URL directly issues tokens silently — but calling `/api/mcp` with that token creates a `pending` connection and every tool call refuses with "awaiting user approval". Deny-by-default holds. |
+| Refresh tokens for pre-registered confidential clients? | **Yes.** `offline_access` is in default scopes; access tokens live 24h (`expires_in: 86399`); `refresh_token` grant works and **rotates** the refresh token. |
+| Do we need to become our own AS? | **No.** The fallback (FGAC-issued codes/tokens) is unnecessary. |
+
+Implications for the design: partner apps are created with `consent_screen_enabled:
+false`; the FGAC interstitial performs provisioning *before* redirecting into Clerk's
+authorize URL; the pending-by-default MCP behavior is the safety net for anyone who
+skips the interstitial. One consent screen total, as designed.
+
+### Spike 2 — Gmail `users.watch` + Pub/Sub with Clerk-vaulted tokens: **PASS (one step remains, gated on GCP access)** 🟡
+
+Method: pulled USER_A's Google token via the Clerk Backend API (the same path
+`getGoogleToken` uses), inspected it via tokeninfo, called `users.watch` with several
+topic names, and validated the `history.list` diff mechanic with a real send.
+
+| Question | Result |
+|----------|--------|
+| Does dev Clerk use shared or custom Google credentials? | **Custom.** Token `azp` = client `627660126377-…` in GCP project **`dev-fgac-ai`**. The feared dev blocker (Clerk shared creds) does not exist — dev/QA of Phase 2 is viable. |
+| Topic-project constraint real? | **Confirmed empirically.** Watch with any foreign topic → `400 Invalid topicName does not match projects/dev-fgac-ai/topics/*`. The topic must live in the OAuth client's project, and the error names it. |
+| Scope sufficient? | **Yes.** Vaulted tokens carry `gmail.modify`; watch calls authenticate and proceed to topic resolution. |
+| Watch → publish chain | Watch with a correctly-formed `projects/dev-fgac-ai/topics/…` name returns `404 Error sending test message to Cloud PubSub … Resource not found` — Gmail **publishes a test message at watch time**, so a single successful watch call will prove the publish grant end-to-end. |
+| `history.list` diff mechanic | **Validated.** Baseline `historyId` 4467334 → sent test email → `history.list(startHistoryId, historyTypes=messageAdded)` returned exactly the new message id and the next cursor (4467385). |
+
+**CLOSED 2026-08-06:** topic + publisher grant created in `dev-fgac-ai`; watch armed
+(`{historyId: 4467423, expiration: +7 days}`); test email produced a Pub/Sub
+notification `{"emailAddress": "kenyesh2@gmail.com", "historyId": …}` within ~2
+seconds; `history.list(startHistoryId=<notification cursor>)` resolved to exactly the
+new message id. Note Gmail also publishes a notification *at watch time* (the arming
+test message) — the receiver must tolerate notifications that diff to zero new
+messages. Dev topic and IAM grant are kept as standing infra; the same setup is
+needed in the production client's GCP project before Phase 2 ships (see Dev→Prod
+Infrastructure Sync below).
+
+## Dev→Prod Infrastructure Sync
+
+The Pub/Sub resources live **outside** the repo/Vercel pipeline — nothing in
+`/deploy-pr-preview` or `/deploy-prod` creates them. Keep dev and prod in sync by
+construction, not by memory:
+
+1. **One idempotent setup script, checked in** — `scripts/setup-gmail-push.sh`
+   (Phase 2 deliverable). Takes `--project <id>`; creates the topic if missing, adds
+   the `gmail-api-push` publisher binding if missing, creates the push subscription
+   pointing at `https://<host>/api/webhooks/gmail` with OIDC auth. Follows the repo's
+   production-script convention: requires explicit `--prod --apply` to touch the prod
+   project, prints a diff-style plan without `--apply`. Running the same script in
+   both projects is what keeps them identical.
+2. **Topic name is an env var, never hardcoded** — `GMAIL_PUBSUB_TOPIC` set per Vercel
+   environment (development → `projects/dev-fgac-ai/topics/fgac-gmail-watch`,
+   production → the prod project's topic). Pasted into Vercel **without quotes**.
+   Code that arms watches reads only this var, so a missing/mismatched value fails
+   loudly instead of silently watching into the wrong project.
+3. **Preflight verification** — extend `env:check` (or add `npm run push:check`) to
+   assert: (a) `GMAIL_PUBSUB_TOPIC` is set and well-formed; (b) the topic's project
+   matches the GCP project of the Clerk instance's Google OAuth client (probe: pull
+   any vaulted token, compare `azp` client project vs. topic project — exactly the
+   mismatch class the spike surfaced); (c) the publisher binding exists. This makes
+   "is prod wired?" a command, not a memory.
+4. **Prod OAuth client's project: IDENTIFIED** — `fine-grain-access-control`
+   (727876597677), verified 2026-08-06 via the `client_id` on the prod sign-in Google
+   redirect. The prod topic goes there:
+   `projects/fine-grain-access-control/topics/fgac-gmail-watch`.
+5. **What does NOT need syncing**: watch registrations are runtime state, created
+   per-subscription by the app and re-armed by the renewal cron — they are never
+   provisioned by hand in either environment. Only topic + IAM binding + push
+   subscription + env var are infrastructure.
+6. **Prod checklist (before Phase 2 `/deploy-prod`)**: run the setup script with
+   `--prod --apply` against the prod project → add `GMAIL_PUBSUB_TOPIC` to Vercel
+   production env (user redeploys) → `push:check` green against prod config.
+
+### Spike 3 — Google verification: **RESOLVED** ✅
+
+FGAC has passed **CASA Tier 2 for Gmail read**. No unverified-app warning in partner
+funnels and no 100-user cap. (Keep in view: scope additions or new restricted scopes
+would trigger re-verification; annual CASA recertification applies.)
+
+### Spike 4 — Webhook delivery on Vercel: design decision (expanded)
+
+See the dedicated section below — recommendation is a **DB-backed outbox drained by
+Vercel cron**, with QStash as the documented escalation path.
+
+## Spike 4 Expanded — Webhook Delivery Mechanics on Vercel
+
+### Why this needs deciding at all
+
+Vercel functions are request-scoped: no resident workers, no in-memory queues that
+survive a response, no `setTimeout`-and-retry. Every delivery attempt must be triggered
+by an inbound HTTP request (a Pub/Sub push, a cron tick) and finish within the
+function's `maxDuration`. "Retry with exponential backoff" therefore has to be encoded
+as *durable state plus a scheduler*, not as code that waits.
+
+### The delivery chain and where each failure lands
+
+```
+Pub/Sub push → /api/webhooks/gmail          (ack fast: verify OIDC, enqueue, 200)
+                    │ write outbox row(s)
+                    ▼
+        webhook_deliveries (outbox table)   status: pending | delivering | delivered | failed | dead
+                    ▼
+Cron tick → /api/cron/deliver-webhooks      (drain due rows, POST to partners)
+                    │ success → delivered
+                    │ failure → attempts++, next_attempt_at = now + backoff(attempts)
+                    ▼
+        after N failures → dead + subscription flagged; dashboard shows it
+```
+
+Key separation: **ack Pub/Sub immediately** (do the `history.list` diff + rule filter +
+outbox insert, return 200), and let delivery to partners be async. Coupling Google's
+retry loop to partner availability is the failure mode to avoid — Pub/Sub's ack
+deadline is short, and an unacked backlog on a flaky partner would stall notifications
+for *everyone* on that subscription's topic.
+
+### Option A — DB-backed outbox + Vercel cron (recommended)
+
+- `webhook_deliveries` table is the queue: `(id, subscriptionId, payload, status,
+  attempts, nextAttemptAt, lastError, createdAt, deliveredAt)`.
+- A Vercel cron hits `/api/cron/deliver-webhooks` every minute (Pro plan floor). The
+  drainer claims due rows (`status='pending' AND nextAttemptAt <= now`) with
+  `UPDATE … SET status='delivering' … RETURNING` (skip-locked semantics) so overlapping
+  ticks never double-send, POSTs each with the HMAC signature, and writes back the
+  outcome.
+- Backoff schedule: 1m, 5m, 15m, 1h, 6h, 24h → `dead` (≈6 attempts over ~31h). With a
+  1-minute cron, sub-minute backoff is unachievable — acceptable, because the *first*
+  attempt is not cron-gated: the Pub/Sub handler fires one immediate best-effort
+  delivery inline after inserting the row (happy path stays real-time, measured
+  seconds from email arrival), and the cron only picks up failures.
+- Auto-disable: N consecutive `dead` deliveries on one subscription → subscription
+  `status='suspended'`, surfaced on the user dashboard and (optionally) emailed to the
+  partner's ops contact. Re-enable is a partner/dashboard action that also triggers a
+  reconciliation sweep (`messages.list` since last delivered `historyId`).
+
+**Pros:** zero new vendors; state lives next to the data it describes; the audit trail
+("DDJS was notified of 42 messages") is the queue table itself; trivially testable in
+QA (call the cron route directly). **Cons:** 1-minute retry granularity; drainer must
+respect `maxDuration` (cap batch size, let the next tick continue); Neon connection
+budget for a chatty cron (fine at this scale).
+
+### Option B — QStash (or similar HTTP task queue)
+
+Publish each delivery to QStash with the partner URL as target; QStash owns retries,
+backoff, and DLQ, and signs requests. **Pros:** less delivery code, second-granularity
+retries, built-in DLQ. **Cons:** new vendor dependency + cost; the audit trail and
+auto-disable logic still need our own table (so much of Option A gets built anyway);
+partner-visible requests originate from QStash IPs (harder allowlisting story);
+webhook secrets/HMAC handling shifts partially into a third party's custody, which is
+an awkward fit for a security-positioning product.
+
+### Option C — lean on Pub/Sub redelivery (rejected)
+
+Don't ack until the partner accepts. Rejected for the coupling reason above, plus:
+ack deadline ceiling (~600s) can't express multi-hour backoff, and one notification
+may fan out to multiple subscriptions with different outcomes — partial-failure
+acking is unexpressible.
+
+### Idempotency & ordering (applies to every option)
+
+- **Inbound dedup:** Pub/Sub is at-least-once. The `(subscription, historyId-range)`
+  work is naturally idempotent because the diff runs off our stored cursor: a duplicate
+  push re-diffs from the same `lastHistoryId` and upserts the same outbox rows —
+  enforce with a unique index on `(subscriptionId, messageId)`.
+- **Outbound idempotency:** every delivery carries an `X-FGAC-Delivery-Id` (the outbox
+  row id) so partners can dedup; document that retries reuse the id.
+- **Ordering:** not guaranteed and not promised — the payload's `historyId` cursor is
+  monotonic, and partners fetching via the proxy always see current state, so
+  out-of-order thin pings are harmless.
+
+### Recommendation
+
+**Option A** for Phase 2. The scale argument is decisive: at launch volume (tens of
+partners, thousands of notifications/day) a cron drainer is far below any limit, and
+the pieces Option B doesn't cover (audit, auto-disable, dashboard) are the majority of
+the work anyway. Revisit QStash only if retry-latency granularity or cron volume
+becomes a measured problem. Build the drainer behind an interface
+(`deliverPending(batch)`) so swapping the scheduler later is contained.
+
+### Verified during strategy review (no spike needed)
+
+- **Read-only role expressibility**: send is deny-by-default absent a whitelist rule
+  (proxy §5); `google_api_modify` exposes only `messages/send` and denies unparseable
+  recipients; DELETE isn't exposed on MCP and trash/emptyTrash are hard-blocked on the
+  proxy. A no-rules key is already read-only.
+- **Token→key resolution chain** for partner servers: `verifyClerkToken` → connection →
+  key already works (MCP), and `/api/auth/cli-token` proves the OAuth-token→proxy-key
+  exchange pattern.
+
+## The Scenario
+
+DDJS runs a server-side agent that categorizes every new email a user receives into an
+interview stage and extracts action items. It needs:
+
+1. A signed-in DDJS user handed off to FGAC (account creation if needed) and back.
+2. FGAC-side **default permissions for the DDJS agent role** (read-only Gmail, no send,
+   no delete) applied without the user hand-assembling rules.
+3. Credentials returned to DDJS's **server** (not a browser/MCP client) that work with
+   the existing proxy/MCP surfaces.
+4. **Push notifications** to DDJS when new mail arrives, filtered by the same rules.
+
+## What Exists Today (and what's missing)
+
+| Need | Today | Gap |
+|------|-------|-----|
+| Third-party OAuth into FGAC | Clerk DCR + `agent_connections` pending-approval flow (built for MCP clients) | Approval is a *separate dashboard visit* where the user manually picks a proxy key; no inline consent, no way back to the app |
+| Default permissions per app | `access_rules` + `key_rule_assignments` exist, fully manual | No concept of a **registered app** with a declared permission manifest/template |
+| Server credentials | `sk_proxy_...` keys + REST proxy; `/api/auth/cli-token` already exchanges an OAuth token for a proxy key | No partner-facing token endpoint; keys are provisioned manually in the dashboard |
+| Push notifications | Nothing (no `users.watch`, no Pub/Sub, no webhook delivery) | Entire subsystem is net-new |
+
+The good news: 1–3 are mostly **recomposition of existing primitives**. Only 4 is a new
+subsystem.
+
+## Piece 1 — Partner App Registry with Permission Manifests ("Agent Roles")
+
+The core new concept. A third-party app registers with FGAC once (initially by us,
+manually — this is also the review/verification gate) and gets:
+
+- An OAuth `client_id` (Clerk OAuth application — same machinery the MCP DCR flow uses,
+  but pre-registered rather than dynamic).
+- A **permission manifest**: the app's requested "role", declared as a template of
+  `access_rules` plus capability flags. For DDJS:
+
+```jsonc
+{
+  "app": "Data Driven Job Search",
+  "logo_url": "...",
+  "requested": {
+    "services": ["gmail"],
+    "access": "read_only",            // no send whitelist rule = send denied by default (proxy §5)
+    "rule_templates": [],             // read-only needs none; write-capable apps declare whitelists here
+    "notifications": { "trigger": "new_email" }
+  },
+  "webhook_url": "https://api.ddjs.com/fgac/webhook",   // verified at registration
+  "redirect_uris": ["https://ddjs.com/fgac/callback"]
+}
+```
+
+**Consent-time provisioning**: when a user approves the app, FGAC auto-creates in one
+transaction what the user builds by hand today:
+
+1. A proxy key labeled `"Data Driven Job Search"`.
+2. `key_email_access` rows for the account(s) the user selected on the consent screen.
+3. Copies of the manifest's rule templates as `access_rules` bound to that key via
+   `key_rule_assignments` (copies, not references — the user can then tighten them per
+   normal, and a later manifest change by the app cannot silently widen existing grants).
+4. The `agent_connections` row, already `approved` and bound to the key.
+5. (If requested + granted) a `notification_subscriptions` row per account.
+
+Manifest changes that *broaden* access require re-consent: bump a `manifest_version`
+on the registry row; connections pinned to an older version keep old permissions until
+the user re-approves.
+
+New schema: `partner_apps` (clientId, name, manifest JSON, manifestVersion, webhookUrl,
+webhookSecret, status). Existing tables carry everything else.
+
+## Piece 2 — The Handoff Flow (lowest-friction path)
+
+Standard OAuth 2.0 authorization-code + PKCE, with Clerk as the identity/token layer
+(as today) and a new **FGAC consent interstitial** replacing the manual dashboard
+approval:
+
+```
+DDJS "Connect your Gmail" button
+  → https://fgac.ai/oauth/authorize?client_id=<ddjs>&state=...&code_challenge=...
+  → [no Clerk session] Clerk sign-in with Google → Google consent (Gmail scope)
+       ← this is the ONLY Google screen; FGAC becomes the token holder via Clerk
+  → FGAC consent page (server-renders partner_apps manifest):
+       "Data Driven Job Search wants to:
+          • Read email in [account picker: kenyesh@gmail.com ▾]  (read-only — cannot send or delete)
+          • Be notified when new email arrives
+        [Approve] [Deny]"
+  → Approve = one click → provisioning transaction (Piece 1) → redirect to
+    https://ddjs.com/fgac/callback?code=...&state=...
+  → DDJS server exchanges code at the token endpoint
+```
+
+Click count: **existing FGAC user = 1 screen** (consent). New user = Google account
+chooser + Google consent + FGAC consent ≈ 3 screens, all standard-feeling. No dashboard
+visit, no manual key creation, no rule configuration.
+
+Why keep Clerk underneath: the MCP flow already proves out Clerk DCR → token → userId
+resolution, discovery endpoints exist, and Google token custody stays exactly where it
+is (Clerk as token vault — the fake-token principle is preserved; DDJS never sees a
+Google credential).
+
+## Piece 3 — Credentials DDJS Receives
+
+Two-step, both reusing existing machinery:
+
+1. **Token endpoint** (Clerk's, as today): authorization code → access token + refresh
+   token. The MCP server already resolves `OAuth token → (userId, clientId) →
+   agent_connections → proxy_key`, so these tokens work against `/api/mcp` immediately.
+2. **Optional key exchange** for the REST proxy: a partner-facing sibling of the
+   existing `/api/auth/cli-token` — `POST /api/auth/partner-token` with the OAuth
+   token returns the connection's `sk_proxy_...` for direct
+   `gmail.fgac.ai/gmail/v1/...` calls with off-the-shelf Google SDKs (Prong 1).
+
+DDJS stores per-user: `{ refresh_token or proxy_key, connection_id }`. Revocation
+story is already built: user blocks the connection or revokes the key in the dashboard
+and both surfaces die.
+
+Recommendation: steer partners to the **OAuth-token path** as primary (rotatable,
+standard, auditable per-connection) and treat the raw proxy key as the escape hatch for
+SDK-endpoint-override users.
+
+## Piece 4 — Push Notifications (net-new subsystem)
+
+Gmail's push model: `users.watch` → Google Cloud **Pub/Sub topic** → HTTPS push to us →
+we fan out to partners. FGAC sits in the middle, which is precisely the product: the
+partner gets notified only about mail its rules let it see.
+
+```
+Gmail ── users.watch ──▶ Pub/Sub topic ── push ──▶ POST /api/webhooks/gmail  (verify OIDC token from Google)
+                                                        │  {emailAddress, historyId}
+                                                        ▼
+                                          history.list(since lastHistoryId)   [owner's Clerk Google token]
+                                                        │  new message IDs
+                                                        ▼
+                                          For each subscription on that account:
+                                            apply the bound key's READ RULES to each message
+                                            (label/sender blacklists — same code path as gmail_read)
+                                                        │  surviving IDs only
+                                                        ▼
+                                          POST partner webhook_url   (HMAC-signed, thin payload)
+                                          { connection_id, account, message_ids: [...], event: "new_email" }
+```
+
+Design decisions:
+
+- **Thin pings, not payloads.** The webhook carries message IDs only; DDJS fetches
+  content back through the proxy with its own credentials, where rules are enforced
+  again at read time. This keeps FGAC out of the business of pushing email bodies to
+  third parties, makes the webhook low-sensitivity, and means a mid-flight rule change
+  is honored at fetch.
+- **Rule-filtered notification.** If the user blacklists a label/sender, DDJS is not
+  even *told* those messages exist. This is the differentiating feature — notification
+  as an access-controlled surface, not a firehose.
+- **Watch lifecycle**: `users.watch` expires after 7 days → daily cron (Vercel cron)
+  re-arms all active subscriptions; store `lastHistoryId` per subscription;
+  `historyId` gaps (expired history) fall back to a `messages.list` reconciliation.
+- **Delivery semantics**: at-least-once, HMAC-SHA256 signature header with the app's
+  `webhookSecret`, exponential-backoff retries, auto-disable + dashboard flag after N
+  consecutive failures. `webhook_deliveries` table for the audit trail ("DDJS was
+  notified about 42 messages this week" belongs in the user's dashboard).
+- **One topic, many accounts**: a single Pub/Sub topic; the notification names the
+  account, we route by `emailAddress → notification_subscriptions`.
+
+New schema: `notification_subscriptions` (connectionId, targetEmail, lastHistoryId,
+watchExpiresAt, status), `webhook_deliveries` (subscriptionId, messageIds, status,
+attempts, timestamps).
+
+Prerequisite: a GCP project with Pub/Sub + granting `gmail-api-push@system.gserviceaccount.com`
+publish rights on the topic. Note `users.watch` must be called with the *user's* OAuth
+token (from Clerk) — scope-wise `gmail.readonly` suffices, which we already hold.
+
+## Security Notes
+
+- **Confused deputy / CSRF**: `state` + PKCE mandatory; consent page binds to the
+  authenticated Clerk session.
+- **No silent escalation**: manifest is copied at consent; broadening requires
+  re-consent (manifest_version pinning).
+- **Webhook SSRF/exfil**: webhook URLs are registered and verified at app registration
+  (challenge round-trip), never taken from runtime requests; reject private-range hosts.
+- **Fake-token principle intact**: partners receive FGAC credentials only; Google
+  tokens never leave Clerk custody.
+- **Registry as trust gate**: manual app registration doubles as app review; the
+  consent screen renders only registry data, never client-supplied strings.
+
+## Sequencing
+
+**Phase 1 — Handoff + default permissions** (recomposition, ~all existing infra):
+`partner_apps` table + manifest format → consent page (`/oauth/authorize` interstitial)
+→ provisioning transaction → partner token exchange endpoint → dashboard shows partner
+connections like agent connections today.
+*Fallback that works day one: DDJS polls `gmail_list` on an interval — notifications are
+an optimization, not a blocker for the integration.*
+
+**Phase 2 — Push notifications**: Pub/Sub topic + `/api/webhooks/gmail` receiver →
+subscription provisioning at consent → watch-renewal cron → HMAC webhook dispatcher
+with retries → delivery audit in dashboard.
+
+**Phase 3 — Self-serve registry** (later): partner-facing app registration UI with a
+review queue, once more than a handful of partners exist.
+
+## Deployment Roadmap to Production
+
+Two PRs, each following the standard pipeline: branch → implement → local QA →
+`/deploy-pr-preview` → QA suites against the preview → user runs `/deploy-prod`.
+Phase 1 ships alone first; the polling fallback (`gmail_list`) makes it independently
+useful, and it de-risks the schema and consent surface before any Pub/Sub code exists.
+
+### PR 1 — Partner handoff + default permissions (Phase 1)
+
+1. **Schema** (`npm run db:branch` FIRST, then edit `src/db/schema.ts`):
+   `partner_apps` (clerkOauthAppId, clientId, name, logoUrl, manifest JSONB,
+   manifestVersion, webhookUrl, webhookSecret, status). Add `partnerAppId` +
+   `manifestVersion` nullable FKs on `agent_connections` (provenance + re-consent
+   pinning). `drizzle-kit generate` → verify NNNN_*.sql exists → `npm run db:migrate`
+   against the branch (Database Rule 8).
+2. **Partner registration script** — `scripts/register-partner-app.ts`: creates the
+   Clerk OAuth application (`consent_screen_enabled: false`, partner redirect URIs)
+   via the Backend API AND the `partner_apps` row in one go. Per-environment by
+   design (dev Clerk + prod Clerk are separate instances — a partner must be
+   registered in each). `--prod` + `--apply` guards per repo convention.
+3. **Consent interstitial** — `/oauth/authorize` page route: require Clerk session
+   (redirect to sign-in and back if absent); look up `partner_apps` by `client_id`;
+   render manifest-driven consent (app name/logo, permission summary, account
+   picker); Approve = one provisioning transaction (proxy key labeled with app name,
+   `key_email_access`, rule copies from manifest, `agent_connections` row approved +
+   pinned to manifestVersion) then 302 into Clerk's authorize URL; Deny = 302 to
+   partner `redirect_uri` with `error=access_denied`. `state` and PKCE params pass
+   through untouched.
+4. **Partner token exchange** — `/api/auth/partner-token` (sibling of `cli-token`):
+   Clerk OAuth token in, connection's `sk_proxy_...` out.
+5. **Dashboard** — partner connections render in ConnectionsPanel with a partner
+   badge (name/logo from registry); revoke/block works unchanged.
+6. **Docs** — update `distribution_architecture.md` (5th distribution channel),
+   `architecture_and_strategy.md`, `user_guide.md`, data model docs.
+7. **QA** — new capability doc 11 + setup doc 04 (below); update the four agent
+   runbooks; `npx tsx scripts/qa-coverage-check.ts` green; run `/qa-hosted-mcp`
+   minimum, ideally all four suites.
+8. **Security review** — run `/security-review` on the branch (new auth surface).
+9. **Deploy** — `/deploy-pr-preview`, register the spike partner app against the
+   preview URL, walk the handoff end-to-end on preview, then hand to user for
+   `/deploy-prod`. Post-deploy: run `register-partner-app.ts --prod` for the first
+   real partner (DDJS), smoke the flow against `fgac.ai`.
+
+### PR 2 — Push notifications (Phase 2)
+
+1. **Schema**: `notification_subscriptions` (connectionId, targetEmail,
+   lastHistoryId, watchExpiresAt, status) + `webhook_deliveries` (subscriptionId,
+   messageIds, status, attempts, nextAttemptAt, lastError, deliveredAt; unique
+   (subscriptionId, messageId)).
+2. **GCP infra script** — `scripts/setup-gmail-push.sh --project <id> [--prod
+   --apply]`: idempotent topic + `gmail-api-push` publisher grant + push
+   subscription → `https://<host>/api/webhooks/gmail` with OIDC. Dev
+   (`dev-fgac-ai`) already has topic+grant from the spike — script adopts it;
+   prod target is `projects/fine-grain-access-control/topics/fgac-gmail-watch`.
+3. **Env** — `GMAIL_PUBSUB_TOPIC` per Vercel environment (no quotes). Extend
+   `env:check`/add `push:check`: topic set + topic project == token `azp` project +
+   publisher binding present.
+4. **Receiver** — `/api/webhooks/gmail`: verify Google OIDC JWT, load subscriptions
+   for `emailAddress`, `history.list` from stored cursor, apply the bound key's read
+   rules, insert outbox rows, fire one inline delivery attempt, ack 200 fast.
+   Tolerate zero-diff notifications (watch-time test message — spike finding).
+5. **Crons** (`vercel.json`): `/api/cron/deliver-webhooks` every minute (atomic
+   claim, HMAC POST, backoff ladder 1m→5m→15m→1h→6h→24h→dead, auto-suspend after N
+   dead + reconciliation sweep on re-enable); `/api/cron/renew-watches` daily
+   (re-arm watches expiring within 48h; watches live 7 days).
+6. **Consent integration** — manifest `notifications` grant creates the subscription
+   and arms the watch inside the Phase 1 provisioning transaction; revoke/block
+   tears down watch + subscription.
+7. **QA** — capability doc 12 + local webhook-receiver harness (below); coverage
+   check green; full suites.
+8. **Deploy** — preview QA uses the dev topic with a **pull-drain harness** (Pub/Sub
+   cannot push to localhost/preview reliably: a QA script drains a pull subscription
+   and POSTs to the local receiver, simulating Google's push). Prod: run infra
+   script `--prod --apply`, add prod env var, user runs `/deploy-prod`, `push:check`
+   green, then a canary: arm one watch on the owner account, send a self-email,
+   verify the delivery row and partner ping.
+
+### Standing prod checklist (condensed)
+
+| Step | Owner |
+|------|-------|
+| `setup-gmail-push.sh --prod --apply` (topic/grant/push-sub in `fine-grain-access-control`) | Claude (user-approved) |
+| `GMAIL_PUBSUB_TOPIC` added to Vercel production env, no quotes | user approves `vercel env add` |
+| Production redeploy | **user** (`/deploy-prod`) |
+| `register-partner-app.ts --prod` per partner (Clerk prod app + registry row) | Claude (user-approved) |
+| `push:check` + canary watch verification | Claude |
+
+## QA Acceptance Test Additions
+
+Two new capability docs (assertion checklists) + one setup doc + harness changes.
+Adding them makes `qa-coverage-check` require their assertions in every
+`qa-results.json` — the agent runbooks must be updated in the same PR, with
+channel-applicability notes where a surface is browser-only.
+
+### `capabilities/11_partner_handoff.md` (PR 1) — draft assertions
+
+- **A1** Unknown `client_id` on `/oauth/authorize` → error page, nothing provisioned.
+- **A2** Registered partner authorize → FGAC consent interstitial renders manifest
+  (app name, permission summary, account picker) — registry data only, no
+  client-supplied strings.
+- **A3** Deny → partner callback receives `error=access_denied`, `state` intact; no
+  key/connection/rules created.
+- **A4** Approve → single transaction provisions: key labeled with app name,
+  `key_email_access` for the chosen account, manifest rule copies bound to the key,
+  connection `approved` + pinned to manifestVersion; redirect carries `code` + `state`.
+- **A5** Code exchange returns access + refresh token; an MCP tool call works
+  immediately (no pending step). Refresh grant rotates and works.
+- **A6** `/api/auth/partner-token` exchanges the OAuth token for the connection's
+  `sk_proxy_...`; REST proxy call succeeds with it.
+- **A7** **Bypass fail-safe**: driving Clerk's authorize URL directly (interstitial
+  skipped) yields tokens whose MCP calls return "pending approval" — never
+  auto-provisioned. (Spike 1 finding, must stay true forever.)
+- **A8** Read-only default: `gmail_send` and proxy `messages/send` → 403
+  deny-by-default (manifest has no send whitelist).
+- **A9** Dashboard shows the partner connection with partner badge; Detach/block
+  kills BOTH the OAuth-token path and the proxy-key path.
+- **A10** Re-consent pinning: bumping `manifestVersion` in the registry does not
+  widen an existing connection's permissions.
+- *Channels*: A2–A4, A9 are browser-agent assertions; A1, A5–A8, A10 run via curl —
+  primary runbook `agents/01_hosted_mcp.md`, with dashboard steps marked
+  browser-only (same pattern as capability 06).
+
+### `capabilities/12_push_notifications.md` (PR 2) — draft assertions
+
+- **A1** Consent with notifications grant → `notification_subscriptions` row exists,
+  watch armed (`watchExpiresAt` ~7 days out, `lastHistoryId` set).
+- **A2** New email → local webhook receiver gets thin ping `{connection_id, account,
+  message_ids[]}` with valid HMAC signature and `X-FGAC-Delivery-Id` header, within
+  60s.
+- **A3** Payload is IDs-only — no subject, snippet, body, or sender anywhere in it.
+- **A4** **Rule filtering**: email carrying a read-blacklisted label (reuse
+  capability 05 baseline) produces NO webhook; a mixed batch delivers only the
+  allowed IDs.
+- **A5** Zero-diff notification (watch-time test message) produces no partner ping.
+- **A6** Duplicate Pub/Sub delivery of the same notification → exactly one outbox
+  row per (subscription, messageId); no double ping.
+- **A7** Failing receiver (harness returns 500) → `attempts` increments on backoff
+  schedule; after N dead the subscription is `suspended` and the dashboard flags it.
+- **A8** Re-enabling a suspended subscription triggers a reconciliation sweep that
+  delivers the missed message IDs.
+- **A9** Renewal cron advances `watchExpiresAt` for watches near expiry.
+- **A10** Detach/revoke → watch stopped, subscription cancelled, no further pings
+  (send another email to prove silence).
+- **A11** Unsigned/invalid-OIDC POST to `/api/webhooks/gmail` → 401/403, nothing
+  processed.
+- **A12** `push:check` passes: `GMAIL_PUBSUB_TOPIC` project matches the Google
+  client (`azp`) project and the publisher binding exists.
+- *Channels*: inherently channel-independent (server-side) — runs once per QA cycle
+  from the hosted-MCP runbook + browser agent for dashboard assertions, not
+  repeated per agent runtime.
+
+### `setup/04_partner_app_registration.md` (PR 1)
+
+Registers the QA partner app ("QA Spike Partner") via `register-partner-app.ts`
+against the dev Clerk instance with redirect URI on localhost, read-only Gmail
+manifest + notifications grant, and records client credentials into the gitignored
+QA config (pattern: `qa-test-agents.json`). Torn down / re-created idempotently each
+cycle.
+
+### Harness changes
+
+- **Local webhook receiver** for capability 12: tiny script
+  (`scripts/qa-webhook-receiver.ts`) that listens on localhost, records received
+  pings + HMAC validity to a JSON file the runner asserts against, and can be told
+  to return 500 (for A7).
+- **Pull-drain bridge** for non-prod Pub/Sub: script drains the dev pull
+  subscription and POSTs to the local receiver-under-test, simulating Google push
+  (Pub/Sub cannot reach localhost).
+- **USER_B re-auth** precondition: dev-instance Google refresh token for USER_B is
+  currently dead (`oauth_token_retrieval_error`, found 2026-08-06) — `/qa-setup`
+  must re-sign-in USER_B before delegation-dependent capabilities run.

--- a/docs/implementation_plans/third-party-handoff-permissions_v7.md
+++ b/docs/implementation_plans/third-party-handoff-permissions_v7.md
@@ -1,0 +1,620 @@
+# Third-Party App Handoff: Auth, Default Permissions, and Push Notifications
+
+> Strategy for letting third-party websites/agents (canonical example: "Data Driven Job
+> Search", DDJS) hand their signed-in users off to FGAC, receive scoped credentials with
+> app-declared default permissions, and get push notifications for new emails.
+>
+> Branch: `claude/third-party-handoff-permissions-81dc96` — v7 (IMPLEMENTED + locally validated)
+>
+> **v7 changes (2026-08-06):** Both PRs implemented on this branch and validated
+> end-to-end against the local dev stack (branch DB, dev Clerk, real Gmail +
+> Pub/Sub via the pull-drain bridge). Validated: consent flow A1-A5, partner
+> token exchange + REST proxy A6, read-only default A8, dashboard badge +
+> detach-kills-both-paths A9, manifest pinning A10 (registry bumped to v3,
+> connection stayed pinned until re-consent picked up v3); push pipeline
+> 12-A1-A4 (signed thin pings, rule-filtered silence: SECRETWORD email filtered,
+> clean control delivered), dedup 12-A6, retry/backoff first rung + recovery
+> 12-A7/A8 (real 60s+ waits, no DB fudging), renewal cron 12-A9, receiver auth
+> 12-A11, teardown 12-A10. Five defects found & fixed during validation:
+> (1) neon-http has no transactions → compensation-based provisioning;
+> (2) duplicate users rows with stale clerkUserIds broke token lookup →
+> candidate fallback; (3) DB/app clock skew defeated inline delivery →
+> app-clock nextAttemptAt; (4) backoff ladder off-by-one (first retry hit 5m
+> rung); (5) **detach left the partner proxy key alive on the REST proxy**
+> (confirmed live read post-detach) → partner-provisioned keys now revoked on
+> block. NOT yet validated: full 6-attempt dead/suspend walk (design-only),
+> Google OIDC push auth (needs preview/prod push subscription), Vercel cron
+> execution (local = direct route calls; per-minute crons need Vercel Pro).
+> Known QA artifact: one pre-fix unrevoked key labeled 'QA Spike Partner'
+> remains active in the disposable branch DB.
+>
+> **v6 changes (2026-08-06):** added the Deployment Roadmap to Production and the QA
+> Acceptance Test Additions sections (new capability docs 11 & 12, setup doc 04, runbook
+> and harness changes).
+>
+> **v5 changes (2026-08-06):** Production GCP project confirmed as
+> **`fine-grain-access-control`** (project number 727876597677) — verified by reading
+> the `client_id` off the prod sign-in Google redirect
+> (`727876597677-mah85mt4es0j11hkbin5a0ira72lhqq4.apps.googleusercontent.com`), not by
+> name-matching. The Phase 2 prod topic must be created in that project
+> (`projects/fine-grain-access-control/topics/fgac-gmail-watch`).
+>
+> **v4 changes (2026-08-06):** Spike 2 closed end-to-end — topic
+> `projects/dev-fgac-ai/topics/fgac-gmail-watch` created with
+> `gmail-api-push@system.gserviceaccount.com` as publisher (durable dev infra, kept);
+> watch armed via Clerk-vaulted token (`{historyId: 4467423, expiration: +7d}`); test
+> email → Pub/Sub notification `{emailAddress, historyId}` in ~2s → `history.list`
+> diff resolved the exact message id. Watch stopped and spike pull subscription
+> deleted after the test. Added the Dev→Prod Infrastructure Sync section.
+> **v3 changes:** Spikes 1 and 2 executed 2026-08-05 — results below. Spike 3 resolved
+> (FGAC has passed CASA Tier 2 for Gmail read). Spike 4 expanded from a question into a
+> concrete design recommendation (DB-backed outbox + cron).
+> **v2 changes:** added the De-risking Spikes section; corrected the DDJS manifest
+> example — send is already deny-by-default when no `send_whitelist` rule exists
+> (`src/app/api/proxy/[...path]/route.ts` §5), so a read-only role needs no rule
+> templates at all.
+
+## Spike Results (executed 2026-08-05, dev environment)
+
+### Spike 1 — Clerk as OAuth AS with FGAC-owned consent: **PASS** ✅
+
+Method: created a pre-registered OAuth application ("DDJS Spike Partner App") via the
+Clerk Backend API (`POST /v1/oauth_applications`), walked the full authorize flow in
+the browser as USER_A against the dev instance, exercised the token endpoint, and
+probed the bypass path against the local MCP server.
+
+| Question | Result |
+|----------|--------|
+| Can Clerk's consent screen be skipped per-app? | **Yes.** `consent_screen_enabled` is a per-app, API-writable boolean. `false` → authorize silently redirects with a code, no screen. `true` → consent shown on **every** authorize (no grant-memory skip), so the toggle is fully authoritative. |
+| Is Clerk's consent screen usable as FGAC consent? | No — it renders only identity scopes ("your email address, basic profile"), nothing about Gmail/FGAC permissions. Confirms the FGAC interstitial is required and Clerk's screen should be disabled for partner apps. |
+| Does the bypass fail safe? | **Yes.** With consent disabled, driving Clerk's authorize URL directly issues tokens silently — but calling `/api/mcp` with that token creates a `pending` connection and every tool call refuses with "awaiting user approval". Deny-by-default holds. |
+| Refresh tokens for pre-registered confidential clients? | **Yes.** `offline_access` is in default scopes; access tokens live 24h (`expires_in: 86399`); `refresh_token` grant works and **rotates** the refresh token. |
+| Do we need to become our own AS? | **No.** The fallback (FGAC-issued codes/tokens) is unnecessary. |
+
+Implications for the design: partner apps are created with `consent_screen_enabled:
+false`; the FGAC interstitial performs provisioning *before* redirecting into Clerk's
+authorize URL; the pending-by-default MCP behavior is the safety net for anyone who
+skips the interstitial. One consent screen total, as designed.
+
+### Spike 2 — Gmail `users.watch` + Pub/Sub with Clerk-vaulted tokens: **PASS (one step remains, gated on GCP access)** 🟡
+
+Method: pulled USER_A's Google token via the Clerk Backend API (the same path
+`getGoogleToken` uses), inspected it via tokeninfo, called `users.watch` with several
+topic names, and validated the `history.list` diff mechanic with a real send.
+
+| Question | Result |
+|----------|--------|
+| Does dev Clerk use shared or custom Google credentials? | **Custom.** Token `azp` = client `627660126377-…` in GCP project **`dev-fgac-ai`**. The feared dev blocker (Clerk shared creds) does not exist — dev/QA of Phase 2 is viable. |
+| Topic-project constraint real? | **Confirmed empirically.** Watch with any foreign topic → `400 Invalid topicName does not match projects/dev-fgac-ai/topics/*`. The topic must live in the OAuth client's project, and the error names it. |
+| Scope sufficient? | **Yes.** Vaulted tokens carry `gmail.modify`; watch calls authenticate and proceed to topic resolution. |
+| Watch → publish chain | Watch with a correctly-formed `projects/dev-fgac-ai/topics/…` name returns `404 Error sending test message to Cloud PubSub … Resource not found` — Gmail **publishes a test message at watch time**, so a single successful watch call will prove the publish grant end-to-end. |
+| `history.list` diff mechanic | **Validated.** Baseline `historyId` 4467334 → sent test email → `history.list(startHistoryId, historyTypes=messageAdded)` returned exactly the new message id and the next cursor (4467385). |
+
+**CLOSED 2026-08-06:** topic + publisher grant created in `dev-fgac-ai`; watch armed
+(`{historyId: 4467423, expiration: +7 days}`); test email produced a Pub/Sub
+notification `{"emailAddress": "kenyesh2@gmail.com", "historyId": …}` within ~2
+seconds; `history.list(startHistoryId=<notification cursor>)` resolved to exactly the
+new message id. Note Gmail also publishes a notification *at watch time* (the arming
+test message) — the receiver must tolerate notifications that diff to zero new
+messages. Dev topic and IAM grant are kept as standing infra; the same setup is
+needed in the production client's GCP project before Phase 2 ships (see Dev→Prod
+Infrastructure Sync below).
+
+## Dev→Prod Infrastructure Sync
+
+The Pub/Sub resources live **outside** the repo/Vercel pipeline — nothing in
+`/deploy-pr-preview` or `/deploy-prod` creates them. Keep dev and prod in sync by
+construction, not by memory:
+
+1. **One idempotent setup script, checked in** — `scripts/setup-gmail-push.sh`
+   (Phase 2 deliverable). Takes `--project <id>`; creates the topic if missing, adds
+   the `gmail-api-push` publisher binding if missing, creates the push subscription
+   pointing at `https://<host>/api/webhooks/gmail` with OIDC auth. Follows the repo's
+   production-script convention: requires explicit `--prod --apply` to touch the prod
+   project, prints a diff-style plan without `--apply`. Running the same script in
+   both projects is what keeps them identical.
+2. **Topic name is an env var, never hardcoded** — `GMAIL_PUBSUB_TOPIC` set per Vercel
+   environment (development → `projects/dev-fgac-ai/topics/fgac-gmail-watch`,
+   production → the prod project's topic). Pasted into Vercel **without quotes**.
+   Code that arms watches reads only this var, so a missing/mismatched value fails
+   loudly instead of silently watching into the wrong project.
+3. **Preflight verification** — extend `env:check` (or add `npm run push:check`) to
+   assert: (a) `GMAIL_PUBSUB_TOPIC` is set and well-formed; (b) the topic's project
+   matches the GCP project of the Clerk instance's Google OAuth client (probe: pull
+   any vaulted token, compare `azp` client project vs. topic project — exactly the
+   mismatch class the spike surfaced); (c) the publisher binding exists. This makes
+   "is prod wired?" a command, not a memory.
+4. **Prod OAuth client's project: IDENTIFIED** — `fine-grain-access-control`
+   (727876597677), verified 2026-08-06 via the `client_id` on the prod sign-in Google
+   redirect. The prod topic goes there:
+   `projects/fine-grain-access-control/topics/fgac-gmail-watch`.
+5. **What does NOT need syncing**: watch registrations are runtime state, created
+   per-subscription by the app and re-armed by the renewal cron — they are never
+   provisioned by hand in either environment. Only topic + IAM binding + push
+   subscription + env var are infrastructure.
+6. **Prod checklist (before Phase 2 `/deploy-prod`)**: run the setup script with
+   `--prod --apply` against the prod project → add `GMAIL_PUBSUB_TOPIC` to Vercel
+   production env (user redeploys) → `push:check` green against prod config.
+
+### Spike 3 — Google verification: **RESOLVED** ✅
+
+FGAC has passed **CASA Tier 2 for Gmail read**. No unverified-app warning in partner
+funnels and no 100-user cap. (Keep in view: scope additions or new restricted scopes
+would trigger re-verification; annual CASA recertification applies.)
+
+### Spike 4 — Webhook delivery on Vercel: design decision (expanded)
+
+See the dedicated section below — recommendation is a **DB-backed outbox drained by
+Vercel cron**, with QStash as the documented escalation path.
+
+## Spike 4 Expanded — Webhook Delivery Mechanics on Vercel
+
+### Why this needs deciding at all
+
+Vercel functions are request-scoped: no resident workers, no in-memory queues that
+survive a response, no `setTimeout`-and-retry. Every delivery attempt must be triggered
+by an inbound HTTP request (a Pub/Sub push, a cron tick) and finish within the
+function's `maxDuration`. "Retry with exponential backoff" therefore has to be encoded
+as *durable state plus a scheduler*, not as code that waits.
+
+### The delivery chain and where each failure lands
+
+```
+Pub/Sub push → /api/webhooks/gmail          (ack fast: verify OIDC, enqueue, 200)
+                    │ write outbox row(s)
+                    ▼
+        webhook_deliveries (outbox table)   status: pending | delivering | delivered | failed | dead
+                    ▼
+Cron tick → /api/cron/deliver-webhooks      (drain due rows, POST to partners)
+                    │ success → delivered
+                    │ failure → attempts++, next_attempt_at = now + backoff(attempts)
+                    ▼
+        after N failures → dead + subscription flagged; dashboard shows it
+```
+
+Key separation: **ack Pub/Sub immediately** (do the `history.list` diff + rule filter +
+outbox insert, return 200), and let delivery to partners be async. Coupling Google's
+retry loop to partner availability is the failure mode to avoid — Pub/Sub's ack
+deadline is short, and an unacked backlog on a flaky partner would stall notifications
+for *everyone* on that subscription's topic.
+
+### Option A — DB-backed outbox + Vercel cron (recommended)
+
+- `webhook_deliveries` table is the queue: `(id, subscriptionId, payload, status,
+  attempts, nextAttemptAt, lastError, createdAt, deliveredAt)`.
+- A Vercel cron hits `/api/cron/deliver-webhooks` every minute (Pro plan floor). The
+  drainer claims due rows (`status='pending' AND nextAttemptAt <= now`) with
+  `UPDATE … SET status='delivering' … RETURNING` (skip-locked semantics) so overlapping
+  ticks never double-send, POSTs each with the HMAC signature, and writes back the
+  outcome.
+- Backoff schedule: 1m, 5m, 15m, 1h, 6h, 24h → `dead` (≈6 attempts over ~31h). With a
+  1-minute cron, sub-minute backoff is unachievable — acceptable, because the *first*
+  attempt is not cron-gated: the Pub/Sub handler fires one immediate best-effort
+  delivery inline after inserting the row (happy path stays real-time, measured
+  seconds from email arrival), and the cron only picks up failures.
+- Auto-disable: N consecutive `dead` deliveries on one subscription → subscription
+  `status='suspended'`, surfaced on the user dashboard and (optionally) emailed to the
+  partner's ops contact. Re-enable is a partner/dashboard action that also triggers a
+  reconciliation sweep (`messages.list` since last delivered `historyId`).
+
+**Pros:** zero new vendors; state lives next to the data it describes; the audit trail
+("DDJS was notified of 42 messages") is the queue table itself; trivially testable in
+QA (call the cron route directly). **Cons:** 1-minute retry granularity; drainer must
+respect `maxDuration` (cap batch size, let the next tick continue); Neon connection
+budget for a chatty cron (fine at this scale).
+
+### Option B — QStash (or similar HTTP task queue)
+
+Publish each delivery to QStash with the partner URL as target; QStash owns retries,
+backoff, and DLQ, and signs requests. **Pros:** less delivery code, second-granularity
+retries, built-in DLQ. **Cons:** new vendor dependency + cost; the audit trail and
+auto-disable logic still need our own table (so much of Option A gets built anyway);
+partner-visible requests originate from QStash IPs (harder allowlisting story);
+webhook secrets/HMAC handling shifts partially into a third party's custody, which is
+an awkward fit for a security-positioning product.
+
+### Option C — lean on Pub/Sub redelivery (rejected)
+
+Don't ack until the partner accepts. Rejected for the coupling reason above, plus:
+ack deadline ceiling (~600s) can't express multi-hour backoff, and one notification
+may fan out to multiple subscriptions with different outcomes — partial-failure
+acking is unexpressible.
+
+### Idempotency & ordering (applies to every option)
+
+- **Inbound dedup:** Pub/Sub is at-least-once. The `(subscription, historyId-range)`
+  work is naturally idempotent because the diff runs off our stored cursor: a duplicate
+  push re-diffs from the same `lastHistoryId` and upserts the same outbox rows —
+  enforce with a unique index on `(subscriptionId, messageId)`.
+- **Outbound idempotency:** every delivery carries an `X-FGAC-Delivery-Id` (the outbox
+  row id) so partners can dedup; document that retries reuse the id.
+- **Ordering:** not guaranteed and not promised — the payload's `historyId` cursor is
+  monotonic, and partners fetching via the proxy always see current state, so
+  out-of-order thin pings are harmless.
+
+### Recommendation
+
+**Option A** for Phase 2. The scale argument is decisive: at launch volume (tens of
+partners, thousands of notifications/day) a cron drainer is far below any limit, and
+the pieces Option B doesn't cover (audit, auto-disable, dashboard) are the majority of
+the work anyway. Revisit QStash only if retry-latency granularity or cron volume
+becomes a measured problem. Build the drainer behind an interface
+(`deliverPending(batch)`) so swapping the scheduler later is contained.
+
+### Verified during strategy review (no spike needed)
+
+- **Read-only role expressibility**: send is deny-by-default absent a whitelist rule
+  (proxy §5); `google_api_modify` exposes only `messages/send` and denies unparseable
+  recipients; DELETE isn't exposed on MCP and trash/emptyTrash are hard-blocked on the
+  proxy. A no-rules key is already read-only.
+- **Token→key resolution chain** for partner servers: `verifyClerkToken` → connection →
+  key already works (MCP), and `/api/auth/cli-token` proves the OAuth-token→proxy-key
+  exchange pattern.
+
+## The Scenario
+
+DDJS runs a server-side agent that categorizes every new email a user receives into an
+interview stage and extracts action items. It needs:
+
+1. A signed-in DDJS user handed off to FGAC (account creation if needed) and back.
+2. FGAC-side **default permissions for the DDJS agent role** (read-only Gmail, no send,
+   no delete) applied without the user hand-assembling rules.
+3. Credentials returned to DDJS's **server** (not a browser/MCP client) that work with
+   the existing proxy/MCP surfaces.
+4. **Push notifications** to DDJS when new mail arrives, filtered by the same rules.
+
+## What Exists Today (and what's missing)
+
+| Need | Today | Gap |
+|------|-------|-----|
+| Third-party OAuth into FGAC | Clerk DCR + `agent_connections` pending-approval flow (built for MCP clients) | Approval is a *separate dashboard visit* where the user manually picks a proxy key; no inline consent, no way back to the app |
+| Default permissions per app | `access_rules` + `key_rule_assignments` exist, fully manual | No concept of a **registered app** with a declared permission manifest/template |
+| Server credentials | `sk_proxy_...` keys + REST proxy; `/api/auth/cli-token` already exchanges an OAuth token for a proxy key | No partner-facing token endpoint; keys are provisioned manually in the dashboard |
+| Push notifications | Nothing (no `users.watch`, no Pub/Sub, no webhook delivery) | Entire subsystem is net-new |
+
+The good news: 1–3 are mostly **recomposition of existing primitives**. Only 4 is a new
+subsystem.
+
+## Piece 1 — Partner App Registry with Permission Manifests ("Agent Roles")
+
+The core new concept. A third-party app registers with FGAC once (initially by us,
+manually — this is also the review/verification gate) and gets:
+
+- An OAuth `client_id` (Clerk OAuth application — same machinery the MCP DCR flow uses,
+  but pre-registered rather than dynamic).
+- A **permission manifest**: the app's requested "role", declared as a template of
+  `access_rules` plus capability flags. For DDJS:
+
+```jsonc
+{
+  "app": "Data Driven Job Search",
+  "logo_url": "...",
+  "requested": {
+    "services": ["gmail"],
+    "access": "read_only",            // no send whitelist rule = send denied by default (proxy §5)
+    "rule_templates": [],             // read-only needs none; write-capable apps declare whitelists here
+    "notifications": { "trigger": "new_email" }
+  },
+  "webhook_url": "https://api.ddjs.com/fgac/webhook",   // verified at registration
+  "redirect_uris": ["https://ddjs.com/fgac/callback"]
+}
+```
+
+**Consent-time provisioning**: when a user approves the app, FGAC auto-creates in one
+transaction what the user builds by hand today:
+
+1. A proxy key labeled `"Data Driven Job Search"`.
+2. `key_email_access` rows for the account(s) the user selected on the consent screen.
+3. Copies of the manifest's rule templates as `access_rules` bound to that key via
+   `key_rule_assignments` (copies, not references — the user can then tighten them per
+   normal, and a later manifest change by the app cannot silently widen existing grants).
+4. The `agent_connections` row, already `approved` and bound to the key.
+5. (If requested + granted) a `notification_subscriptions` row per account.
+
+Manifest changes that *broaden* access require re-consent: bump a `manifest_version`
+on the registry row; connections pinned to an older version keep old permissions until
+the user re-approves.
+
+New schema: `partner_apps` (clientId, name, manifest JSON, manifestVersion, webhookUrl,
+webhookSecret, status). Existing tables carry everything else.
+
+## Piece 2 — The Handoff Flow (lowest-friction path)
+
+Standard OAuth 2.0 authorization-code + PKCE, with Clerk as the identity/token layer
+(as today) and a new **FGAC consent interstitial** replacing the manual dashboard
+approval:
+
+```
+DDJS "Connect your Gmail" button
+  → https://fgac.ai/oauth/authorize?client_id=<ddjs>&state=...&code_challenge=...
+  → [no Clerk session] Clerk sign-in with Google → Google consent (Gmail scope)
+       ← this is the ONLY Google screen; FGAC becomes the token holder via Clerk
+  → FGAC consent page (server-renders partner_apps manifest):
+       "Data Driven Job Search wants to:
+          • Read email in [account picker: kenyesh@gmail.com ▾]  (read-only — cannot send or delete)
+          • Be notified when new email arrives
+        [Approve] [Deny]"
+  → Approve = one click → provisioning transaction (Piece 1) → redirect to
+    https://ddjs.com/fgac/callback?code=...&state=...
+  → DDJS server exchanges code at the token endpoint
+```
+
+Click count: **existing FGAC user = 1 screen** (consent). New user = Google account
+chooser + Google consent + FGAC consent ≈ 3 screens, all standard-feeling. No dashboard
+visit, no manual key creation, no rule configuration.
+
+Why keep Clerk underneath: the MCP flow already proves out Clerk DCR → token → userId
+resolution, discovery endpoints exist, and Google token custody stays exactly where it
+is (Clerk as token vault — the fake-token principle is preserved; DDJS never sees a
+Google credential).
+
+## Piece 3 — Credentials DDJS Receives
+
+Two-step, both reusing existing machinery:
+
+1. **Token endpoint** (Clerk's, as today): authorization code → access token + refresh
+   token. The MCP server already resolves `OAuth token → (userId, clientId) →
+   agent_connections → proxy_key`, so these tokens work against `/api/mcp` immediately.
+2. **Optional key exchange** for the REST proxy: a partner-facing sibling of the
+   existing `/api/auth/cli-token` — `POST /api/auth/partner-token` with the OAuth
+   token returns the connection's `sk_proxy_...` for direct
+   `gmail.fgac.ai/gmail/v1/...` calls with off-the-shelf Google SDKs (Prong 1).
+
+DDJS stores per-user: `{ refresh_token or proxy_key, connection_id }`. Revocation
+story is already built: user blocks the connection or revokes the key in the dashboard
+and both surfaces die.
+
+Recommendation: steer partners to the **OAuth-token path** as primary (rotatable,
+standard, auditable per-connection) and treat the raw proxy key as the escape hatch for
+SDK-endpoint-override users.
+
+## Piece 4 — Push Notifications (net-new subsystem)
+
+Gmail's push model: `users.watch` → Google Cloud **Pub/Sub topic** → HTTPS push to us →
+we fan out to partners. FGAC sits in the middle, which is precisely the product: the
+partner gets notified only about mail its rules let it see.
+
+```
+Gmail ── users.watch ──▶ Pub/Sub topic ── push ──▶ POST /api/webhooks/gmail  (verify OIDC token from Google)
+                                                        │  {emailAddress, historyId}
+                                                        ▼
+                                          history.list(since lastHistoryId)   [owner's Clerk Google token]
+                                                        │  new message IDs
+                                                        ▼
+                                          For each subscription on that account:
+                                            apply the bound key's READ RULES to each message
+                                            (label/sender blacklists — same code path as gmail_read)
+                                                        │  surviving IDs only
+                                                        ▼
+                                          POST partner webhook_url   (HMAC-signed, thin payload)
+                                          { connection_id, account, message_ids: [...], event: "new_email" }
+```
+
+Design decisions:
+
+- **Thin pings, not payloads.** The webhook carries message IDs only; DDJS fetches
+  content back through the proxy with its own credentials, where rules are enforced
+  again at read time. This keeps FGAC out of the business of pushing email bodies to
+  third parties, makes the webhook low-sensitivity, and means a mid-flight rule change
+  is honored at fetch.
+- **Rule-filtered notification.** If the user blacklists a label/sender, DDJS is not
+  even *told* those messages exist. This is the differentiating feature — notification
+  as an access-controlled surface, not a firehose.
+- **Watch lifecycle**: `users.watch` expires after 7 days → daily cron (Vercel cron)
+  re-arms all active subscriptions; store `lastHistoryId` per subscription;
+  `historyId` gaps (expired history) fall back to a `messages.list` reconciliation.
+- **Delivery semantics**: at-least-once, HMAC-SHA256 signature header with the app's
+  `webhookSecret`, exponential-backoff retries, auto-disable + dashboard flag after N
+  consecutive failures. `webhook_deliveries` table for the audit trail ("DDJS was
+  notified about 42 messages this week" belongs in the user's dashboard).
+- **One topic, many accounts**: a single Pub/Sub topic; the notification names the
+  account, we route by `emailAddress → notification_subscriptions`.
+
+New schema: `notification_subscriptions` (connectionId, targetEmail, lastHistoryId,
+watchExpiresAt, status), `webhook_deliveries` (subscriptionId, messageIds, status,
+attempts, timestamps).
+
+Prerequisite: a GCP project with Pub/Sub + granting `gmail-api-push@system.gserviceaccount.com`
+publish rights on the topic. Note `users.watch` must be called with the *user's* OAuth
+token (from Clerk) — scope-wise `gmail.readonly` suffices, which we already hold.
+
+## Security Notes
+
+- **Confused deputy / CSRF**: `state` + PKCE mandatory; consent page binds to the
+  authenticated Clerk session.
+- **No silent escalation**: manifest is copied at consent; broadening requires
+  re-consent (manifest_version pinning).
+- **Webhook SSRF/exfil**: webhook URLs are registered and verified at app registration
+  (challenge round-trip), never taken from runtime requests; reject private-range hosts.
+- **Fake-token principle intact**: partners receive FGAC credentials only; Google
+  tokens never leave Clerk custody.
+- **Registry as trust gate**: manual app registration doubles as app review; the
+  consent screen renders only registry data, never client-supplied strings.
+
+## Sequencing
+
+**Phase 1 — Handoff + default permissions** (recomposition, ~all existing infra):
+`partner_apps` table + manifest format → consent page (`/oauth/authorize` interstitial)
+→ provisioning transaction → partner token exchange endpoint → dashboard shows partner
+connections like agent connections today.
+*Fallback that works day one: DDJS polls `gmail_list` on an interval — notifications are
+an optimization, not a blocker for the integration.*
+
+**Phase 2 — Push notifications**: Pub/Sub topic + `/api/webhooks/gmail` receiver →
+subscription provisioning at consent → watch-renewal cron → HMAC webhook dispatcher
+with retries → delivery audit in dashboard.
+
+**Phase 3 — Self-serve registry** (later): partner-facing app registration UI with a
+review queue, once more than a handful of partners exist.
+
+## Deployment Roadmap to Production
+
+Two PRs, each following the standard pipeline: branch → implement → local QA →
+`/deploy-pr-preview` → QA suites against the preview → user runs `/deploy-prod`.
+Phase 1 ships alone first; the polling fallback (`gmail_list`) makes it independently
+useful, and it de-risks the schema and consent surface before any Pub/Sub code exists.
+
+### PR 1 — Partner handoff + default permissions (Phase 1)
+
+1. **Schema** (`npm run db:branch` FIRST, then edit `src/db/schema.ts`):
+   `partner_apps` (clerkOauthAppId, clientId, name, logoUrl, manifest JSONB,
+   manifestVersion, webhookUrl, webhookSecret, status). Add `partnerAppId` +
+   `manifestVersion` nullable FKs on `agent_connections` (provenance + re-consent
+   pinning). `drizzle-kit generate` → verify NNNN_*.sql exists → `npm run db:migrate`
+   against the branch (Database Rule 8).
+2. **Partner registration script** — `scripts/register-partner-app.ts`: creates the
+   Clerk OAuth application (`consent_screen_enabled: false`, partner redirect URIs)
+   via the Backend API AND the `partner_apps` row in one go. Per-environment by
+   design (dev Clerk + prod Clerk are separate instances — a partner must be
+   registered in each). `--prod` + `--apply` guards per repo convention.
+3. **Consent interstitial** — `/oauth/authorize` page route: require Clerk session
+   (redirect to sign-in and back if absent); look up `partner_apps` by `client_id`;
+   render manifest-driven consent (app name/logo, permission summary, account
+   picker); Approve = one provisioning transaction (proxy key labeled with app name,
+   `key_email_access`, rule copies from manifest, `agent_connections` row approved +
+   pinned to manifestVersion) then 302 into Clerk's authorize URL; Deny = 302 to
+   partner `redirect_uri` with `error=access_denied`. `state` and PKCE params pass
+   through untouched.
+4. **Partner token exchange** — `/api/auth/partner-token` (sibling of `cli-token`):
+   Clerk OAuth token in, connection's `sk_proxy_...` out.
+5. **Dashboard** — partner connections render in ConnectionsPanel with a partner
+   badge (name/logo from registry); revoke/block works unchanged.
+6. **Docs** — update `distribution_architecture.md` (5th distribution channel),
+   `architecture_and_strategy.md`, `user_guide.md`, data model docs.
+7. **QA** — new capability doc 11 + setup doc 04 (below); update the four agent
+   runbooks; `npx tsx scripts/qa-coverage-check.ts` green; run `/qa-hosted-mcp`
+   minimum, ideally all four suites.
+8. **Security review** — run `/security-review` on the branch (new auth surface).
+9. **Deploy** — `/deploy-pr-preview`, register the spike partner app against the
+   preview URL, walk the handoff end-to-end on preview, then hand to user for
+   `/deploy-prod`. Post-deploy: run `register-partner-app.ts --prod` for the first
+   real partner (DDJS), smoke the flow against `fgac.ai`.
+
+### PR 2 — Push notifications (Phase 2)
+
+1. **Schema**: `notification_subscriptions` (connectionId, targetEmail,
+   lastHistoryId, watchExpiresAt, status) + `webhook_deliveries` (subscriptionId,
+   messageIds, status, attempts, nextAttemptAt, lastError, deliveredAt; unique
+   (subscriptionId, messageId)).
+2. **GCP infra script** — `scripts/setup-gmail-push.sh --project <id> [--prod
+   --apply]`: idempotent topic + `gmail-api-push` publisher grant + push
+   subscription → `https://<host>/api/webhooks/gmail` with OIDC. Dev
+   (`dev-fgac-ai`) already has topic+grant from the spike — script adopts it;
+   prod target is `projects/fine-grain-access-control/topics/fgac-gmail-watch`.
+3. **Env** — `GMAIL_PUBSUB_TOPIC` per Vercel environment (no quotes). Extend
+   `env:check`/add `push:check`: topic set + topic project == token `azp` project +
+   publisher binding present.
+4. **Receiver** — `/api/webhooks/gmail`: verify Google OIDC JWT, load subscriptions
+   for `emailAddress`, `history.list` from stored cursor, apply the bound key's read
+   rules, insert outbox rows, fire one inline delivery attempt, ack 200 fast.
+   Tolerate zero-diff notifications (watch-time test message — spike finding).
+5. **Crons** (`vercel.json`): `/api/cron/deliver-webhooks` every minute (atomic
+   claim, HMAC POST, backoff ladder 1m→5m→15m→1h→6h→24h→dead, auto-suspend after N
+   dead + reconciliation sweep on re-enable); `/api/cron/renew-watches` daily
+   (re-arm watches expiring within 48h; watches live 7 days).
+6. **Consent integration** — manifest `notifications` grant creates the subscription
+   and arms the watch inside the Phase 1 provisioning transaction; revoke/block
+   tears down watch + subscription.
+7. **QA** — capability doc 12 + local webhook-receiver harness (below); coverage
+   check green; full suites.
+8. **Deploy** — preview QA uses the dev topic with a **pull-drain harness** (Pub/Sub
+   cannot push to localhost/preview reliably: a QA script drains a pull subscription
+   and POSTs to the local receiver, simulating Google's push). Prod: run infra
+   script `--prod --apply`, add prod env var, user runs `/deploy-prod`, `push:check`
+   green, then a canary: arm one watch on the owner account, send a self-email,
+   verify the delivery row and partner ping.
+
+### Standing prod checklist (condensed)
+
+| Step | Owner |
+|------|-------|
+| `setup-gmail-push.sh --prod --apply` (topic/grant/push-sub in `fine-grain-access-control`) | Claude (user-approved) |
+| `GMAIL_PUBSUB_TOPIC` added to Vercel production env, no quotes | user approves `vercel env add` |
+| Production redeploy | **user** (`/deploy-prod`) |
+| `register-partner-app.ts --prod` per partner (Clerk prod app + registry row) | Claude (user-approved) |
+| `push:check` + canary watch verification | Claude |
+
+## QA Acceptance Test Additions
+
+Two new capability docs (assertion checklists) + one setup doc + harness changes.
+Adding them makes `qa-coverage-check` require their assertions in every
+`qa-results.json` — the agent runbooks must be updated in the same PR, with
+channel-applicability notes where a surface is browser-only.
+
+### `capabilities/11_partner_handoff.md` (PR 1) — draft assertions
+
+- **A1** Unknown `client_id` on `/oauth/authorize` → error page, nothing provisioned.
+- **A2** Registered partner authorize → FGAC consent interstitial renders manifest
+  (app name, permission summary, account picker) — registry data only, no
+  client-supplied strings.
+- **A3** Deny → partner callback receives `error=access_denied`, `state` intact; no
+  key/connection/rules created.
+- **A4** Approve → single transaction provisions: key labeled with app name,
+  `key_email_access` for the chosen account, manifest rule copies bound to the key,
+  connection `approved` + pinned to manifestVersion; redirect carries `code` + `state`.
+- **A5** Code exchange returns access + refresh token; an MCP tool call works
+  immediately (no pending step). Refresh grant rotates and works.
+- **A6** `/api/auth/partner-token` exchanges the OAuth token for the connection's
+  `sk_proxy_...`; REST proxy call succeeds with it.
+- **A7** **Bypass fail-safe**: driving Clerk's authorize URL directly (interstitial
+  skipped) yields tokens whose MCP calls return "pending approval" — never
+  auto-provisioned. (Spike 1 finding, must stay true forever.)
+- **A8** Read-only default: `gmail_send` and proxy `messages/send` → 403
+  deny-by-default (manifest has no send whitelist).
+- **A9** Dashboard shows the partner connection with partner badge; Detach/block
+  kills BOTH the OAuth-token path and the proxy-key path.
+- **A10** Re-consent pinning: bumping `manifestVersion` in the registry does not
+  widen an existing connection's permissions.
+- *Channels*: A2–A4, A9 are browser-agent assertions; A1, A5–A8, A10 run via curl —
+  primary runbook `agents/01_hosted_mcp.md`, with dashboard steps marked
+  browser-only (same pattern as capability 06).
+
+### `capabilities/12_push_notifications.md` (PR 2) — draft assertions
+
+- **A1** Consent with notifications grant → `notification_subscriptions` row exists,
+  watch armed (`watchExpiresAt` ~7 days out, `lastHistoryId` set).
+- **A2** New email → local webhook receiver gets thin ping `{connection_id, account,
+  message_ids[]}` with valid HMAC signature and `X-FGAC-Delivery-Id` header, within
+  60s.
+- **A3** Payload is IDs-only — no subject, snippet, body, or sender anywhere in it.
+- **A4** **Rule filtering**: email carrying a read-blacklisted label (reuse
+  capability 05 baseline) produces NO webhook; a mixed batch delivers only the
+  allowed IDs.
+- **A5** Zero-diff notification (watch-time test message) produces no partner ping.
+- **A6** Duplicate Pub/Sub delivery of the same notification → exactly one outbox
+  row per (subscription, messageId); no double ping.
+- **A7** Failing receiver (harness returns 500) → `attempts` increments on backoff
+  schedule; after N dead the subscription is `suspended` and the dashboard flags it.
+- **A8** Re-enabling a suspended subscription triggers a reconciliation sweep that
+  delivers the missed message IDs.
+- **A9** Renewal cron advances `watchExpiresAt` for watches near expiry.
+- **A10** Detach/revoke → watch stopped, subscription cancelled, no further pings
+  (send another email to prove silence).
+- **A11** Unsigned/invalid-OIDC POST to `/api/webhooks/gmail` → 401/403, nothing
+  processed.
+- **A12** `push:check` passes: `GMAIL_PUBSUB_TOPIC` project matches the Google
+  client (`azp`) project and the publisher binding exists.
+- *Channels*: inherently channel-independent (server-side) — runs once per QA cycle
+  from the hosted-MCP runbook + browser agent for dashboard assertions, not
+  repeated per agent runtime.
+
+### `setup/04_partner_app_registration.md` (PR 1)
+
+Registers the QA partner app ("QA Spike Partner") via `register-partner-app.ts`
+against the dev Clerk instance with redirect URI on localhost, read-only Gmail
+manifest + notifications grant, and records client credentials into the gitignored
+QA config (pattern: `qa-test-agents.json`). Torn down / re-created idempotently each
+cycle.
+
+### Harness changes
+
+- **Local webhook receiver** for capability 12: tiny script
+  (`scripts/qa-webhook-receiver.ts`) that listens on localhost, records received
+  pings + HMAC validity to a JSON file the runner asserts against, and can be told
+  to return 500 (for A7).
+- **Pull-drain bridge** for non-prod Pub/Sub: script drains the dev pull
+  subscription and POSTs to the local receiver-under-test, simulating Google push
+  (Pub/Sub cannot reach localhost).
+- **USER_B re-auth** precondition: dev-instance Google refresh token for USER_B is
+  currently dead (`oauth_token_retrieval_error`, found 2026-08-06) — `/qa-setup`
+  must re-sign-in USER_B before delegation-dependent capabilities run.

--- a/scripts/qa-pubsub-bridge.ts
+++ b/scripts/qa-pubsub-bridge.ts
@@ -1,0 +1,74 @@
+/**
+ * QA Pub/Sub bridge — Pub/Sub cannot push to localhost, so this drains the dev
+ * PULL subscription and re-POSTs each notification to the local receiver
+ * exactly as Google's push would (same envelope), authenticated with the
+ * QA_BRIDGE_SECRET header the receiver accepts outside production.
+ *
+ * Usage:
+ *   npx tsx scripts/qa-pubsub-bridge.ts [--once] [--endpoint http://localhost:3000/api/webhooks/gmail]
+ *
+ * Requires: gcloud authed to the dev project; QA_BRIDGE_SECRET +
+ * GMAIL_PUBSUB_TOPIC in .env.local (written by scripts/setup-gmail-push.ts).
+ */
+import { config } from 'dotenv';
+import { execFileSync } from 'child_process';
+
+config({ path: '.env.local' });
+
+const args = process.argv.slice(2);
+const once = args.includes('--once');
+const epIdx = args.indexOf('--endpoint');
+const ENDPOINT = epIdx >= 0 ? args[epIdx + 1] : 'http://localhost:3000/api/webhooks/gmail';
+
+const topic = process.env.GMAIL_PUBSUB_TOPIC;
+const secret = process.env.QA_BRIDGE_SECRET;
+if (!topic || !secret) {
+  console.error('GMAIL_PUBSUB_TOPIC / QA_BRIDGE_SECRET missing from .env.local — run scripts/setup-gmail-push.ts first.');
+  process.exit(1);
+}
+const BRIDGE_SECRET: string = secret!;
+const [, , project, , topicShort] = topic!.split('/');
+const pullSub = `${topicShort}-dev-pull`;
+
+async function drainOnce(): Promise<number> {
+  const out = execFileSync('gcloud', [
+    'pubsub', 'subscriptions', 'pull', pullSub,
+    '--project', project, '--limit', '10', '--auto-ack', '--format=json',
+  ], { encoding: 'utf8' });
+  const messages = JSON.parse(out || '[]') as Array<{
+    message: { data: string; messageId: string; publishTime: string };
+  }>;
+
+  for (const m of messages) {
+    const envelope = {
+      message: {
+        data: m.message.data,
+        messageId: m.message.messageId,
+        publishTime: m.message.publishTime,
+      },
+      subscription: `projects/${project}/subscriptions/${pullSub}`,
+    };
+    const res = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-qa-bridge-secret': BRIDGE_SECRET },
+      body: JSON.stringify(envelope),
+    });
+    const bodyText = await res.text();
+    console.log(`[Bridge] ${m.message.messageId} → ${ENDPOINT} → ${res.status} ${bodyText.slice(0, 200)}`);
+  }
+  return messages.length;
+}
+
+async function main() {
+  console.log(`[Bridge] Draining ${pullSub} (project ${project}) → ${ENDPOINT}${once ? ' (single pass)' : ' every 5s'}`);
+  do {
+    try {
+      await drainOnce();
+    } catch (err) {
+      console.error('[Bridge] drain failed:', err instanceof Error ? err.message : err);
+    }
+    if (!once) await new Promise(r => setTimeout(r, 5000));
+  } while (!once);
+}
+
+main();

--- a/scripts/qa-pubsub-bridge.ts
+++ b/scripts/qa-pubsub-bridge.ts
@@ -27,7 +27,8 @@ if (!topic || !secret) {
   process.exit(1);
 }
 const BRIDGE_SECRET: string = secret!;
-const [, , project, , topicShort] = topic!.split('/');
+// "projects/<project>/topics/<name>"
+const [, project, , topicShort] = topic!.split('/');
 const pullSub = `${topicShort}-dev-pull`;
 
 async function drainOnce(): Promise<number> {

--- a/scripts/qa-webhook-receiver.ts
+++ b/scripts/qa-webhook-receiver.ts
@@ -1,0 +1,76 @@
+/**
+ * QA webhook receiver — stands in for a partner's notification endpoint during
+ * capability 12 runs. Records every ping (headers, body, HMAC validity) to
+ * qa-webhook-log.json (gitignored) for the runner to assert against.
+ *
+ * Usage:
+ *   FGAC_WEBHOOK_SECRET=<partner webhook_secret> npx tsx scripts/qa-webhook-receiver.ts [--port 4571]
+ *
+ * Failure injection (assertion A7 — retry/backoff/suspend): create a file
+ * named `qa-webhook-fail` in the repo root and the receiver returns 500 until
+ * it is removed. No restart needed.
+ */
+import http from 'http';
+import fs from 'fs';
+import crypto from 'crypto';
+
+const args = process.argv.slice(2);
+const portIdx = args.indexOf('--port');
+const PORT = portIdx >= 0 ? Number(args[portIdx + 1]) : 4571;
+const LOG_FILE = 'qa-webhook-log.json';
+const FAIL_FLAG = 'qa-webhook-fail';
+const SECRET = process.env.FGAC_WEBHOOK_SECRET ?? '';
+
+interface LogEntry {
+  receivedAt: string;
+  status: number;
+  deliveryId: string | null;
+  timestamp: string | null;
+  signatureValid: boolean | null;
+  body: unknown;
+}
+
+function appendLog(entry: LogEntry) {
+  const log: LogEntry[] = fs.existsSync(LOG_FILE)
+    ? JSON.parse(fs.readFileSync(LOG_FILE, 'utf8'))
+    : [];
+  log.push(entry);
+  fs.writeFileSync(LOG_FILE, JSON.stringify(log, null, 2));
+}
+
+http.createServer((req, res) => {
+  let raw = '';
+  req.on('data', chunk => { raw += chunk; });
+  req.on('end', () => {
+    const failing = fs.existsSync(FAIL_FLAG);
+    const status = failing ? 500 : 200;
+
+    const sig = req.headers['x-fgac-signature'] as string | undefined;
+    const ts = req.headers['x-fgac-timestamp'] as string | undefined;
+    let signatureValid: boolean | null = null;
+    if (SECRET && sig && ts) {
+      const expected = `sha256=${crypto.createHmac('sha256', SECRET).update(`${ts}.${raw}`).digest('hex')}`;
+      try {
+        signatureValid = crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
+      } catch { signatureValid = false; }
+    }
+
+    let body: unknown = raw;
+    try { body = JSON.parse(raw); } catch { /* keep raw */ }
+
+    appendLog({
+      receivedAt: new Date().toISOString(),
+      status,
+      deliveryId: (req.headers['x-fgac-delivery-id'] as string) ?? null,
+      timestamp: ts ?? null,
+      signatureValid,
+      body,
+    });
+
+    console.log(`[Receiver] ${new Date().toISOString()} → ${status}${failing ? ' (FAIL_FLAG active)' : ''} sig=${signatureValid} delivery=${req.headers['x-fgac-delivery-id'] ?? '-'}`);
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: !failing }));
+  });
+}).listen(PORT, () => {
+  console.log(`[Receiver] QA webhook receiver on http://localhost:${PORT} (log: ${LOG_FILE}, fail flag: ${FAIL_FLAG})`);
+});

--- a/scripts/register-partner-app.ts
+++ b/scripts/register-partner-app.ts
@@ -1,0 +1,138 @@
+/**
+ * Register (or update) a partner application: creates the pre-registered Clerk
+ * OAuth application with consent_screen_enabled=false (FGAC's /oauth/authorize
+ * interstitial is the ONLY consent screen) AND the partner_apps registry row.
+ *
+ * Per-environment by design — dev and prod Clerk are separate instances, so a
+ * partner must be registered in each. Dev is the default; production requires
+ * BOTH --prod and --apply and reads .secrets/prod.env by name (repo convention:
+ * see scripts/tombstone-orphaned-users.ts and CLAUDE.md → Production
+ * Credentials).
+ *
+ * Usage (dev):
+ *   npx tsx scripts/register-partner-app.ts \
+ *     --name "Data Driven Job Search" \
+ *     --redirect-uri https://ddjs.example.com/fgac/callback \
+ *     --webhook-url https://api.ddjs.example.com/fgac/webhook \
+ *     --notifications
+ *
+ * Prints the client credentials ONCE — hand them to the partner over a secure
+ * channel; the client_secret is not stored by FGAC outside Clerk.
+ */
+import { config } from 'dotenv';
+import crypto from 'crypto';
+import { eq } from 'drizzle-orm';
+
+const args = process.argv.slice(2);
+const flag = (name: string) => args.includes(`--${name}`);
+const opt = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+const optAll = (name: string): string[] => {
+  const out: string[] = [];
+  args.forEach((a, i) => { if (a === `--${name}` && args[i + 1]) out.push(args[i + 1]); });
+  return out;
+};
+
+const isProd = flag('prod');
+if (isProd && !flag('apply')) {
+  console.error('--prod requires --apply (explicit write consent). Aborting.');
+  process.exit(1);
+}
+config({ path: isProd ? '.secrets/prod.env' : '.env.local' });
+
+async function main() {
+  const name = opt('name');
+  const redirectUris = optAll('redirect-uri');
+  if (!name || redirectUris.length === 0) {
+    console.error('Required: --name <app name> --redirect-uri <uri> [--redirect-uri <uri2>] [--webhook-url <url>] [--logo-url <url>] [--notifications] [--prod --apply]');
+    process.exit(1);
+  }
+
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!secretKey) throw new Error('CLERK_SECRET_KEY not found in environment file');
+  if (isProd && !secretKey.startsWith('sk_live_')) throw new Error('--prod given but key is not sk_live_');
+  if (!isProd && !secretKey.startsWith('sk_test_')) throw new Error('dev mode but key is not sk_test_ — refusing');
+
+  // Late import so dotenv runs first; src/db enforces branch isolation in dev.
+  const { db } = await import('../src/db');
+  const { partnerApps } = await import('../src/db/schema');
+
+  const manifest = {
+    services: ['gmail'],
+    access: 'read_only',
+    rule_templates: [],
+    ...(flag('notifications') ? { notifications: { trigger: 'new_email' } } : {}),
+  };
+
+  const existing = await db.query.partnerApps.findFirst({
+    where: eq(partnerApps.name, name),
+  });
+
+  let clientId: string; let clientSecret: string | null = null; let clerkAppId: string;
+
+  if (existing?.clerkOauthAppId) {
+    // Update path: sync redirect URIs on the existing Clerk app.
+    const res = await fetch(`https://api.clerk.com/v1/oauth_applications/${existing.clerkOauthAppId}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: redirectUris, consent_screen_enabled: false }),
+    });
+    if (!res.ok) throw new Error(`Clerk PATCH failed: ${res.status} ${await res.text()}`);
+    const app = await res.json();
+    clientId = app.client_id; clerkAppId = app.id;
+  } else {
+    const res = await fetch('https://api.clerk.com/v1/oauth_applications', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${secretKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        redirect_uris: redirectUris,
+        scopes: 'profile email offline_access',
+        consent_screen_enabled: false,
+        public: false,
+      }),
+    });
+    if (!res.ok) throw new Error(`Clerk POST failed: ${res.status} ${await res.text()}`);
+    const app = await res.json();
+    clientId = app.client_id; clientSecret = app.client_secret; clerkAppId = app.id;
+  }
+
+  const webhookSecret = crypto.randomBytes(32).toString('hex');
+  const values = {
+    clientId,
+    clerkOauthAppId: clerkAppId,
+    name,
+    logoUrl: opt('logo-url') ?? null,
+    manifest,
+    redirectUris,
+    webhookUrl: opt('webhook-url') ?? null,
+    status: 'active',
+    updatedAt: new Date(),
+  };
+
+  if (existing) {
+    // Manifest changes bump the version — existing connections stay pinned to
+    // the version they consented to (no silent widening).
+    const manifestChanged = JSON.stringify(existing.manifest) !== JSON.stringify(manifest);
+    await db.update(partnerApps).set({
+      ...values,
+      ...(manifestChanged ? { manifestVersion: existing.manifestVersion + 1 } : {}),
+      // Keep the original webhook secret unless explicitly rolled.
+      ...(flag('roll-webhook-secret') ? { webhookSecret } : {}),
+    }).where(eq(partnerApps.id, existing.id));
+    console.log(`Updated partner app '${name}' (client_id=${clientId})${manifestChanged ? ` — manifestVersion bumped to ${existing.manifestVersion + 1}` : ''}`);
+    if (flag('roll-webhook-secret')) console.log(`New webhook secret: ${webhookSecret}`);
+  } else {
+    await db.insert(partnerApps).values({ ...values, webhookSecret });
+    console.log(`Registered partner app '${name}'`);
+    console.log(`  client_id:      ${clientId}`);
+    if (clientSecret) console.log(`  client_secret:  ${clientSecret}   <-- hand to partner ONCE, not stored`);
+    console.log(`  webhook_secret: ${webhookSecret}   <-- partner verifies X-FGAC-Signature with this`);
+    console.log(`  authorize URL:  <app-host>/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUris[0])}&response_type=code&state=...`);
+  }
+  process.exit(0);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/setup-gmail-push.ts
+++ b/scripts/setup-gmail-push.ts
@@ -1,0 +1,174 @@
+/**
+ * Idempotent GCP infrastructure for Gmail push notifications. The SAME script
+ * provisions dev and prod — that is what keeps them in sync (plan v6, "Dev→Prod
+ * Infrastructure Sync").
+ *
+ * Creates/verifies, in the given project:
+ *   1. Pub/Sub topic  (default: fgac-gmail-watch)
+ *   2. gmail-api-push@system.gserviceaccount.com → roles/pubsub.publisher
+ *   3. (--push-endpoint) OIDC push subscription → https://<host>/api/webhooks/gmail
+ *      with a dedicated invoker service account
+ *   4. (dev only) writes GMAIL_PUBSUB_TOPIC (+ QA_BRIDGE_SECRET if absent) into
+ *      .env.local — mirroring how db:branch manages neon__POSTGRES_URL
+ *
+ * Constraint (spike-verified): the topic MUST live in the GCP project of the
+ * Google OAuth client behind the environment's Clerk instance.
+ *   dev  → dev-fgac-ai
+ *   prod → fine-grain-access-control (verified 2026-08-06, plan v5)
+ *
+ * Usage:
+ *   npx tsx scripts/setup-gmail-push.ts --project dev-fgac-ai
+ *   npx tsx scripts/setup-gmail-push.ts --project fine-grain-access-control \
+ *     --push-endpoint https://fgac.ai/api/webhooks/gmail --prod --apply
+ *
+ * Without --apply it only PRINTS the plan. Prod additionally requires --prod.
+ */
+import { execFileSync } from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+
+const args = process.argv.slice(2);
+const flag = (name: string) => args.includes(`--${name}`);
+const opt = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const PROD_PROJECT = 'fine-grain-access-control';
+const project = opt('project');
+const topicName = opt('topic') ?? 'fgac-gmail-watch';
+const pushEndpoint = opt('push-endpoint');
+const apply = flag('apply');
+
+if (!project) {
+  console.error('Required: --project <gcp-project-id> [--topic name] [--push-endpoint url] [--prod] [--apply]');
+  process.exit(1);
+}
+if (project === PROD_PROJECT && !flag('prod')) {
+  console.error(`Project ${PROD_PROJECT} is PRODUCTION — pass --prod (and --apply) explicitly.`);
+  process.exit(1);
+}
+if (flag('prod') && !apply) {
+  console.error('--prod requires --apply. Without --apply this is a dry run anyway; add both to touch prod.');
+  process.exit(1);
+}
+
+function gcloud(gcArgs: string[], allowFail = false): { ok: boolean; out: string } {
+  try {
+    const out = execFileSync('gcloud', [...gcArgs, '--project', project!], {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, out };
+  } catch (err) {
+    const e = err as { stderr?: string; stdout?: string };
+    if (!allowFail) {
+      console.error(e.stderr ?? String(err));
+      process.exit(1);
+    }
+    return { ok: false, out: (e.stderr ?? '') + (e.stdout ?? '') };
+  }
+}
+
+const GMAIL_SA = 'gmail-api-push@system.gserviceaccount.com';
+const topicPath = `projects/${project}/topics/${topicName}`;
+const invokerSa = `fgac-push-invoker@${project}.iam.gserviceaccount.com`;
+
+const plan: string[] = [];
+const actions: Array<() => void> = [];
+
+// 1. Topic
+const topicExists = gcloud(['pubsub', 'topics', 'describe', topicName], true).ok;
+if (topicExists) {
+  plan.push(`✔ topic ${topicPath} exists`);
+} else {
+  plan.push(`+ create topic ${topicPath}`);
+  actions.push(() => gcloud(['pubsub', 'topics', 'create', topicName]));
+}
+
+// 2. Publisher binding
+const iam = gcloud(['pubsub', 'topics', 'get-iam-policy', topicName, '--format=json'], true);
+const hasBinding = iam.ok && iam.out.includes(GMAIL_SA) && iam.out.includes('roles/pubsub.publisher');
+if (hasBinding) {
+  plan.push(`✔ ${GMAIL_SA} has roles/pubsub.publisher`);
+} else {
+  plan.push(`+ grant roles/pubsub.publisher to ${GMAIL_SA}`);
+  actions.push(() => gcloud([
+    'pubsub', 'topics', 'add-iam-policy-binding', topicName,
+    `--member=serviceAccount:${GMAIL_SA}`, '--role=roles/pubsub.publisher',
+  ]));
+}
+
+// 3. Push subscription (only when an endpoint is given — dev QA uses pull)
+if (pushEndpoint) {
+  const subName = `${topicName}-push`;
+  const saExists = gcloud(['iam', 'service-accounts', 'describe', invokerSa], true).ok;
+  if (!saExists) {
+    plan.push(`+ create invoker service account ${invokerSa}`);
+    actions.push(() => gcloud([
+      'iam', 'service-accounts', 'create', 'fgac-push-invoker',
+      '--display-name=FGAC PubSub push OIDC identity',
+    ]));
+  } else {
+    plan.push(`✔ invoker service account ${invokerSa} exists`);
+  }
+  const subExists = gcloud(['pubsub', 'subscriptions', 'describe', subName], true).ok;
+  if (!subExists) {
+    plan.push(`+ create push subscription ${subName} → ${pushEndpoint} (OIDC as ${invokerSa})`);
+    actions.push(() => gcloud([
+      'pubsub', 'subscriptions', 'create', subName,
+      `--topic=${topicName}`,
+      `--push-endpoint=${pushEndpoint}`,
+      `--push-auth-service-account=${invokerSa}`,
+      `--push-auth-token-audience=${pushEndpoint}`,
+      '--ack-deadline=60',
+    ]));
+  } else {
+    plan.push(`✔ push subscription ${subName} exists`);
+  }
+  plan.push(`  → set on Vercel for this environment (no quotes):`);
+  plan.push(`      GMAIL_PUBSUB_TOPIC=${topicPath}`);
+  plan.push(`      PUBSUB_PUSH_AUDIENCE=${pushEndpoint}`);
+  plan.push(`      PUBSUB_PUSH_SA_EMAIL=${invokerSa}`);
+}
+
+// 4. Dev pull subscription for the QA bridge + local env wiring
+if (!flag('prod')) {
+  const pullSub = `${topicName}-dev-pull`;
+  const pullExists = gcloud(['pubsub', 'subscriptions', 'describe', pullSub], true).ok;
+  if (pullExists) {
+    plan.push(`✔ dev pull subscription ${pullSub} exists`);
+  } else {
+    plan.push(`+ create dev pull subscription ${pullSub} (QA bridge drains this)`);
+    actions.push(() => gcloud(['pubsub', 'subscriptions', 'create', pullSub, `--topic=${topicName}`]));
+  }
+
+  if (fs.existsSync('.env.local')) {
+    plan.push(`+ ensure GMAIL_PUBSUB_TOPIC/QA_BRIDGE_SECRET in .env.local (script-managed, like db:branch)`);
+    actions.push(() => {
+      let env = fs.readFileSync('.env.local', 'utf8');
+      const setVar = (key: string, value: string) => {
+        if (new RegExp(`^${key}=`, 'm').test(env)) {
+          env = env.replace(new RegExp(`^${key}=.*$`, 'm'), `${key}=${value}`);
+        } else {
+          env += `${env.endsWith('\n') ? '' : '\n'}${key}=${value}\n`;
+        }
+      };
+      setVar('GMAIL_PUBSUB_TOPIC', topicPath);
+      if (!/^QA_BRIDGE_SECRET=/m.test(env)) {
+        setVar('QA_BRIDGE_SECRET', crypto.randomBytes(24).toString('hex'));
+      }
+      fs.writeFileSync('.env.local', env);
+    });
+  }
+}
+
+console.log(`\nGmail push setup plan for project '${project}':\n`);
+for (const line of plan) console.log(`  ${line}`);
+
+if (!apply) {
+  console.log('\nDry run (no --apply). Nothing changed.');
+  process.exit(0);
+}
+
+for (const action of actions) action();
+console.log(`\n✅ Applied. Topic: ${topicPath}`);

--- a/src/app/api/auth/partner-token/route.ts
+++ b/src/app/api/auth/partner-token/route.ts
@@ -1,0 +1,97 @@
+/**
+ * Partner Token Exchange — /api/auth/partner-token
+ *
+ * A partner server exchanges its Clerk OAuth access token for the connection's
+ * sk_proxy_ key, for use against the REST proxy (gmail.fgac.ai) with stock
+ * Google SDKs. Sibling of /api/auth/cli-token with partner-flow semantics:
+ * a consented partner connection is already approved, so the normal outcome is
+ * an immediate key. Pending/blocked map to the same fail-safe behavior the MCP
+ * server enforces.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/db';
+import { agentConnections, users, proxyKeys, keyEmailAccess } from '@/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { verifyClerkOauthToken } from '@/lib/partner/clerkOauth';
+import { filterLiveDelegatedAccess } from '@/db/delegationQueries';
+
+const DASHBOARD_URL = process.env.NEXT_PUBLIC_APP_URL
+  || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : null)
+  || 'http://localhost:3000';
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ status: 'error', message: 'Missing Authorization header' }, { status: 401 });
+  }
+
+  const verified = await verifyClerkOauthToken(authHeader.slice(7));
+  if (!verified) {
+    return NextResponse.json({ status: 'error', message: 'Invalid or expired token' }, { status: 401 });
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.clerkUserId, verified.userId),
+  });
+  if (!user) {
+    return NextResponse.json({ status: 'error', message: 'User not found' }, { status: 404 });
+  }
+
+  const connection = await db.query.agentConnections.findFirst({
+    where: and(
+      eq(agentConnections.userId, user.id),
+      eq(agentConnections.clientId, verified.clientId),
+    ),
+  });
+
+  if (!connection || connection.status === 'pending' || !connection.proxyKeyId) {
+    return NextResponse.json({
+      status: 'pending',
+      message: '⏳ This connection is awaiting user approval.',
+      dashboard_url: `${DASHBOARD_URL}/dashboard?tab=connections`,
+    });
+  }
+  if (connection.status === 'blocked') {
+    return NextResponse.json({
+      status: 'blocked',
+      message: '🚫 This connection has been blocked by the user.',
+    }, { status: 403 });
+  }
+
+  const key = await db.query.proxyKeys.findFirst({
+    where: eq(proxyKeys.id, connection.proxyKeyId),
+  });
+  if (!key || key.revokedAt || (key.expiresAt && key.expiresAt < new Date())) {
+    return NextResponse.json({
+      status: 'blocked',
+      message: '🚫 The key behind this connection is revoked or expired.',
+    }, { status: 403 });
+  }
+
+  const emailRows = await db.select().from(keyEmailAccess)
+    .where(eq(keyEmailAccess.proxyKeyId, key.id));
+  const liveAccess = await filterLiveDelegatedAccess(emailRows);
+
+  await db.update(agentConnections)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(agentConnections.id, connection.id));
+
+  return NextResponse.json({
+    status: 'approved',
+    proxy_key: key.key,
+    key_label: key.label,
+    connection_id: connection.id,
+    emails: liveAccess.map(e => e.targetEmail),
+    proxy_endpoint: DASHBOARD_URL.includes('localhost')
+      ? DASHBOARD_URL
+      : DASHBOARD_URL.replace('://', '://gmail.'),
+  });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    endpoint: '/api/auth/partner-token',
+    description: 'Exchange a Clerk OAuth token from the partner handoff for the connection\'s FGAC proxy key.',
+    usage: 'POST with Authorization: Bearer <clerk_oauth_access_token>',
+  });
+}

--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -9,8 +9,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 import { db } from '@/db';
-import { agentConnections, users, proxyKeys } from '@/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { agentConnections, users, proxyKeys, partnerApps } from '@/db/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+import { cancelSubscriptionsForConnection } from '@/lib/notifications/subscriptions';
 
 export async function GET() {
   const { userId: clerkUserId } = await auth();
@@ -30,6 +31,13 @@ export async function GET() {
     where: eq(agentConnections.userId, user.id),
   });
 
+  // Partner provenance for the dashboard badge
+  const partnerIds = [...new Set(connections.map(c => c.partnerAppId).filter((id): id is string => !!id))];
+  const partners = partnerIds.length > 0
+    ? await db.select().from(partnerApps).where(inArray(partnerApps.id, partnerIds))
+    : [];
+  const partnerById = new Map(partners.map(p => [p.id, p]));
+
   // Also get user's proxy keys for the approval dropdown
   const keys = await db.query.proxyKeys.findMany({
     where: eq(proxyKeys.userId, user.id),
@@ -46,6 +54,12 @@ export async function GET() {
       createdAt: c.createdAt,
       approvedAt: c.approvedAt,
       lastUsedAt: c.lastUsedAt,
+      partnerApp: c.partnerAppId && partnerById.has(c.partnerAppId)
+        ? {
+            name: partnerById.get(c.partnerAppId)!.name,
+            logoUrl: partnerById.get(c.partnerAppId)!.logoUrl,
+          }
+        : null,
     })),
     availableKeys: keys.map(k => ({
       id: k.id,
@@ -136,6 +150,14 @@ export async function POST(req: NextRequest) {
       await db.update(agentConnections)
         .set({ status: 'blocked', proxyKeyId: null })
         .where(eq(agentConnections.id, connectionId));
+
+      // A blocked partner must also stop being NOTIFIED — cancel its
+      // subscriptions and stop the Gmail watch if no one else needs it.
+      try {
+        await cancelSubscriptionsForConnection(connectionId);
+      } catch (err) {
+        console.error(`[Connections] Subscription teardown failed for ${connectionId}:`, err);
+      }
 
       return NextResponse.json({ status: 'blocked' });
     }

--- a/src/app/api/connections/route.ts
+++ b/src/app/api/connections/route.ts
@@ -147,9 +147,21 @@ export async function POST(req: NextRequest) {
     }
 
     case 'block': {
+      const detachedKeyId = connection.proxyKeyId;
+
       await db.update(agentConnections)
         .set({ status: 'blocked', proxyKeyId: null })
         .where(eq(agentConnections.id, connectionId));
+
+      // Partner-provisioned keys exist 1:1 for their connection (created by the
+      // consent interstitial, never user-shared) — detaching the connection
+      // must kill the REST-proxy path too, so revoke the key outright.
+      // Agent-profile keys (no partnerAppId) are user-owned and stay usable.
+      if (connection.partnerAppId && detachedKeyId) {
+        await db.update(proxyKeys)
+          .set({ revokedAt: new Date() })
+          .where(and(eq(proxyKeys.id, detachedKeyId), eq(proxyKeys.userId, user.id)));
+      }
 
       // A blocked partner must also stop being NOTIFIED — cancel its
       // subscriptions and stop the Gmail watch if no one else needs it.

--- a/src/app/api/cron/deliver-webhooks/route.ts
+++ b/src/app/api/cron/deliver-webhooks/route.ts
@@ -1,0 +1,30 @@
+/**
+ * Webhook delivery drainer cron — every minute (vercel.json). The inline
+ * attempt in the Pub/Sub receiver covers the happy path; this mops up retries
+ * on the backoff ladder. Guarded by CRON_SECRET when configured (Vercel sends
+ * it as a Bearer token on cron invocations).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { deliverPending } from '@/lib/notifications/deliver';
+
+function cronAuthorized(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return process.env.VERCEL_ENV !== 'production';
+  return req.headers.get('Authorization') === `Bearer ${secret}`;
+}
+
+export async function GET(req: NextRequest) {
+  if (!cronAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const stats = await deliverPending();
+    if (stats.delivered + stats.retried + stats.dead > 0) {
+      console.log(`[Cron:deliver] delivered=${stats.delivered} retried=${stats.retried} dead=${stats.dead} suspended=${stats.suspendedSubs.length}`);
+    }
+    return NextResponse.json({ status: 'ok', ...stats });
+  } catch (err) {
+    console.error('[Cron:deliver] failed:', err);
+    return NextResponse.json({ error: 'drain failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/renew-watches/route.ts
+++ b/src/app/api/cron/renew-watches/route.ts
@@ -1,0 +1,62 @@
+/**
+ * Watch renewal cron — daily (vercel.json). Gmail watches expire after ~7
+ * days; re-arm every active subscription whose watch is missing (failed arm at
+ * consent time) or expires within 48h. Renewal never regresses the history
+ * cursor — armWatch's historyId is only adopted when no cursor exists.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/db';
+import { notificationSubscriptions } from '@/db/schema';
+import { and, eq, isNull, lt, or } from 'drizzle-orm';
+import { armWatch } from '@/lib/notifications/gmail';
+
+function cronAuthorized(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return process.env.VERCEL_ENV !== 'production';
+  return req.headers.get('Authorization') === `Bearer ${secret}`;
+}
+
+export async function GET(req: NextRequest) {
+  if (!cronAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const cutoff = new Date(Date.now() + 48 * 3600 * 1000);
+  const due = await db.select().from(notificationSubscriptions)
+    .where(and(
+      eq(notificationSubscriptions.status, 'active'),
+      or(
+        isNull(notificationSubscriptions.watchExpiresAt),
+        lt(notificationSubscriptions.watchExpiresAt, cutoff),
+      ),
+    ));
+
+  // One arm per mailbox is enough — the watch is account-scoped.
+  const byEmail = new Map<string, typeof due>();
+  for (const sub of due) {
+    (byEmail.get(sub.targetEmail) ?? byEmail.set(sub.targetEmail, []).get(sub.targetEmail)!).push(sub);
+  }
+
+  let renewed = 0; const failures: string[] = [];
+  for (const [email, subs] of byEmail) {
+    try {
+      const { historyId, expiration } = await armWatch(email);
+      for (const sub of subs) {
+        await db.update(notificationSubscriptions)
+          .set({
+            lastHistoryId: sub.lastHistoryId ?? historyId,
+            watchExpiresAt: expiration,
+            updatedAt: new Date(),
+          })
+          .where(eq(notificationSubscriptions.id, sub.id));
+        renewed++;
+      }
+    } catch (err) {
+      console.error(`[Cron:renew] Failed to re-arm watch for ${email}:`, err);
+      failures.push(email);
+    }
+  }
+
+  console.log(`[Cron:renew] due=${due.length} renewed=${renewed} failures=${failures.length}`);
+  return NextResponse.json({ status: 'ok', due: due.length, renewed, failedMailboxes: failures.length });
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -26,9 +26,10 @@ import { filterLiveDelegatedAccess } from '@/db/delegationQueries';
 import { clerkClient } from '@clerk/nextjs/server';
 import safeRegex from 'safe-regex';
 import { resolveDbUser } from '@/db/userHelpers';
+import { loadApplicableRules, checkReadRestrictions, type ApplicableRules } from '@/lib/gmailRules';
 import { TOOL_DEFS, toolAnnotations, type FgacToolDef } from './toolDefs';
 import {
-  classifyGoogleApiCall, extractSendRecipients, collectLabelIds,
+  classifyGoogleApiCall, extractSendRecipients,
 } from './googleApiPolicy';
 
 const DASHBOARD_URL = process.env.NEXT_PUBLIC_APP_URL
@@ -220,69 +221,9 @@ async function getGoogleToken(targetEmail: string, keyOwner: { id: string; email
   return tokenResponse.data?.[0]?.token || null;
 }
 
-async function loadApplicableRules(userId: string, proxyKeyId: string, targetEmail: string) {
-  const allUserRules = await db.select().from(accessRules)
-    .where(eq(accessRules.userId, userId));
-
-  const keyAssignments = await db.select().from(keyRuleAssignments)
-    .where(eq(keyRuleAssignments.proxyKeyId, proxyKeyId));
-
-  const assignedRuleIds = new Set(keyAssignments.map(a => a.accessRuleId));
-  const allAssignments = await db.select().from(keyRuleAssignments);
-  const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
-
-  return allUserRules.filter(rule => {
-    const isGlobal = !rulesWithAssignments.has(rule.id);
-    const isAssignedToThisKey = assignedRuleIds.has(rule.id);
-    const emailMatches = !rule.targetEmail ||
-      rule.targetEmail.toLowerCase() === targetEmail.toLowerCase();
-    return (isGlobal || isAssignedToThisKey) && emailMatches;
-  });
-}
-
-type ApplicableRules = Awaited<ReturnType<typeof loadApplicableRules>>;
-
-/**
- * Read-time enforcement, shared by every path that returns message content.
- * Policy: messages may APPEAR in listings, but reading content must respect
- * label blacklists (checked first — precedence), label whitelists, and content
- * read-blacklists — identically on MCP and the raw API proxy.
- *
- * Label rules consider every labelIds array in the response (thread and list
- * responses nest messages). Whitelists only apply when the response carries
- * labels at all — ID-only listings stay visible, matching the policy above.
- * Returns a user-facing restriction message, or null if the read is allowed.
- */
-function checkReadRestrictions(
-  rules: ApplicableRules,
-  message: unknown,
-): string | null {
-  const gmailRules = rules.filter(r => r.service === 'gmail');
-  const labelIds = collectLabelIds(message);
-
-  for (const rule of gmailRules.filter(r => r.actionType === 'label_blacklist')) {
-    if (rule.regexPattern && labelIds.includes(rule.regexPattern)) {
-      return `🚫 Access restricted: Email contains blacklisted label '${rule.regexPattern}'.`;
-    }
-  }
-
-  const whitelists = gmailRules.filter(r => r.actionType === 'label_whitelist' && !!r.regexPattern);
-  if (whitelists.length > 0 && labelIds.length > 0 && !whitelists.some(r => labelIds.includes(r.regexPattern!))) {
-    return '🚫 Access restricted: Email lacks a required whitelisted label.';
-  }
-
-  const bodyStr = JSON.stringify(message);
-  for (const rule of gmailRules.filter(r => r.actionType === 'read_blacklist')) {
-    if (!rule.regexPattern) continue;
-    const regexStr = rule.regexPattern.replace(/\*/g, '.*');
-    if (!safeRegex(regexStr)) continue;
-    if (new RegExp(regexStr, 'i').test(bodyStr)) {
-      return `🚫 Access restricted: Content blocked by rule '${rule.ruleName}'.`;
-    }
-  }
-
-  return null;
-}
+// loadApplicableRules / checkReadRestrictions moved to src/lib/gmailRules.ts —
+// shared with the push-notification filter so read policy and notification
+// policy can never drift apart.
 
 /**
  * Send-whitelist enforcement shared by gmail_send and google_api_modify.

--- a/src/app/api/partner/consent/route.ts
+++ b/src/app/api/partner/consent/route.ts
@@ -1,0 +1,114 @@
+/**
+ * Consent decision endpoint for the /oauth/authorize interstitial.
+ *
+ * Approve: provision (key + email access + rule copies + approved connection +
+ * optional notification subscription), then 303 into Clerk's real authorize
+ * endpoint — which, with consent_screen_enabled=false, silently issues the
+ * code to the partner's redirect_uri.
+ *
+ * Deny: 303 straight back to the partner with error=access_denied.
+ *
+ * Security: session-bound (Clerk cookie), partner + redirect_uri re-validated
+ * server-side, and the redirect into Clerk carries only re-validated params.
+ * Skipping this endpoint entirely (driving Clerk's authorize directly) is safe:
+ * the resulting connection is pending-by-default and tools refuse to run.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { auth, currentUser } from '@clerk/nextjs/server';
+import { db } from '@/db';
+import { partnerApps } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+import { resolveDbUser } from '@/db/userHelpers';
+import { parseManifest } from '@/lib/partner/manifest';
+import { provisionPartnerConnection } from '@/lib/partner/provision';
+import { expectedClerkIssuer } from '@/lib/partner/clerkOauth';
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const form = await req.formData();
+  const get = (k: string) => {
+    const v = form.get(k);
+    return typeof v === 'string' && v.length > 0 ? v : undefined;
+  };
+
+  const clientId = get('client_id');
+  const redirectUri = get('redirect_uri');
+  const decision = get('decision');
+  const selectedEmail = get('email');
+  const state = get('state');
+
+  if (!clientId || !redirectUri || !decision) {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  const partner = await db.query.partnerApps.findFirst({
+    where: eq(partnerApps.clientId, clientId),
+  });
+  if (!partner || partner.status !== 'active') {
+    return NextResponse.json({ error: 'Unknown application' }, { status: 404 });
+  }
+  if (!((partner.redirectUris as string[]) ?? []).includes(redirectUri)) {
+    return NextResponse.json({ error: 'redirect_uri not registered for this application' }, { status: 400 });
+  }
+
+  const denyUrl = new URL(redirectUri);
+  if (decision !== 'approve') {
+    denyUrl.searchParams.set('error', 'access_denied');
+    if (state) denyUrl.searchParams.set('state', state);
+    return NextResponse.redirect(denyUrl, 303);
+  }
+
+  const manifest = parseManifest(partner.manifest);
+  if (!manifest) {
+    return NextResponse.json({ error: 'Invalid partner manifest' }, { status: 500 });
+  }
+  if (!selectedEmail) {
+    return NextResponse.json({ error: 'No mailbox selected' }, { status: 400 });
+  }
+
+  const clerkUser = await currentUser();
+  const email = clerkUser?.emailAddresses[0]?.emailAddress;
+  if (!email) return NextResponse.json({ error: 'Account has no email' }, { status: 400 });
+  const dbUser = await resolveDbUser(userId, email);
+  if (!dbUser) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+  try {
+    const { connectionId } = await provisionPartnerConnection({
+      user: { id: dbUser.id, email: dbUser.email },
+      partner: {
+        id: partner.id,
+        clientId: partner.clientId,
+        name: partner.name,
+        manifestVersion: partner.manifestVersion,
+        webhookUrl: partner.webhookUrl,
+      },
+      manifest,
+      selectedEmails: [selectedEmail],
+    });
+    console.log(`[Consent] Provisioned partner connection ${connectionId} for user=${dbUser.id} partner=${partner.name}`);
+  } catch (err) {
+    console.error('[Consent] Provisioning failed:', err);
+    const detail = err instanceof Error ? err.message : 'provisioning failed';
+    return NextResponse.json({ error: detail }, { status: 400 });
+  }
+
+  const issuer = expectedClerkIssuer();
+  if (!issuer) {
+    return NextResponse.json({ error: 'Clerk issuer unavailable' }, { status: 500 });
+  }
+
+  const authorizeUrl = new URL(`${issuer}/oauth/authorize`);
+  authorizeUrl.searchParams.set('response_type', get('response_type') ?? 'code');
+  authorizeUrl.searchParams.set('client_id', clientId);
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+  for (const k of ['state', 'scope', 'code_challenge', 'code_challenge_method'] as const) {
+    const v = get(k);
+    if (v) authorizeUrl.searchParams.set(k, v);
+  }
+
+  return NextResponse.redirect(authorizeUrl, 303);
+}

--- a/src/app/api/webhooks/gmail/route.ts
+++ b/src/app/api/webhooks/gmail/route.ts
@@ -1,0 +1,83 @@
+/**
+ * Gmail Pub/Sub push receiver.
+ *
+ * Google POSTs {message:{data: b64({emailAddress, historyId}), messageId},
+ * subscription} here. We verify the caller, process the notification (diff +
+ * rule-filter + outbox enqueue + inline delivery attempt), and ack FAST —
+ * partner delivery is never allowed to hold Google's ack hostage.
+ *
+ * Caller verification:
+ *  - Production path: Google-signed OIDC JWT (configured on the push
+ *    subscription by scripts/setup-gmail-push.ts). Verified against Google's
+ *    JWKS; audience must equal PUBSUB_PUSH_AUDIENCE; if PUBSUB_PUSH_SA_EMAIL is
+ *    set, the token's email claim must match it.
+ *  - Non-production only: the QA pull-drain bridge authenticates with the
+ *    QA_BRIDGE_SECRET header (Pub/Sub cannot push to localhost). Disabled when
+ *    VERCEL_ENV === 'production'.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { processGmailNotification } from '@/lib/notifications/process';
+
+const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'];
+const GOOGLE_JWKS = createRemoteJWKSet(new URL('https://www.googleapis.com/oauth2/v3/certs'));
+
+async function verifyGoogleOidc(token: string): Promise<boolean> {
+  const audience = process.env.PUBSUB_PUSH_AUDIENCE;
+  if (!audience) return false;
+  try {
+    const { payload } = await jwtVerify(token, GOOGLE_JWKS, { audience, clockTolerance: 30 });
+    if (!GOOGLE_ISSUERS.includes(payload.iss ?? '')) return false;
+    const expectedSa = process.env.PUBSUB_PUSH_SA_EMAIL;
+    if (expectedSa && (payload as Record<string, unknown>).email !== expectedSa) return false;
+    return true;
+  } catch (err) {
+    console.error('[GmailWebhook] OIDC verification failed:', err);
+    return false;
+  }
+}
+
+function bridgeAuthorized(req: NextRequest): boolean {
+  if (process.env.VERCEL_ENV === 'production') return false;
+  const secret = process.env.QA_BRIDGE_SECRET;
+  return !!secret && req.headers.get('x-qa-bridge-secret') === secret;
+}
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('Authorization');
+  const oidcOk = authHeader?.startsWith('Bearer ')
+    ? await verifyGoogleOidc(authHeader.slice(7))
+    : false;
+
+  if (!oidcOk && !bridgeAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let emailAddress: string | undefined;
+  let historyId: string | undefined;
+  try {
+    const envelope = await req.json() as { message?: { data?: string } };
+    const decoded = JSON.parse(
+      Buffer.from(envelope.message?.data ?? '', 'base64').toString('utf8'),
+    ) as { emailAddress?: string; historyId?: number | string };
+    emailAddress = decoded.emailAddress;
+    historyId = decoded.historyId !== undefined ? String(decoded.historyId) : undefined;
+  } catch {
+    // Malformed envelope: ack it — redelivery cannot fix a bad payload.
+    return NextResponse.json({ status: 'ignored', reason: 'malformed envelope' });
+  }
+
+  if (!emailAddress || !historyId) {
+    return NextResponse.json({ status: 'ignored', reason: 'missing emailAddress/historyId' });
+  }
+
+  try {
+    const result = await processGmailNotification(emailAddress, historyId);
+    console.log(`[GmailWebhook] ${emailAddress} h=${historyId} subs=${result.subscriptionsSeen} enqueued=${result.enqueued} filtered=${result.filtered}`);
+    return NextResponse.json({ status: 'ok', ...result });
+  } catch (err) {
+    // Transient failure → 500 so Pub/Sub redelivers (dedup absorbs the replay).
+    console.error('[GmailWebhook] Processing failed:', err);
+    return NextResponse.json({ error: 'processing failed' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/AgentProfilesView.tsx
+++ b/src/app/dashboard/AgentProfilesView.tsx
@@ -41,6 +41,9 @@ interface Connection {
   proxyKeyId: string | null;
   createdAt: string;
   lastUsedAt: string | null;
+  // Set when the connection was provisioned via the partner handoff
+  // (/oauth/authorize consent) rather than agent-initiated DCR.
+  partnerApp?: { name: string; logoUrl: string | null } | null;
 }
 
 interface AccessibleEmail {
@@ -911,7 +914,10 @@ function ApprovedAgentCard({
             {conn.nickname || conn.clientName || conn.clientId}
           </button>
         )}
-        <Badge tone="success">Approved</Badge>
+        <span className="flex items-center gap-1.5">
+          {conn.partnerApp && <Badge tone="info">Partner · {conn.partnerApp.name}</Badge>}
+          <Badge tone="success">Approved</Badge>
+        </span>
       </div>
       <div className="mt-2 flex items-center justify-between gap-2">
         <span className="text-[11px] text-subtle">Last used {timeAgo(conn.lastUsedAt)}</span>

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,163 @@
+/**
+ * Partner Handoff Consent Interstitial — the ONLY consent screen a partner-app
+ * user sees (the partner's Clerk OAuth application is registered with
+ * consent_screen_enabled=false).
+ *
+ * Flow: partner redirects here with standard authorize params → user approves →
+ * /api/partner/consent provisions key/rules/connection → 303 into Clerk's
+ * /oauth/authorize (which silently issues the code) → partner callback.
+ *
+ * Everything rendered comes from the partner_apps REGISTRY — request params are
+ * validated against it and never echoed into the page.
+ */
+import { auth, currentUser } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+import { db } from '@/db';
+import { partnerApps, emailDelegations, users } from '@/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { resolveDbUser } from '@/db/userHelpers';
+import { parseManifest, describeManifest } from '@/lib/partner/manifest';
+
+export const dynamic = 'force-dynamic';
+
+interface AuthorizeParams {
+  client_id?: string;
+  redirect_uri?: string;
+  state?: string;
+  scope?: string;
+  response_type?: string;
+  code_challenge?: string;
+  code_challenge_method?: string;
+}
+
+function ErrorCard({ title, detail }: { title: string; detail: string }) {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <div className="max-w-md w-full rounded-xl border border-red-300 dark:border-red-800 p-6 text-center">
+        <h1 className="text-lg font-semibold mb-2">{title}</h1>
+        <p className="text-sm opacity-80">{detail}</p>
+      </div>
+    </main>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<AuthorizeParams>;
+}) {
+  const params = await searchParams;
+  const { userId, redirectToSignIn } = await auth();
+
+  if (!userId) {
+    const qs = new URLSearchParams(
+      Object.entries(params).filter(([, v]) => typeof v === 'string') as [string, string][],
+    );
+    return redirectToSignIn({ returnBackUrl: `/oauth/authorize?${qs}` });
+  }
+
+  if (!params.client_id || !params.redirect_uri) {
+    return <ErrorCard title="Invalid request" detail="Missing client_id or redirect_uri." />;
+  }
+
+  const partner = await db.query.partnerApps.findFirst({
+    where: eq(partnerApps.clientId, params.client_id),
+  });
+  if (!partner || partner.status !== 'active') {
+    return <ErrorCard title="Unknown application" detail="This application is not registered with FGAC. Nothing has been shared." />;
+  }
+
+  const registeredUris = (partner.redirectUris as string[]) ?? [];
+  if (!registeredUris.includes(params.redirect_uri)) {
+    return <ErrorCard title="Invalid redirect URI" detail="The redirect URI does not match this application's registration. Nothing has been shared." />;
+  }
+
+  const manifest = parseManifest(partner.manifest);
+  if (!manifest) {
+    return <ErrorCard title="Configuration error" detail="This application's permission manifest is invalid. Contact support." />;
+  }
+
+  const clerkUser = await currentUser();
+  const email = clerkUser?.emailAddresses[0]?.emailAddress;
+  if (!email) return <ErrorCard title="Account error" detail="Your account has no email address." />;
+  const dbUser = await resolveDbUser(userId, email);
+  if (!dbUser) redirect('/dashboard');
+
+  // Own mailbox + any actively delegated to this user.
+  const delegated = await db.select({ ownerEmail: users.email })
+    .from(emailDelegations)
+    .innerJoin(users, eq(emailDelegations.ownerUserId, users.id))
+    .where(and(
+      eq(emailDelegations.delegateUserId, dbUser.id),
+      eq(emailDelegations.status, 'active'),
+    ));
+  const availableEmails = [dbUser.email, ...delegated.map(d => d.ownerEmail)];
+
+  const permissionLines = describeManifest(manifest);
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <div className="max-w-md w-full rounded-xl border border-neutral-200 dark:border-neutral-800 p-6 shadow-sm">
+        <div className="text-center mb-5">
+          {partner.logoUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={partner.logoUrl} alt="" className="h-12 w-12 mx-auto mb-3 rounded" />
+          )}
+          <h1 className="text-xl font-semibold">{partner.name}</h1>
+          <p className="text-sm opacity-70 mt-1">
+            wants to connect to your FGAC-protected account
+          </p>
+        </div>
+
+        <div className="rounded-lg bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 p-4 mb-5">
+          <p className="text-sm font-medium mb-2">This will allow {partner.name} to:</p>
+          <ul className="text-sm space-y-1.5">
+            {permissionLines.map(line => (
+              <li key={line} className="flex gap-2">
+                <span aria-hidden>•</span>
+                <span>{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <form method="POST" action="/api/partner/consent" className="space-y-4">
+          {(['client_id', 'redirect_uri', 'state', 'scope', 'response_type', 'code_challenge', 'code_challenge_method'] as const)
+            .filter(k => params[k])
+            .map(k => <input key={k} type="hidden" name={k} value={params[k]} />)}
+
+          <label className="block text-sm">
+            <span className="font-medium">Mailbox to share</span>
+            <select
+              name="email"
+              defaultValue={dbUser.email}
+              className="mt-1 w-full rounded-md border border-neutral-300 dark:border-neutral-700 bg-transparent p-2 text-sm"
+            >
+              {availableEmails.map(e => <option key={e} value={e}>{e}</option>)}
+            </select>
+          </label>
+
+          <div className="flex gap-3">
+            <button
+              type="submit" name="decision" value="deny"
+              className="flex-1 rounded-md border border-neutral-300 dark:border-neutral-700 py-2 text-sm"
+            >
+              Deny
+            </button>
+            <button
+              type="submit" name="decision" value="approve"
+              className="flex-1 rounded-md bg-indigo-600 text-white py-2 text-sm font-medium"
+            >
+              Approve
+            </button>
+          </div>
+        </form>
+
+        <p className="text-xs opacity-60 mt-4 text-center">
+          Signed in as {dbUser.email}. You can revoke this connection at any time
+          from your FGAC dashboard — {partner.name} never sees your Google credentials.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/db/migrations/0006_cool_living_lightning.sql
+++ b/src/db/migrations/0006_cool_living_lightning.sql
@@ -1,0 +1,48 @@
+CREATE TABLE "notification_subscriptions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"connection_id" uuid NOT NULL,
+	"target_email" text NOT NULL,
+	"last_history_id" text,
+	"watch_expires_at" timestamp,
+	"status" text DEFAULT 'active' NOT NULL,
+	"consecutive_failures" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "partner_apps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"client_id" text NOT NULL,
+	"clerk_oauth_app_id" text,
+	"name" text NOT NULL,
+	"logo_url" text,
+	"manifest" jsonb NOT NULL,
+	"manifest_version" integer DEFAULT 1 NOT NULL,
+	"redirect_uris" jsonb NOT NULL,
+	"webhook_url" text,
+	"webhook_secret" text,
+	"status" text DEFAULT 'active' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "partner_apps_client_id_unique" UNIQUE("client_id")
+);
+--> statement-breakpoint
+CREATE TABLE "webhook_deliveries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"subscription_id" uuid NOT NULL,
+	"message_id" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"next_attempt_at" timestamp DEFAULT now() NOT NULL,
+	"last_error" text,
+	"delivered_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agent_connections" ADD COLUMN "partner_app_id" uuid;--> statement-breakpoint
+ALTER TABLE "agent_connections" ADD COLUMN "manifest_version" integer;--> statement-breakpoint
+ALTER TABLE "notification_subscriptions" ADD CONSTRAINT "notification_subscriptions_connection_id_agent_connections_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."agent_connections"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_subscription_id_notification_subscriptions_id_fk" FOREIGN KEY ("subscription_id") REFERENCES "public"."notification_subscriptions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "subscription_connection_email_unique" ON "notification_subscriptions" USING btree ("connection_id","target_email");--> statement-breakpoint
+CREATE UNIQUE INDEX "delivery_subscription_message_unique" ON "webhook_deliveries" USING btree ("subscription_id","message_id");--> statement-breakpoint
+ALTER TABLE "agent_connections" ADD CONSTRAINT "agent_connections_partner_app_id_partner_apps_id_fk" FOREIGN KEY ("partner_app_id") REFERENCES "public"."partner_apps"("id") ON DELETE set null ON UPDATE no action;

--- a/src/db/migrations/meta/0006_snapshot.json
+++ b/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1106 @@
+{
+  "id": "dc3b9635-ab0e-4fa1-bc34-c94361047ea5",
+  "prevId": "d35857bb-6e1f-4385-b4d8-0289375dc042",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_rules": {
+      "name": "access_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "regex_pattern": {
+          "name": "regex_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "access_rules_user_id_users_id_fk": {
+          "name": "access_rules_user_id_users_id_fk",
+          "tableFrom": "access_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connections": {
+      "name": "agent_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_key_id": {
+          "name": "proxy_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "partner_app_id": {
+          "name": "partner_app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connection_user_client_unique": {
+          "name": "connection_user_client_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connections_user_id_users_id_fk": {
+          "name": "agent_connections_user_id_users_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connections_proxy_key_id_proxy_keys_id_fk": {
+          "name": "agent_connections_proxy_key_id_proxy_keys_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "proxy_keys",
+          "columnsFrom": [
+            "proxy_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_connections_partner_app_id_partner_apps_id_fk": {
+          "name": "agent_connections_partner_app_id_partner_apps_id_fk",
+          "tableFrom": "agent_connections",
+          "tableTo": "partner_apps",
+          "columnsFrom": [
+            "partner_app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_delegations": {
+      "name": "email_delegations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_user_id": {
+          "name": "delegate_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "delegation_unique": {
+          "name": "delegation_unique",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_delegations_owner_user_id_users_id_fk": {
+          "name": "email_delegations_owner_user_id_users_id_fk",
+          "tableFrom": "email_delegations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_delegations_delegate_user_id_users_id_fk": {
+          "name": "email_delegations_delegate_user_id_users_id_fk",
+          "tableFrom": "email_delegations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "delegate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.key_email_access": {
+      "name": "key_email_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proxy_key_id": {
+          "name": "proxy_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegation_id": {
+          "name": "delegation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "key_email_unique": {
+          "name": "key_email_unique",
+          "columns": [
+            {
+              "expression": "proxy_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "key_email_access_proxy_key_id_proxy_keys_id_fk": {
+          "name": "key_email_access_proxy_key_id_proxy_keys_id_fk",
+          "tableFrom": "key_email_access",
+          "tableTo": "proxy_keys",
+          "columnsFrom": [
+            "proxy_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "key_email_access_delegation_id_email_delegations_id_fk": {
+          "name": "key_email_access_delegation_id_email_delegations_id_fk",
+          "tableFrom": "key_email_access",
+          "tableTo": "email_delegations",
+          "columnsFrom": [
+            "delegation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.key_rule_assignments": {
+      "name": "key_rule_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proxy_key_id": {
+          "name": "proxy_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_rule_id": {
+          "name": "access_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "key_rule_unique": {
+          "name": "key_rule_unique",
+          "columns": [
+            {
+              "expression": "proxy_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "key_rule_assignments_proxy_key_id_proxy_keys_id_fk": {
+          "name": "key_rule_assignments_proxy_key_id_proxy_keys_id_fk",
+          "tableFrom": "key_rule_assignments",
+          "tableTo": "proxy_keys",
+          "columnsFrom": [
+            "proxy_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "key_rule_assignments_access_rule_id_access_rules_id_fk": {
+          "name": "key_rule_assignments_access_rule_id_access_rules_id_fk",
+          "tableFrom": "key_rule_assignments",
+          "tableTo": "access_rules",
+          "columnsFrom": [
+            "access_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_subscriptions": {
+      "name": "notification_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_history_id": {
+          "name": "last_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_expires_at": {
+          "name": "watch_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_connection_email_unique": {
+          "name": "subscription_connection_email_unique",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_subscriptions_connection_id_agent_connections_id_fk": {
+          "name": "notification_subscriptions_connection_id_agent_connections_id_fk",
+          "tableFrom": "notification_subscriptions",
+          "tableTo": "agent_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_apps": {
+      "name": "partner_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_oauth_app_id": {
+          "name": "clerk_oauth_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "partner_apps_client_id_unique": {
+          "name": "partner_apps_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proxy_keys": {
+      "name": "proxy_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proxy_keys_user_id_users_id_fk": {
+          "name": "proxy_keys_user_id_users_id_fk",
+          "tableFrom": "proxy_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "proxy_keys_key_unique": {
+          "name": "proxy_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_accounts": {
+          "name": "num_accounts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_too_cheap": {
+          "name": "price_too_cheap",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_bargain": {
+          "name": "price_bargain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_expensive": {
+          "name": "price_expensive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_too_expensive": {
+          "name": "price_too_expensive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_model_preference": {
+          "name": "pricing_model_preference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wants_beta": {
+          "name": "wants_beta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreed_to_interview": {
+          "name": "agreed_to_interview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreed_to_beta_pricing": {
+          "name": "agreed_to_beta_pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comfortable_with_unverified_app": {
+          "name": "comfortable_with_unverified_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'partial'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_subscription_message_unique": {
+          "name": "delivery_subscription_message_unique",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_subscription_id_notification_subscriptions_id_fk": {
+          "name": "webhook_deliveries_subscription_id_notification_subscriptions_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "notification_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785070083590,
       "tag": "0005_overconfident_vapor",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1786032376763,
+      "tag": "0006_cool_living_lightning",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, uuid, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, uuid, uniqueIndex, jsonb, integer } from 'drizzle-orm/pg-core';
 
 // ─── Users ───────────────────────────────────────────────────────────────────
 // Core user table. proxyKey removed — keys now live in proxy_keys table.
@@ -124,9 +124,80 @@ export const agentConnections = pgTable('agent_connections', {
   nickname: text('nickname'),                      // User-assigned label (e.g., "My Work Agent")
   proxyKeyId: uuid('proxy_key_id').references(() => proxyKeys.id, { onDelete: 'set null' }), // NULL = pending
   status: text('status').notNull().default('pending'), // 'pending', 'approved', 'blocked'
+  // Partner-app provenance: set when the connection was provisioned through the
+  // /oauth/authorize consent interstitial for a registered partner app. The
+  // manifestVersion pins which manifest revision the user consented to — a
+  // registry manifest bump must NOT widen this connection until re-consent.
+  partnerAppId: uuid('partner_app_id').references(() => partnerApps.id, { onDelete: 'set null' }),
+  manifestVersion: integer('manifest_version'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   approvedAt: timestamp('approved_at'),
   lastUsedAt: timestamp('last_used_at'),
 }, (table) => [
   uniqueIndex('connection_user_client_unique').on(table.userId, table.clientId),
+]);
+
+// ─── Partner Apps ───────────────────────────────────────────────────────────
+// Registry of third-party applications that hand their users off to FGAC via
+// the /oauth/authorize consent interstitial. Registered out-of-band by
+// scripts/register-partner-app.ts (which also creates the pre-registered Clerk
+// OAuth application with consent_screen_enabled=false — FGAC's interstitial is
+// the ONLY consent screen). The manifest declares the app's requested "agent
+// role"; consent-time provisioning copies it into concrete keys/rules so later
+// manifest edits can never silently widen existing grants.
+export const partnerApps = pgTable('partner_apps', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  clientId: text('client_id').notNull().unique(),  // Clerk OAuth app client_id
+  clerkOauthAppId: text('clerk_oauth_app_id'),     // Clerk "oa_..." id, for admin ops
+  name: text('name').notNull(),                    // e.g. "Data Driven Job Search"
+  logoUrl: text('logo_url'),
+  // { services: ['gmail'], access: 'read_only', rule_templates: [...],
+  //   notifications?: { trigger: 'new_email' } }
+  manifest: jsonb('manifest').notNull(),
+  manifestVersion: integer('manifest_version').notNull().default(1),
+  redirectUris: jsonb('redirect_uris').notNull(),  // string[] — validated on /oauth/authorize
+  webhookUrl: text('webhook_url'),                 // partner's notification receiver
+  webhookSecret: text('webhook_secret'),           // HMAC-SHA256 signing secret
+  status: text('status').notNull().default('active'), // 'active', 'suspended'
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+// ─── Notification Subscriptions ─────────────────────────────────────────────
+// One row per (partner connection, watched mailbox). Created inside the consent
+// provisioning transaction when the partner's manifest requests notifications.
+// lastHistoryId is the Gmail history cursor the diff resumes from; the watch is
+// re-armed by /api/cron/renew-watches (Gmail watches expire after 7 days).
+export const notificationSubscriptions = pgTable('notification_subscriptions', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  connectionId: uuid('connection_id').references(() => agentConnections.id, { onDelete: 'cascade' }).notNull(),
+  targetEmail: text('target_email').notNull(),
+  lastHistoryId: text('last_history_id'),
+  watchExpiresAt: timestamp('watch_expires_at'),   // NULL = watch not armed (cron retries)
+  status: text('status').notNull().default('active'), // 'active', 'suspended', 'cancelled'
+  consecutiveFailures: integer('consecutive_failures').notNull().default(0),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => [
+  uniqueIndex('subscription_connection_email_unique').on(table.connectionId, table.targetEmail),
+]);
+
+// ─── Webhook Deliveries ─────────────────────────────────────────────────────
+// The delivery outbox AND the user-facing audit trail. One row per
+// (subscription, Gmail message) — the unique index is what makes Pub/Sub's
+// at-least-once redelivery idempotent. The drainer groups due rows per
+// subscription into one thin ping (message IDs only, never content).
+// Backoff ladder: 1m, 5m, 15m, 1h, 6h, 24h → dead.
+export const webhookDeliveries = pgTable('webhook_deliveries', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  subscriptionId: uuid('subscription_id').references(() => notificationSubscriptions.id, { onDelete: 'cascade' }).notNull(),
+  messageId: text('message_id').notNull(),         // Gmail message id (opaque to us)
+  status: text('status').notNull().default('pending'), // 'pending', 'delivering', 'delivered', 'dead'
+  attempts: integer('attempts').notNull().default(0),
+  nextAttemptAt: timestamp('next_attempt_at').defaultNow().notNull(),
+  lastError: text('last_error'),
+  deliveredAt: timestamp('delivered_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+}, (table) => [
+  uniqueIndex('delivery_subscription_message_unique').on(table.subscriptionId, table.messageId),
 ]);

--- a/src/lib/gmailRules.ts
+++ b/src/lib/gmailRules.ts
@@ -1,0 +1,76 @@
+/**
+ * Gmail rule loading + read-time enforcement, shared by the MCP server, the
+ * REST proxy paths that need it, and the push-notification filter. Extracted
+ * from src/app/api/mcp/route.ts so notification filtering can never drift from
+ * read-time filtering — a message a key cannot read must also never be
+ * announced to a partner webhook.
+ */
+import safeRegex from 'safe-regex';
+import { db } from '@/db';
+import { accessRules, keyRuleAssignments } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+import { collectLabelIds } from '@/app/api/mcp/googleApiPolicy';
+
+export async function loadApplicableRules(userId: string, proxyKeyId: string, targetEmail: string) {
+  const allUserRules = await db.select().from(accessRules)
+    .where(eq(accessRules.userId, userId));
+
+  const keyAssignments = await db.select().from(keyRuleAssignments)
+    .where(eq(keyRuleAssignments.proxyKeyId, proxyKeyId));
+
+  const assignedRuleIds = new Set(keyAssignments.map(a => a.accessRuleId));
+  const allAssignments = await db.select().from(keyRuleAssignments);
+  const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
+
+  return allUserRules.filter(rule => {
+    const isGlobal = !rulesWithAssignments.has(rule.id);
+    const isAssignedToThisKey = assignedRuleIds.has(rule.id);
+    const emailMatches = !rule.targetEmail ||
+      rule.targetEmail.toLowerCase() === targetEmail.toLowerCase();
+    return (isGlobal || isAssignedToThisKey) && emailMatches;
+  });
+}
+
+export type ApplicableRules = Awaited<ReturnType<typeof loadApplicableRules>>;
+
+/**
+ * Read-time enforcement, shared by every path that returns message content.
+ * Policy: messages may APPEAR in listings, but reading content must respect
+ * label blacklists (checked first — precedence), label whitelists, and content
+ * read-blacklists — identically on MCP and the raw API proxy.
+ *
+ * Label rules consider every labelIds array in the response (thread and list
+ * responses nest messages). Whitelists only apply when the response carries
+ * labels at all — ID-only listings stay visible, matching the policy above.
+ * Returns a user-facing restriction message, or null if the read is allowed.
+ */
+export function checkReadRestrictions(
+  rules: ApplicableRules,
+  message: unknown,
+): string | null {
+  const gmailRules = rules.filter(r => r.service === 'gmail');
+  const labelIds = collectLabelIds(message);
+
+  for (const rule of gmailRules.filter(r => r.actionType === 'label_blacklist')) {
+    if (rule.regexPattern && labelIds.includes(rule.regexPattern)) {
+      return `🚫 Access restricted: Email contains blacklisted label '${rule.regexPattern}'.`;
+    }
+  }
+
+  const whitelists = gmailRules.filter(r => r.actionType === 'label_whitelist' && !!r.regexPattern);
+  if (whitelists.length > 0 && labelIds.length > 0 && !whitelists.some(r => labelIds.includes(r.regexPattern!))) {
+    return '🚫 Access restricted: Email lacks a required whitelisted label.';
+  }
+
+  const bodyStr = JSON.stringify(message);
+  for (const rule of gmailRules.filter(r => r.actionType === 'read_blacklist')) {
+    if (!rule.regexPattern) continue;
+    const regexStr = rule.regexPattern.replace(/\*/g, '.*');
+    if (!safeRegex(regexStr)) continue;
+    if (new RegExp(regexStr, 'i').test(bodyStr)) {
+      return `🚫 Access restricted: Content blocked by rule '${rule.ruleName}'.`;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -1,0 +1,173 @@
+/**
+ * Webhook delivery drainer. The webhook_deliveries table IS the queue and the
+ * audit trail (docs/implementation_plans/third-party-handoff-permissions_v6.md,
+ * "Spike 4 Expanded" — Option A).
+ *
+ * Semantics: at-least-once, per-row backoff ladder, rows grouped per
+ * subscription into one thin ping (message IDs only). After MAX_ATTEMPTS a row
+ * goes 'dead'; DEAD_STRIKES consecutive dead groups suspend the subscription.
+ * Claiming uses UPDATE … RETURNING so overlapping cron ticks never double-send.
+ */
+import { db } from '@/db';
+import {
+  webhookDeliveries, notificationSubscriptions, agentConnections, partnerApps,
+} from '@/db/schema';
+import { and, eq, inArray, lte, sql } from 'drizzle-orm';
+import { signWebhookBody } from './hmac';
+
+// 1m, 5m, 15m, 1h, 6h, 24h (seconds). attempts is 1-based after first failure.
+const BACKOFF_S = [60, 300, 900, 3600, 21600, 86400];
+const MAX_ATTEMPTS = BACKOFF_S.length;
+const DEAD_STRIKES = 3;
+const DELIVERY_TIMEOUT_MS = 10_000;
+
+interface ClaimedRow { id: string; subscriptionId: string; messageId: string; attempts: number }
+
+async function claimDueRows(subscriptionId?: string, limit = 50): Promise<ClaimedRow[]> {
+  const due = db.select({ id: webhookDeliveries.id })
+    .from(webhookDeliveries)
+    .where(and(
+      eq(webhookDeliveries.status, 'pending'),
+      lte(webhookDeliveries.nextAttemptAt, new Date()),
+      ...(subscriptionId ? [eq(webhookDeliveries.subscriptionId, subscriptionId)] : []),
+    ))
+    .limit(limit);
+
+  return db.update(webhookDeliveries)
+    .set({ status: 'delivering' })
+    .where(and(inArray(webhookDeliveries.id, due), eq(webhookDeliveries.status, 'pending')))
+    .returning({
+      id: webhookDeliveries.id,
+      subscriptionId: webhookDeliveries.subscriptionId,
+      messageId: webhookDeliveries.messageId,
+      attempts: webhookDeliveries.attempts,
+    });
+}
+
+async function postPing(
+  webhookUrl: string, secret: string,
+  payload: Record<string, unknown>, deliveryId: string,
+): Promise<{ ok: boolean; detail: string }> {
+  const body = JSON.stringify(payload);
+  const ts = Math.floor(Date.now() / 1000);
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-FGAC-Signature': signWebhookBody(secret, ts, body),
+        'X-FGAC-Timestamp': String(ts),
+        'X-FGAC-Delivery-Id': deliveryId,
+      },
+      body,
+      signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+    });
+    return res.ok
+      ? { ok: true, detail: `HTTP ${res.status}` }
+      : { ok: false, detail: `HTTP ${res.status}` };
+  } catch (err) {
+    return { ok: false, detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export interface DrainStats { delivered: number; retried: number; dead: number; suspendedSubs: string[] }
+
+/** Drain due rows (optionally scoped to one subscription — the inline path). */
+export async function deliverPending(subscriptionId?: string): Promise<DrainStats> {
+  const stats: DrainStats = { delivered: 0, retried: 0, dead: 0, suspendedSubs: [] };
+  const claimed = await claimDueRows(subscriptionId);
+  if (claimed.length === 0) return stats;
+
+  const bySub = new Map<string, ClaimedRow[]>();
+  for (const row of claimed) {
+    (bySub.get(row.subscriptionId) ?? bySub.set(row.subscriptionId, []).get(row.subscriptionId)!).push(row);
+  }
+
+  for (const [subId, rows] of bySub) {
+    const ctx = await db.select({
+      sub: notificationSubscriptions,
+      connection: agentConnections,
+      partner: partnerApps,
+    })
+      .from(notificationSubscriptions)
+      .innerJoin(agentConnections, eq(notificationSubscriptions.connectionId, agentConnections.id))
+      .innerJoin(partnerApps, eq(agentConnections.partnerAppId, partnerApps.id))
+      .where(eq(notificationSubscriptions.id, subId))
+      .limit(1)
+      .then(r => r[0]);
+
+    // No partner/webhook context, or subscription no longer active → dead-letter.
+    if (!ctx || !ctx.partner.webhookUrl || !ctx.partner.webhookSecret || ctx.sub.status !== 'active') {
+      await db.update(webhookDeliveries)
+        .set({ status: 'dead', lastError: 'subscription inactive or partner has no webhook' })
+        .where(inArray(webhookDeliveries.id, rows.map(r => r.id)));
+      stats.dead += rows.length;
+      continue;
+    }
+
+    const deliveryId = rows[0].id;
+    const outcome = await postPing(ctx.partner.webhookUrl, ctx.partner.webhookSecret, {
+      event: 'new_email',
+      connection_id: ctx.connection.id,
+      account: ctx.sub.targetEmail,
+      message_ids: rows.map(r => r.messageId),
+      deliveries: rows.map(r => ({ delivery_id: r.id, message_id: r.messageId })),
+    }, deliveryId);
+
+    if (outcome.ok) {
+      await db.update(webhookDeliveries)
+        .set({ status: 'delivered', deliveredAt: new Date(), lastError: null })
+        .where(inArray(webhookDeliveries.id, rows.map(r => r.id)));
+      await db.update(notificationSubscriptions)
+        .set({ consecutiveFailures: 0, updatedAt: new Date() })
+        .where(eq(notificationSubscriptions.id, subId));
+      stats.delivered += rows.length;
+      continue;
+    }
+
+    // Failure: per-row backoff or dead.
+    let groupWentDead = false;
+    for (const row of rows) {
+      const attempts = row.attempts + 1;
+      if (attempts >= MAX_ATTEMPTS) {
+        await db.update(webhookDeliveries)
+          .set({ status: 'dead', attempts, lastError: outcome.detail })
+          .where(eq(webhookDeliveries.id, row.id));
+        stats.dead++;
+        groupWentDead = true;
+      } else {
+        const delayMs = BACKOFF_S[Math.min(attempts, BACKOFF_S.length - 1)] * 1000;
+        await db.update(webhookDeliveries)
+          .set({
+            status: 'pending',
+            attempts,
+            lastError: outcome.detail,
+            nextAttemptAt: new Date(Date.now() + delayMs),
+          })
+          .where(eq(webhookDeliveries.id, row.id));
+        stats.retried++;
+      }
+    }
+
+    if (groupWentDead) {
+      const [updated] = await db.update(notificationSubscriptions)
+        .set({
+          consecutiveFailures: sql`${notificationSubscriptions.consecutiveFailures} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(eq(notificationSubscriptions.id, subId))
+        .returning({ failures: notificationSubscriptions.consecutiveFailures });
+      if (updated && updated.failures >= DEAD_STRIKES) {
+        await db.update(notificationSubscriptions)
+          .set({ status: 'suspended', updatedAt: new Date() })
+          .where(eq(notificationSubscriptions.id, subId));
+        stats.suspendedSubs.push(subId);
+        console.warn(`[Deliver] Subscription ${subId} suspended after ${updated.failures} dead delivery groups`);
+      }
+    }
+  }
+
+  return stats;
+}
+
+export const deliverPendingForSubscription = (subscriptionId: string) => deliverPending(subscriptionId);

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -136,7 +136,8 @@ export async function deliverPending(subscriptionId?: string): Promise<DrainStat
         stats.dead++;
         groupWentDead = true;
       } else {
-        const delayMs = BACKOFF_S[Math.min(attempts, BACKOFF_S.length - 1)] * 1000;
+        // attempts is 1-based here (just incremented): first failure → 1m rung.
+        const delayMs = BACKOFF_S[Math.min(attempts - 1, BACKOFF_S.length - 1)] * 1000;
         await db.update(webhookDeliveries)
           .set({
             status: 'pending',

--- a/src/lib/notifications/gmail.ts
+++ b/src/lib/notifications/gmail.ts
@@ -24,19 +24,33 @@ export function pubsubTopic(): string {
   return topic;
 }
 
-/** Google access token for the OWNER of a mailbox, via Clerk's token vault. */
+/** Google access token for the OWNER of a mailbox, via Clerk's token vault.
+ *
+ * The users table can hold duplicate rows per email with stale clerkUserIds
+ * (see src/db/userHelpers.ts — Clerk reissues ids). Trying candidates in
+ * recency order and taking the first that resolves a vaulted token is the
+ * same tolerance the rest of the app gets via resolveDbUser at sign-in. */
 export async function googleTokenForEmail(targetEmail: string): Promise<string> {
-  const owner = await db.query.users.findFirst({
-    where: eq(users.email, targetEmail),
-  });
-  if (!owner || owner.deletedAt) {
+  const candidates = (await db.select().from(users)
+    .where(eq(users.email, targetEmail)))
+    .filter(u => !u.deletedAt)
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  if (candidates.length === 0) {
     throw new Error(`No live FGAC user owns mailbox ${targetEmail}`);
   }
   const client = await clerkClient();
-  const tokens = await client.users.getUserOauthAccessToken(owner.clerkUserId, 'google');
-  const token = tokens.data[0]?.token;
-  if (!token) throw new Error(`No Google token vaulted for ${targetEmail}`);
-  return token;
+  let lastErr: unknown;
+  for (const owner of candidates) {
+    try {
+      const tokens = await client.users.getUserOauthAccessToken(owner.clerkUserId, 'google');
+      const token = tokens.data[0]?.token;
+      if (token) return token;
+      lastErr = new Error('no google token on user');
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw new Error(`No Google token vaulted for ${targetEmail}: ${lastErr instanceof Error ? lastErr.message : lastErr}`);
 }
 
 async function gmailFetch(token: string, path: string, init?: RequestInit): Promise<unknown> {

--- a/src/lib/notifications/gmail.ts
+++ b/src/lib/notifications/gmail.ts
@@ -1,0 +1,111 @@
+/**
+ * Gmail plumbing for the push-notification subsystem: Clerk-vaulted token
+ * lookup, watch arm/stop, history diff, and metadata fetch.
+ *
+ * Spike-validated constraints (docs/implementation_plans/third-party-handoff-
+ * permissions_v4.md):
+ *  - The Pub/Sub topic MUST live in the GCP project of the Google OAuth client
+ *    behind Clerk's vaulted tokens (GMAIL_PUBSUB_TOPIC env var, per environment).
+ *  - Watches expire after ~7 days; Gmail publishes a test notification at watch
+ *    time, so zero-diff notifications are normal.
+ */
+import { clerkClient } from '@clerk/nextjs/server';
+import { db } from '@/db';
+import { users } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+
+const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1';
+
+export function pubsubTopic(): string {
+  const topic = process.env.GMAIL_PUBSUB_TOPIC;
+  if (!topic || !topic.startsWith('projects/')) {
+    throw new Error('GMAIL_PUBSUB_TOPIC is not configured (projects/<id>/topics/<name>)');
+  }
+  return topic;
+}
+
+/** Google access token for the OWNER of a mailbox, via Clerk's token vault. */
+export async function googleTokenForEmail(targetEmail: string): Promise<string> {
+  const owner = await db.query.users.findFirst({
+    where: eq(users.email, targetEmail),
+  });
+  if (!owner || owner.deletedAt) {
+    throw new Error(`No live FGAC user owns mailbox ${targetEmail}`);
+  }
+  const client = await clerkClient();
+  const tokens = await client.users.getUserOauthAccessToken(owner.clerkUserId, 'google');
+  const token = tokens.data[0]?.token;
+  if (!token) throw new Error(`No Google token vaulted for ${targetEmail}`);
+  return token;
+}
+
+async function gmailFetch(token: string, path: string, init?: RequestInit): Promise<unknown> {
+  const res = await fetch(`${GMAIL_API}/${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Gmail ${path} → ${res.status}: ${body.slice(0, 300)}`);
+  }
+  const text = await res.text();
+  return text.trim() ? JSON.parse(text) : {};
+}
+
+/** Arm (or re-arm) the INBOX watch. Returns Gmail's current historyId + expiry. */
+export async function armWatch(targetEmail: string): Promise<{ historyId: string; expiration: Date }> {
+  const token = await googleTokenForEmail(targetEmail);
+  const resp = await gmailFetch(token, 'users/me/watch', {
+    method: 'POST',
+    body: JSON.stringify({ topicName: pubsubTopic(), labelIds: ['INBOX'] }),
+  }) as { historyId: string; expiration: string };
+  return { historyId: resp.historyId, expiration: new Date(Number(resp.expiration)) };
+}
+
+export async function stopWatch(targetEmail: string): Promise<void> {
+  const token = await googleTokenForEmail(targetEmail);
+  await gmailFetch(token, 'users/me/stop', { method: 'POST', body: '{}' });
+}
+
+/** Message ids added since the given cursor, plus the new cursor to store. */
+export async function diffHistory(
+  targetEmail: string, startHistoryId: string,
+): Promise<{ messageIds: string[]; newHistoryId: string | null }> {
+  const token = await googleTokenForEmail(targetEmail);
+  const messageIds: string[] = [];
+  let newHistoryId: string | null = null;
+  let pageToken: string | undefined;
+
+  do {
+    const qs = new URLSearchParams({
+      startHistoryId,
+      historyTypes: 'messageAdded',
+      ...(pageToken ? { pageToken } : {}),
+    });
+    const resp = await gmailFetch(token, `users/me/history?${qs}`) as {
+      history?: Array<{ messagesAdded?: Array<{ message: { id: string } }> }>;
+      historyId?: string;
+      nextPageToken?: string;
+    };
+    for (const h of resp.history ?? []) {
+      for (const m of h.messagesAdded ?? []) messageIds.push(m.message.id);
+    }
+    if (resp.historyId) newHistoryId = resp.historyId;
+    pageToken = resp.nextPageToken;
+  } while (pageToken);
+
+  return { messageIds: [...new Set(messageIds)], newHistoryId };
+}
+
+/** Metadata-only fetch used for rule filtering (labels + headers, no body). */
+export async function fetchMessageMetadata(targetEmail: string, messageId: string): Promise<unknown> {
+  const token = await googleTokenForEmail(targetEmail);
+  return gmailFetch(
+    token,
+    `users/me/messages/${messageId}?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject`,
+  );
+}

--- a/src/lib/notifications/hmac.ts
+++ b/src/lib/notifications/hmac.ts
@@ -1,0 +1,23 @@
+/**
+ * Webhook payload signing. Every partner ping carries:
+ *   X-FGAC-Signature: sha256=<hex hmac of raw body>
+ *   X-FGAC-Timestamp: unix seconds (signed as `${ts}.${body}` to stop replay)
+ *   X-FGAC-Delivery-Id: outbox row id (stable across retries for dedup)
+ */
+import crypto from 'crypto';
+
+export function signWebhookBody(secret: string, timestamp: number, body: string): string {
+  const mac = crypto.createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+  return `sha256=${mac}`;
+}
+
+export function verifyWebhookSignature(
+  secret: string, timestamp: number, body: string, signature: string,
+): boolean {
+  const expected = signWebhookBody(secret, timestamp, body);
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/notifications/process.ts
+++ b/src/lib/notifications/process.ts
@@ -90,8 +90,11 @@ export async function processGmailNotification(
         continue;
       }
       // Unique (subscriptionId, messageId) absorbs Pub/Sub at-least-once replays.
+      // nextAttemptAt uses the APP clock, not the DB default — the inline claim
+      // below compares against the app clock, and DB/app skew otherwise leaves
+      // fresh rows "not due" until the next cron tick.
       const inserted = await db.insert(webhookDeliveries)
-        .values({ subscriptionId: sub.id, messageId })
+        .values({ subscriptionId: sub.id, messageId, nextAttemptAt: new Date(Date.now() - 1000) })
         .onConflictDoNothing()
         .returning({ id: webhookDeliveries.id });
       if (inserted.length > 0) result.enqueued++;

--- a/src/lib/notifications/process.ts
+++ b/src/lib/notifications/process.ts
@@ -1,0 +1,120 @@
+/**
+ * Pub/Sub notification processing: resolve subscriptions for the notified
+ * mailbox, diff Gmail history from each subscription's cursor, filter the new
+ * messages through the bound key's READ RULES, and enqueue outbox rows for the
+ * survivors. A message the key cannot read is never even announced.
+ *
+ * Runs inside the Pub/Sub push request but must stay fast — content fetches are
+ * metadata-only, and partner delivery is async (outbox + drainer), with one
+ * inline best-effort attempt so the happy path is real-time.
+ */
+import { db } from '@/db';
+import {
+  notificationSubscriptions, webhookDeliveries, agentConnections, proxyKeys,
+} from '@/db/schema';
+import { eq, and, sql } from 'drizzle-orm';
+import { loadApplicableRules, checkReadRestrictions } from '@/lib/gmailRules';
+import { diffHistory, fetchMessageMetadata } from './gmail';
+import { deliverPendingForSubscription } from './deliver';
+
+export interface ProcessResult {
+  subscriptionsSeen: number;
+  enqueued: number;
+  filtered: number;
+}
+
+export async function processGmailNotification(
+  emailAddress: string, notificationHistoryId: string,
+): Promise<ProcessResult> {
+  const subs = await db.select({
+    sub: notificationSubscriptions,
+    connection: agentConnections,
+  })
+    .from(notificationSubscriptions)
+    .innerJoin(agentConnections, eq(notificationSubscriptions.connectionId, agentConnections.id))
+    .where(and(
+      eq(notificationSubscriptions.targetEmail, emailAddress),
+      eq(notificationSubscriptions.status, 'active'),
+    ));
+
+  const result: ProcessResult = { subscriptionsSeen: subs.length, enqueued: 0, filtered: 0 };
+
+  for (const { sub, connection } of subs) {
+    // Connection must still be live and keyed — a detached partner gets nothing.
+    if (connection.status !== 'approved' || !connection.proxyKeyId) continue;
+    const key = await db.query.proxyKeys.findFirst({
+      where: eq(proxyKeys.id, connection.proxyKeyId),
+    });
+    if (!key || key.revokedAt || (key.expiresAt && key.expiresAt < new Date())) continue;
+
+    // First notification for a fresh subscription: adopt the cursor, diff next time.
+    if (!sub.lastHistoryId) {
+      await db.update(notificationSubscriptions)
+        .set({ lastHistoryId: notificationHistoryId, updatedAt: new Date() })
+        .where(eq(notificationSubscriptions.id, sub.id));
+      continue;
+    }
+
+    let messageIds: string[] = [];
+    let newHistoryId: string | null = null;
+    try {
+      ({ messageIds, newHistoryId } = await diffHistory(emailAddress, sub.lastHistoryId));
+    } catch (err) {
+      // historyId too old (Gmail retains ~1 week) → resync cursor; the gap is
+      // surfaced in logs. Anything else: leave cursor, Pub/Sub redelivery retries.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('404')) {
+        console.warn(`[Notify] History gap for sub=${sub.id}; resyncing cursor to ${notificationHistoryId}`);
+        await db.update(notificationSubscriptions)
+          .set({ lastHistoryId: notificationHistoryId, updatedAt: new Date() })
+          .where(eq(notificationSubscriptions.id, sub.id));
+        continue;
+      }
+      throw err;
+    }
+
+    // Rule-filter each new message with the SAME check the read path uses.
+    const rules = await loadApplicableRules(connection.userId, key.id, emailAddress);
+    for (const messageId of messageIds) {
+      let restricted: string | null = null;
+      try {
+        const meta = await fetchMessageMetadata(emailAddress, messageId);
+        restricted = checkReadRestrictions(rules, meta);
+      } catch (err) {
+        // Metadata fetch failed → fail CLOSED (do not announce what we could not check).
+        console.error(`[Notify] Metadata fetch failed for ${messageId}:`, err);
+        restricted = 'metadata unavailable';
+      }
+      if (restricted) {
+        result.filtered++;
+        continue;
+      }
+      // Unique (subscriptionId, messageId) absorbs Pub/Sub at-least-once replays.
+      const inserted = await db.insert(webhookDeliveries)
+        .values({ subscriptionId: sub.id, messageId })
+        .onConflictDoNothing()
+        .returning({ id: webhookDeliveries.id });
+      if (inserted.length > 0) result.enqueued++;
+    }
+
+    // Advance the cursor monotonically.
+    const advanceTo = newHistoryId ?? notificationHistoryId;
+    await db.update(notificationSubscriptions)
+      .set({
+        lastHistoryId: sql`GREATEST(${notificationSubscriptions.lastHistoryId}::bigint, ${advanceTo}::bigint)::text`,
+        updatedAt: new Date(),
+      })
+      .where(eq(notificationSubscriptions.id, sub.id));
+
+    // Inline best-effort first delivery — cron only mops up failures.
+    if (result.enqueued > 0) {
+      try {
+        await deliverPendingForSubscription(sub.id);
+      } catch (err) {
+        console.error(`[Notify] Inline delivery attempt failed for sub=${sub.id}:`, err);
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/lib/notifications/subscriptions.ts
+++ b/src/lib/notifications/subscriptions.ts
@@ -1,0 +1,90 @@
+/**
+ * Notification subscription lifecycle. Watches are per-mailbox at Gmail, but
+ * subscriptions are per (connection, mailbox) — so a watch is only stopped
+ * when the LAST active subscription on that mailbox goes away.
+ */
+import { db } from '@/db';
+import { notificationSubscriptions, agentConnections } from '@/db/schema';
+import { and, eq, ne } from 'drizzle-orm';
+import { armWatch, stopWatch } from './gmail';
+
+/** Create (or revive) a subscription and try to arm the watch. A failed arm is
+ * not fatal — watchExpiresAt stays NULL and the renewal cron retries. */
+export async function ensureSubscription(connectionId: string, targetEmail: string): Promise<string> {
+  const [sub] = await db.insert(notificationSubscriptions)
+    .values({ connectionId, targetEmail })
+    .onConflictDoUpdate({
+      target: [notificationSubscriptions.connectionId, notificationSubscriptions.targetEmail],
+      set: { status: 'active', consecutiveFailures: 0, updatedAt: new Date() },
+    })
+    .returning();
+
+  try {
+    const { historyId, expiration } = await armWatch(targetEmail);
+    await db.update(notificationSubscriptions)
+      .set({
+        // Adopt the watch-time cursor only if we do not already have one —
+        // never regress an existing cursor.
+        lastHistoryId: sub.lastHistoryId ?? historyId,
+        watchExpiresAt: expiration,
+        updatedAt: new Date(),
+      })
+      .where(eq(notificationSubscriptions.id, sub.id));
+  } catch (err) {
+    console.error(`[Subs] Failed to arm watch for ${targetEmail} (cron will retry):`, err);
+  }
+  return sub.id;
+}
+
+/** Cancel every subscription on a connection (detach/block/revoke path), and
+ * stop the Gmail watch for any mailbox left with no other active subscriber. */
+export async function cancelSubscriptionsForConnection(connectionId: string): Promise<void> {
+  const subs = await db.select().from(notificationSubscriptions)
+    .where(and(
+      eq(notificationSubscriptions.connectionId, connectionId),
+      ne(notificationSubscriptions.status, 'cancelled'),
+    ));
+  if (subs.length === 0) return;
+
+  await db.update(notificationSubscriptions)
+    .set({ status: 'cancelled', updatedAt: new Date() })
+    .where(eq(notificationSubscriptions.connectionId, connectionId));
+
+  for (const sub of subs) {
+    const others = await db.select({ id: notificationSubscriptions.id })
+      .from(notificationSubscriptions)
+      .where(and(
+        eq(notificationSubscriptions.targetEmail, sub.targetEmail),
+        eq(notificationSubscriptions.status, 'active'),
+      ))
+      .limit(1);
+    if (others.length === 0) {
+      try {
+        await stopWatch(sub.targetEmail);
+      } catch (err) {
+        console.error(`[Subs] Failed to stop watch for ${sub.targetEmail}:`, err);
+      }
+    }
+  }
+}
+
+/** Re-enable a suspended subscription (dashboard action). The caller should
+ * follow with a reconciliation sweep if gap coverage matters. */
+export async function reenableSubscription(subscriptionId: string): Promise<void> {
+  await db.update(notificationSubscriptions)
+    .set({ status: 'active', consecutiveFailures: 0, updatedAt: new Date() })
+    .where(eq(notificationSubscriptions.id, subscriptionId));
+}
+
+/** Connections owned by a user, for authorization checks on sub actions. */
+export async function subscriptionBelongsToUser(subscriptionId: string, userId: string): Promise<boolean> {
+  const row = await db.select({ id: notificationSubscriptions.id })
+    .from(notificationSubscriptions)
+    .innerJoin(agentConnections, eq(notificationSubscriptions.connectionId, agentConnections.id))
+    .where(and(
+      eq(notificationSubscriptions.id, subscriptionId),
+      eq(agentConnections.userId, userId),
+    ))
+    .limit(1);
+  return row.length > 0;
+}

--- a/src/lib/partner/clerkOauth.ts
+++ b/src/lib/partner/clerkOauth.ts
@@ -1,0 +1,46 @@
+/**
+ * Direct verification of Clerk-issued OAuth JWTs against the instance JWKS.
+ * Shared by partner-facing endpoints (/api/auth/partner-token). Fails closed
+ * unless the token's issuer is exactly our Clerk instance.
+ */
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+export function expectedClerkIssuer(): string | null {
+  const pk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  if (!pk) return null;
+  try {
+    const domain = Buffer.from(pk.replace(/^pk_(test|live)_/, ''), 'base64')
+      .toString('utf8')
+      .replace(/\$$/, '');
+    return domain ? `https://${domain}` : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function verifyClerkOauthToken(
+  token: string,
+): Promise<{ userId: string; clientId: string } | null> {
+  try {
+    const [, payloadB64] = token.split('.');
+    if (!payloadB64) return null;
+    const rawPayload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+    const issuer = rawPayload.iss;
+
+    const expected = expectedClerkIssuer();
+    if (!expected || issuer !== expected) {
+      console.error(`[PartnerAuth] Rejecting token from issuer '${issuer}' (expected '${expected ?? 'unavailable'}')`);
+      return null;
+    }
+
+    const JWKS = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
+    const { payload: verified } = await jwtVerify(token, JWKS, { issuer, clockTolerance: 30 });
+    const sub = verified.sub;
+    const cid = (verified as Record<string, unknown>).client_id as string | undefined;
+    if (!sub || !cid) return null;
+    return { userId: sub, clientId: cid };
+  } catch (err) {
+    console.error('[PartnerAuth] JWT verification failed:', err);
+    return null;
+  }
+}

--- a/src/lib/partner/manifest.ts
+++ b/src/lib/partner/manifest.ts
@@ -1,0 +1,46 @@
+/**
+ * Partner app manifest — the app-declared "agent role" copied into concrete
+ * keys/rules at consent time. Kept deliberately small; anything not expressible
+ * here is not grantable through the partner handoff.
+ */
+export interface PartnerRuleTemplate {
+  service: 'gmail' | 'sheets';
+  actionType: string;      // e.g. 'send_whitelist', 'label_blacklist'
+  ruleName: string;
+  regexPattern?: string;
+}
+
+export interface PartnerManifest {
+  services: Array<'gmail' | 'sheets'>;
+  // 'read_only' needs no templates: send is deny-by-default absent a
+  // send_whitelist rule, and DELETE is never exposed.
+  access: 'read_only' | 'scoped_write';
+  rule_templates?: PartnerRuleTemplate[];
+  notifications?: { trigger: 'new_email' };
+}
+
+export function parseManifest(raw: unknown): PartnerManifest | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const m = raw as Record<string, unknown>;
+  if (!Array.isArray(m.services) || m.services.length === 0) return null;
+  if (m.access !== 'read_only' && m.access !== 'scoped_write') return null;
+  return raw as PartnerManifest;
+}
+
+/** Human-readable permission summary rendered on the consent screen.
+ * Registry data only — never client-supplied request params. */
+export function describeManifest(m: PartnerManifest): string[] {
+  const lines: string[] = [];
+  if (m.services.includes('gmail')) {
+    lines.push(m.access === 'read_only'
+      ? 'Read your email (read-only — cannot send, modify, or delete)'
+      : 'Read your email and send within an approved recipient list');
+  }
+  if (m.services.includes('sheets')) {
+    lines.push('Access spreadsheets you explicitly share');
+  }
+  if (m.notifications?.trigger === 'new_email') {
+    lines.push('Be notified when new email arrives (message IDs only — content stays behind your rules)');
+  }
+  return lines;
+}

--- a/src/lib/partner/provision.ts
+++ b/src/lib/partner/provision.ts
@@ -1,0 +1,133 @@
+/**
+ * Consent-time provisioning: everything the user assembles by hand for an MCP
+ * agent today, executed as one transaction when they click Approve on the
+ * /oauth/authorize interstitial.
+ *
+ *  1. Proxy key labeled with the partner name
+ *  2. key_email_access for the selected mailboxes (delegation-backed for
+ *     non-own addresses — same invariant as createProxyKey)
+ *  3. COPIES of the manifest's rule templates bound to that key (copies, not
+ *     references: a later manifest edit must never widen an existing grant)
+ *  4. agent_connections row approved + pinned to the consented manifestVersion
+ *  5. (post-transaction) notification subscription + watch arm, if requested
+ */
+import crypto from 'crypto';
+import { db } from '@/db';
+import {
+  proxyKeys, keyEmailAccess, accessRules, keyRuleAssignments,
+  agentConnections, emailDelegations, users,
+} from '@/db/schema';
+import { and, eq } from 'drizzle-orm';
+import type { PartnerManifest } from './manifest';
+import { ensureSubscription } from '@/lib/notifications/subscriptions';
+
+interface PartnerAppRow {
+  id: string;
+  clientId: string;
+  name: string;
+  manifestVersion: number;
+  webhookUrl: string | null;
+}
+
+interface ProvisionInput {
+  user: { id: string; email: string };
+  partner: PartnerAppRow;
+  manifest: PartnerManifest;
+  selectedEmails: string[];
+}
+
+export interface ProvisionOutput {
+  connectionId: string;
+  proxyKeyId: string;
+}
+
+export async function provisionPartnerConnection(input: ProvisionInput): Promise<ProvisionOutput> {
+  const { user, partner, manifest, selectedEmails } = input;
+  if (selectedEmails.length === 0) throw new Error('No mailbox selected');
+
+  // Resolve delegation backing BEFORE the transaction (reads only).
+  const emailBindings: Array<{ email: string; delegationId: string | null }> = [];
+  for (const email of selectedEmails) {
+    if (email.toLowerCase() === user.email.toLowerCase()) {
+      emailBindings.push({ email, delegationId: null });
+      continue;
+    }
+    const owner = await db.select().from(users)
+      .where(eq(users.email, email)).limit(1).then(r => r[0]);
+    if (!owner) throw new Error(`No FGAC account owns ${email}`);
+    const delegation = await db.select().from(emailDelegations)
+      .where(and(
+        eq(emailDelegations.ownerUserId, owner.id),
+        eq(emailDelegations.delegateUserId, user.id),
+        eq(emailDelegations.status, 'active'),
+      )).limit(1).then(r => r[0]);
+    if (!delegation) throw new Error(`No active delegation grants you access to ${email}`);
+    emailBindings.push({ email, delegationId: delegation.id });
+  }
+
+  const output = await db.transaction(async (tx) => {
+    const [key] = await tx.insert(proxyKeys).values({
+      userId: user.id,
+      key: `sk_proxy_${crypto.randomUUID().replace(/-/g, '')}`,
+      label: partner.name,
+    }).returning();
+
+    for (const binding of emailBindings) {
+      await tx.insert(keyEmailAccess).values({
+        proxyKeyId: key.id,
+        delegationId: binding.delegationId,
+        targetEmail: binding.email,
+      });
+    }
+
+    for (const template of manifest.rule_templates ?? []) {
+      const [rule] = await tx.insert(accessRules).values({
+        userId: user.id,
+        ruleName: `${partner.name}: ${template.ruleName}`,
+        service: template.service,
+        actionType: template.actionType,
+        regexPattern: template.regexPattern ?? null,
+      }).returning();
+      // Binding the copy to the key keeps it scoped — never global.
+      await tx.insert(keyRuleAssignments).values({
+        proxyKeyId: key.id,
+        accessRuleId: rule.id,
+      });
+    }
+
+    const [connection] = await tx.insert(agentConnections).values({
+      userId: user.id,
+      clientId: partner.clientId,
+      clientName: partner.name,
+      nickname: partner.name,
+      proxyKeyId: key.id,
+      status: 'approved',
+      partnerAppId: partner.id,
+      manifestVersion: partner.manifestVersion,
+      approvedAt: new Date(),
+    }).onConflictDoUpdate({
+      target: [agentConnections.userId, agentConnections.clientId],
+      set: {
+        clientName: partner.name,
+        proxyKeyId: key.id,
+        status: 'approved',
+        partnerAppId: partner.id,
+        manifestVersion: partner.manifestVersion,
+        approvedAt: new Date(),
+      },
+    }).returning();
+
+    return { connectionId: connection.id, proxyKeyId: key.id };
+  });
+
+  // Outside the transaction: watch arming talks to Gmail and must not be able
+  // to roll back a completed consent. Failure leaves watchExpiresAt NULL for
+  // the renewal cron to retry.
+  if (manifest.notifications?.trigger === 'new_email' && partner.webhookUrl) {
+    for (const binding of emailBindings) {
+      await ensureSubscription(output.connectionId, binding.email);
+    }
+  }
+
+  return output;
+}

--- a/src/lib/partner/provision.ts
+++ b/src/lib/partner/provision.ts
@@ -65,15 +65,23 @@ export async function provisionPartnerConnection(input: ProvisionInput): Promise
     emailBindings.push({ email, delegationId: delegation.id });
   }
 
-  const output = await db.transaction(async (tx) => {
-    const [key] = await tx.insert(proxyKeys).values({
-      userId: user.id,
-      key: `sk_proxy_${crypto.randomUUID().replace(/-/g, '')}`,
-      label: partner.name,
-    }).returning();
+  // The neon-http driver has no transaction support, so provisioning runs as
+  // ordered inserts with explicit compensation: if any later step fails, the
+  // key is deleted (cascading away email access + rule assignments) and the
+  // rule copies are removed — never leaving a partially-granted key behind.
+  // Order matters: the connection upsert is LAST, so approval only ever points
+  // at a fully-assembled key.
+  const [key] = await db.insert(proxyKeys).values({
+    userId: user.id,
+    key: `sk_proxy_${crypto.randomUUID().replace(/-/g, '')}`,
+    label: partner.name,
+  }).returning();
 
+  const createdRuleIds: string[] = [];
+  let output: ProvisionOutput;
+  try {
     for (const binding of emailBindings) {
-      await tx.insert(keyEmailAccess).values({
+      await db.insert(keyEmailAccess).values({
         proxyKeyId: key.id,
         delegationId: binding.delegationId,
         targetEmail: binding.email,
@@ -81,21 +89,22 @@ export async function provisionPartnerConnection(input: ProvisionInput): Promise
     }
 
     for (const template of manifest.rule_templates ?? []) {
-      const [rule] = await tx.insert(accessRules).values({
+      const [rule] = await db.insert(accessRules).values({
         userId: user.id,
         ruleName: `${partner.name}: ${template.ruleName}`,
         service: template.service,
         actionType: template.actionType,
         regexPattern: template.regexPattern ?? null,
       }).returning();
+      createdRuleIds.push(rule.id);
       // Binding the copy to the key keeps it scoped — never global.
-      await tx.insert(keyRuleAssignments).values({
+      await db.insert(keyRuleAssignments).values({
         proxyKeyId: key.id,
         accessRuleId: rule.id,
       });
     }
 
-    const [connection] = await tx.insert(agentConnections).values({
+    const [connection] = await db.insert(agentConnections).values({
       userId: user.id,
       clientId: partner.clientId,
       clientName: partner.name,
@@ -117,8 +126,19 @@ export async function provisionPartnerConnection(input: ProvisionInput): Promise
       },
     }).returning();
 
-    return { connectionId: connection.id, proxyKeyId: key.id };
-  });
+    output = { connectionId: connection.id, proxyKeyId: key.id };
+  } catch (err) {
+    try {
+      await db.delete(proxyKeys).where(eq(proxyKeys.id, key.id));
+      if (createdRuleIds.length > 0) {
+        const { inArray } = await import('drizzle-orm');
+        await db.delete(accessRules).where(inArray(accessRules.id, createdRuleIds));
+      }
+    } catch (cleanupErr) {
+      console.error('[Provision] Compensation cleanup failed:', cleanupErr);
+    }
+    throw err;
+  }
 
   // Outside the transaction: watch arming talks to Gmail and must not be able
   // to roll back a completed consent. Failure leaves watchExpiresAt NULL for

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "crons": [
+    { "path": "/api/cron/deliver-webhooks", "schedule": "* * * * *" },
+    { "path": "/api/cron/renew-watches", "schedule": "0 6 * * *" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "crons": [
-    { "path": "/api/cron/deliver-webhooks", "schedule": "* * * * *" },
+    { "path": "/api/cron/deliver-webhooks", "schedule": "0 12 * * *" },
     { "path": "/api/cron/renew-watches", "schedule": "0 6 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

Implements the third-party partner handoff (distribution package #5) and the push-notification subsystem, per docs/implementation_plans/third-party-handoff-permissions_v7.md.

**Partner handoff**: `partner_apps` registry + manifest model, `/oauth/authorize` consent interstitial (single consent screen — Clerk's is disabled per app), consent-time provisioning (key + email access + rule copies + approved connection pinned to manifestVersion), `/api/auth/partner-token` exchange, dashboard partner badge, `register-partner-app.ts`.

**Push notifications**: Gmail `users.watch` → Pub/Sub → `/api/webhooks/gmail` (OIDC/bridge auth) → read-rule filter → `webhook_deliveries` outbox → HMAC-signed thin pings (message IDs only) with backoff/auto-suspend, watch-renewal + delivery crons, `setup-gmail-push.ts` infra script.

**QA**: capability docs 11 & 12 (22 assertions), setup/04, runbook updates, webhook-receiver + pull-drain bridge harness.

Validated end-to-end locally (see plan v7 for the full assertion matrix and the five defects found & fixed during validation, including partner-key revocation on detach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)