### PR TITLE
docs: partner integration guide + onboarding runbook

### DIFF
--- a/docs/partner_integration_guide.md
+++ b/docs/partner_integration_guide.md
@@ -1,0 +1,215 @@
+# FGAC Partner Integration Guide
+
+> **Audience:** third-party applications that want their users to grant scoped,
+> rule-governed access to Gmail through FGAC — with optional real-time
+> notifications when new mail arrives.
+>
+> The model in one sentence: your user clicks "Connect" in your app, approves a
+> single FGAC consent screen, and your servers receive credentials that can
+> only do what that user allowed — FGAC holds the Google credentials, enforces
+> the user's rules on every request, and never sends you email content you
+> weren't granted.
+
+---
+
+## 1. What you provide us (one-time registration)
+
+FGAC registers partners manually today. Send us:
+
+| Item | Notes |
+|------|-------|
+| **App name** | Shown verbatim on the consent screen (e.g. "Data Driven Job Search") |
+| **Logo URL** (optional) | HTTPS PNG/SVG, square, shown on the consent screen |
+| **Redirect URI(s)** | Where we send the user back with the authorization code. HTTPS only (localhost allowed for your dev builds). Exact-match — no wildcards. |
+| **Webhook URL** (if using notifications) | HTTPS endpoint on your infrastructure that receives new-mail pings. Publicly reachable; no IP allowlisting of our side required (verify by signature, not source). |
+| **Requested access** | Today: `read_only` Gmail (+ optional `new_email` notifications). Read-only means your credentials can list and read mail the user's rules allow — they can never send, modify, or delete. |
+| **Ops contact** | Email for delivery-failure and incident notices |
+
+## 2. What we provide you (once, over a secure channel)
+
+| Credential | Purpose |
+|------------|---------|
+| `client_id` | OAuth client identifier (public) |
+| `client_secret` | OAuth code/refresh exchange (confidential — server-side only) |
+| `webhook_secret` | HMAC-SHA256 key to verify our webhook signatures (confidential) |
+
+Plus these fixed endpoints:
+
+| Endpoint | URL |
+|----------|-----|
+| Authorize (start handoff here) | `https://fgac.ai/oauth/authorize` |
+| Token exchange & refresh | `https://clerk.fgac.ai/oauth/token` |
+| Proxy-key exchange (optional) | `https://fgac.ai/api/auth/partner-token` |
+| Gmail REST proxy | `https://gmail.fgac.ai/gmail/v1/...` |
+| MCP server (alternative surface) | `https://fgac.ai/api/mcp` |
+| OAuth discovery metadata | `https://fgac.ai/.well-known/oauth-authorization-server` |
+
+## 3. What you build
+
+### 3.1 The handoff (OAuth 2.0 authorization code + PKCE)
+
+**Step 1 — redirect the signed-in user to FGAC:**
+
+```
+https://fgac.ai/oauth/authorize
+  ?client_id=<your client_id>
+  &redirect_uri=<your registered redirect URI>
+  &response_type=code
+  &scope=email profile offline_access
+  &state=<opaque anti-CSRF value you generate per attempt>
+  &code_challenge=<BASE64URL(SHA256(code_verifier))>
+  &code_challenge_method=S256
+```
+
+The user sees **one** consent screen (ours), picks which mailbox to share, and
+approves or denies. You do not need to build any consent UI.
+
+**Step 2 — handle the callback** at your redirect URI:
+
+- Approved: `?code=...&state=...` — verify `state` matches what you issued.
+- Denied: `?error=access_denied&state=...` — treat as a normal user choice.
+
+**Step 3 — exchange the code (server-side):**
+
+```
+POST https://clerk.fgac.ai/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code=<code>
+&redirect_uri=<same redirect URI>
+&client_id=<client_id>
+&client_secret=<client_secret>
+&code_verifier=<the PKCE verifier>
+```
+
+Response: `access_token` (valid ~24h) + `refresh_token`. Store both per user,
+encrypted at rest.
+
+**Step 4 — refresh** with `grant_type=refresh_token`. Note the refresh token
+**rotates** on every use: always persist the new one from the response.
+
+### 3.2 Calling Gmail — pick one of two surfaces
+
+**Option A — REST proxy with a proxy key (recommended for stock Google SDKs):**
+
+Exchange your OAuth access token for the connection's long-lived proxy key:
+
+```
+POST https://fgac.ai/api/auth/partner-token
+Authorization: Bearer <access_token>
+```
+
+→ `{ "status": "approved", "proxy_key": "sk_proxy_...", "emails": [...] }`
+
+Then call the standard Gmail REST API shape against our proxy with that key:
+
+```
+GET https://gmail.fgac.ai/gmail/v1/users/me/messages/<id>
+Authorization: Bearer sk_proxy_...
+```
+
+Official Google SDKs work by overriding the API endpoint
+(Python: `client_options={'api_endpoint': 'https://gmail.fgac.ai/gmail/v1'}`;
+Node: `rootUrl: 'https://gmail.fgac.ai/'`).
+
+**Option B — MCP:** point any MCP client at `https://fgac.ai/api/mcp` with the
+OAuth access token as bearer. Tools include `gmail_list`, `gmail_read`,
+`gmail_labels`, `get_my_permissions`.
+
+**Statuses you must handle on either surface:** a `pending` response means the
+connection was created outside our consent flow and awaits manual approval
+(rare, see §5); `blocked`/`403` means the user detached your app — stop
+calling, discard stored credentials, and offer to reconnect.
+
+### 3.3 The webhook receiver (if you requested notifications)
+
+When mail arrives in a connected mailbox, we POST a **thin ping** — message
+IDs only, never content:
+
+```json
+{
+  "event": "new_email",
+  "connection_id": "8bce0f81-…",
+  "account": "user@example.com",
+  "message_ids": ["19fd7e9b4f5d2cf4"],
+  "deliveries": [
+    { "delivery_id": "079b144e-…", "message_id": "19fd7e9b4f5d2cf4" }
+  ]
+}
+```
+
+Headers on every delivery:
+
+| Header | Meaning |
+|--------|---------|
+| `X-FGAC-Signature` | `sha256=<hex HMAC-SHA256(webhook_secret, "<timestamp>.<raw body>")>` |
+| `X-FGAC-Timestamp` | Unix seconds the signature was produced |
+| `X-FGAC-Delivery-Id` | Stable across retries of the same delivery — use for dedup |
+
+Your receiver MUST:
+
+1. **Verify the signature** (constant-time compare) against the raw request
+   body before parsing. Reject stale timestamps (e.g. > 5 minutes) to prevent
+   replay.
+2. **Respond 2xx within 10 seconds.** Do the real processing async — fetch
+   message content afterwards through §3.2 with your own credentials.
+3. **Be idempotent.** Delivery is at-least-once; dedup on `delivery_id` (or
+   `message_id` per account).
+
+Delivery semantics: a failed delivery (non-2xx or timeout) retries on a
+backoff ladder (1m → 5m → 15m → 1h → 6h → 24h, then dead-lettered; retry
+timing may be coarser depending on platform scheduling). Repeated dead
+deliveries **suspend the subscription** and we notify your ops contact —
+re-enabling triggers a catch-up sweep. Ordering is not guaranteed; because
+pings carry only IDs, out-of-order arrival is harmless.
+
+**What you will never receive:** subject lines, bodies, snippets, or sender
+addresses in a webhook — and no ping at all for messages the user's rules
+exclude from your access. Content always comes from your own authenticated
+fetch, where rules are enforced again at read time.
+
+## 4. Testing your integration
+
+Work through this checklist with us on a test account before going live:
+
+- [ ] **Happy path:** Connect → single FGAC consent screen shows your name,
+      logo, and permission summary → callback receives `code` + your `state`.
+- [ ] **Deny path:** user clicks Deny → callback receives
+      `error=access_denied`, your UI handles it gracefully, no credentials stored.
+- [ ] **Token exchange** returns access + refresh; a Gmail list call succeeds
+      immediately (no pending step).
+- [ ] **Refresh rotation:** two consecutive refreshes succeed and you persisted
+      the rotated token both times.
+- [ ] **Read-only enforcement:** a send attempt through your credentials
+      returns 403 (expected — do not build send features against a read-only grant).
+- [ ] **Webhook signature:** valid pings verify; a tampered body or wrong
+      secret fails your verification.
+- [ ] **Webhook dedup:** we will replay a delivery — confirm you process it once.
+- [ ] **Failure/retry:** return 500 for a test ping; confirm the retry arrives
+      and your recovery processes it once.
+- [ ] **Disconnect:** we detach the test connection — confirm your API calls
+      receive blocked/403 and your app surfaces "reconnect" rather than erroring.
+
+## 5. Security model — what keeps everyone honest
+
+- **You never see Google credentials.** FGAC vaults them; your credentials are
+  FGAC-scoped and die instantly when the user detaches your app (both the
+  OAuth tokens and the proxy key).
+- **Permissions are copied at consent, not referenced.** If your requested
+  manifest changes later, existing users keep exactly what they approved until
+  they re-consent.
+- **The consent screen cannot be bypassed.** Driving our OAuth endpoints
+  directly yields tokens whose connection is pending-by-default — every API
+  call refuses until the user explicitly approves.
+- **Users can see everything.** Your app appears in their dashboard with a
+  partner badge, the mailbox it can reach, the rules applied, and (soon) a
+  delivery audit trail. One click detaches you.
+
+## 6. Support
+
+Registration changes (redirect URIs, webhook URL, logo, requested access) go
+through your FGAC contact — access-broadening changes require your users to
+re-consent by design. Include your `connection_id` (from webhook payloads or
+`get_my_permissions`) in support requests; never send us your `client_secret`
+or `webhook_secret`.

--- a/docs/partner_onboarding_runbook.md
+++ b/docs/partner_onboarding_runbook.md
@@ -1,0 +1,153 @@
+# Partner Onboarding & Configuration Runbook (Internal)
+
+> **Audience:** FGAC operators. The partner-facing counterpart is
+> [`partner_integration_guide.md`](partner_integration_guide.md); the design and
+> spike evidence live in
+> [`implementation_plans/third-party-handoff-permissions_v7.md`](implementation_plans/third-party-handoff-permissions_v7.md).
+>
+> This repo is public — nothing in this runbook is secret, and no real partner
+> credentials, ids, or emails may ever be committed or pasted into issues.
+
+---
+
+## 0. One-time environment prerequisites (per environment)
+
+Before the FIRST partner in an environment can use notifications:
+
+1. **GCP push infrastructure** — run the idempotent setup script against the
+   environment's Google-OAuth-client project (spike-verified constraint: the
+   Pub/Sub topic MUST live in that project — dev `dev-fgac-ai`, prod
+   `fine-grain-access-control`):
+
+   ```bash
+   npx tsx scripts/setup-gmail-push.ts --project fine-grain-access-control \
+     --push-endpoint https://fgac.ai/api/webhooks/gmail --prod --apply
+   ```
+
+   Creates/verifies: topic, `gmail-api-push@system.gserviceaccount.com`
+   publisher grant, OIDC push subscription with a dedicated invoker service
+   account. Dev omits `--push-endpoint` (QA uses the pull-drain bridge) and
+   also writes the local env vars.
+
+2. **Vercel env vars** (per environment, pasted WITHOUT quotes; production
+   changes require a redeploy by the user):
+   - `GMAIL_PUBSUB_TOPIC` — `projects/<project>/topics/fgac-gmail-watch`
+   - `PUBSUB_PUSH_AUDIENCE` — the push endpoint URL (OIDC `aud` claim)
+   - `PUBSUB_PUSH_SA_EMAIL` — `fgac-push-invoker@<project>.iam.gserviceaccount.com`
+   - `CRON_SECRET` — random string; **without it the delivery/renewal crons
+     401 in production and never run**
+3. **Plan constraint**: Vercel Hobby allows max 2 crons, daily granularity —
+   `vercel.json` is configured accordingly. Consequence: failed-webhook
+   *retries* wait for the daily drain (happy path is unaffected — first
+   delivery is inline). Upgrading to Pro or pointing an external scheduler at
+   `/api/cron/deliver-webhooks` (Bearer `CRON_SECRET`) restores fast retries.
+   Decide before onboarding latency-sensitive partners.
+
+## 1. Intake & review
+
+Collect from the partner (see the integration guide §1): name, logo URL,
+redirect URIs, webhook URL, requested access, ops contact.
+
+Review gate — decline or escalate if any of these fail:
+
+- [ ] Redirect URIs and webhook URL are HTTPS on domains the partner
+      demonstrably controls (localhost acceptable for their dev registration).
+- [ ] Requested access is expressible as a manifest we support — today that is
+      `read_only` Gmail ± `new_email` notifications. Write access
+      (`scoped_write` + send whitelists) is a deliberate product decision per
+      partner, not a default.
+- [ ] The app name/logo do not impersonate another product.
+- [ ] We are satisfied the use case is legitimate (the consent screen renders
+      OUR summary of their manifest — users trust our description, so we own it).
+
+## 2. Registration (per environment — dev and prod are separate Clerk instances)
+
+Registration = one script, which creates BOTH the pre-registered Clerk OAuth
+application (`consent_screen_enabled: false` — the FGAC interstitial is the
+only consent screen) AND the `partner_apps` registry row:
+
+```bash
+# Dev (default; uses .env.local + branch DB):
+npx tsx scripts/register-partner-app.ts \
+  --name "Data Driven Job Search" \
+  --redirect-uri https://ddjs.example.com/fgac/callback \
+  --webhook-url https://api.ddjs.example.com/fgac/webhook \
+  --logo-url https://ddjs.example.com/logo.png \
+  --notifications
+
+# Production (reads .secrets/prod.env by name; both flags required):
+npx tsx scripts/register-partner-app.ts ... --prod --apply
+```
+
+The script prints `client_id`, `client_secret`, and `webhook_secret` **once**
+— we do not store the client secret outside Clerk. Deliver all three to the
+partner over a secure channel (never email/issue/chat log), then delete any
+local copy. `--roll-webhook-secret` rotates the HMAC key on a re-run.
+
+Re-running with the same `--name` updates the existing registration
+idempotently. A changed manifest bumps `manifestVersion` — see §4.
+
+## 3. Verification before telling the partner "you're live"
+
+- [ ] `GET https://fgac.ai/oauth/authorize?client_id=<theirs>&redirect_uri=<theirs>`
+      (signed in as a test user) renders the consent screen with their
+      name/logo and correct permission lines.
+- [ ] A wrong redirect_uri renders "Invalid redirect URI" and shares nothing.
+- [ ] Unauthenticated `POST /api/webhooks/gmail` → 401.
+- [ ] Walk the partner through the testing checklist in the integration guide
+      §4 against a QA account. For notifications, confirm on OUR side:
+      subscription row active, `watchExpiresAt` ~7 days out, and a signed ping
+      in their receiver within a minute of a test email.
+- [ ] Confirm the **bypass fail-safe** stands: their client driven straight at
+      `clerk.fgac.ai/oauth/authorize` yields a `pending` connection whose
+      calls refuse (this is capability 11 A7 — it must never regress).
+
+## 4. Manifest changes & re-consent policy
+
+Permissions are **copied** into keys/rules at consent and pinned by
+`manifestVersion` on each connection. Therefore:
+
+- **Narrowing or metadata changes** (name, logo, URIs): re-run the register
+  script; existing connections are unaffected.
+- **Broadening** (e.g. read_only → scoped_write, adding notifications): re-run
+  the script (registry version bumps automatically), but existing users keep
+  their consented grant until they go through `/oauth/authorize` again. Never
+  hand-edit rules to "upgrade" existing connections — that bypasses consent by
+  design, and the QA suite (capability 11 A10) will catch it.
+
+## 5. Monitoring & incident response
+
+- **Delivery health**: `webhook_deliveries` is both queue and audit trail —
+  `dead` rows and `notification_subscriptions.status = 'suspended'` are the
+  failure signals. Suspension happens after 3 consecutive dead delivery
+  groups; notify the partner's ops contact, and on their fix re-enable the
+  subscription (which should be followed by a reconciliation sweep from
+  `lastHistoryId`).
+- **Watch health**: `renew-watches` cron re-arms anything expiring within 48h
+  and self-heals subscriptions whose initial arm failed (`watchExpiresAt`
+  NULL). Gmail also publishes a zero-diff notification at arm time — normal,
+  not a bug.
+- **Instant Vercel deploy failures with empty Builds**: check the Neon branch
+  count (10-branch limit) AND `vercel.json` plan-validity (sub-daily crons on
+  Hobby reject the deployment) before anything destructive.
+
+## 6. Suspension & offboarding
+
+| Action | Effect | How |
+|--------|--------|-----|
+| **User detaches** (their choice) | Connection blocked, partner proxy key revoked, subscriptions cancelled, Gmail watch stopped if last subscriber — both credential surfaces die immediately | Dashboard "Detach" (self-serve) |
+| **Suspend partner** (our choice, all users) | New authorizations refused ("Unknown application" path); existing connections keep working | Set `partner_apps.status = 'suspended'` |
+| **Full offboarding** | Everything above plus existing access dies | Suspend registry row; block each connection (revokes keys, cancels subscriptions); delete the Clerk OAuth application (kills token refresh) |
+
+Rotate the webhook secret (`--roll-webhook-secret`) any time the partner
+reports a possible leak.
+
+## 7. QA hooks
+
+Capabilities [`11_partner_handoff.md`](QA_Acceptance_Test/capabilities/11_partner_handoff.md)
+and [`12_push_notifications.md`](QA_Acceptance_Test/capabilities/12_push_notifications.md)
+cover this surface (22 assertions);
+[`setup/04_partner_app_registration.md`](QA_Acceptance_Test/setup/04_partner_app_registration.md)
+bootstraps the QA partner ("QA Spike Partner") each cycle. Any change to the
+consent flow, provisioning, or webhook pipeline must keep those suites green —
+`npx tsx scripts/qa-coverage-check.ts` is the arbiter.


### PR DESCRIPTION
Two companion documents for the partner handoff channel shipped in #56:

- **docs/partner_integration_guide.md** — external, hand to partners: what they provide us, what we provide them, what they build (OAuth handoff w/ PKCE, two Gmail surfaces, webhook receiver with HMAC verification), a pre-launch testing checklist, and the security model.
- **docs/partner_onboarding_runbook.md** — internal: per-environment prerequisites (GCP push infra, env vars incl CRON_SECRET, Vercel plan constraint), intake review gate, registration via register-partner-app.ts, go-live verification, manifest re-consent policy, monitoring, suspension/offboarding, QA hooks.

Endpoints verified against production discovery metadata (clerk.fgac.ai issuer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)