### PR TITLE
docs: partner packet fixes from DDJS pilot feedback

### DIFF
--- a/docs/partner_integration_guide.md
+++ b/docs/partner_integration_guide.md
@@ -14,7 +14,19 @@
 
 ## 1. What you provide us (one-time registration)
 
-FGAC registers partners manually today. Send us:
+**How to register:** email the table below to **fgac-ai@googlegroups.com**
+(also the support channel for partners not yet registered). During the pilot
+phase expect a response within **2 business days**. Credentials are delivered
+to your ops contact via a **one-time secret link** — never over email body or
+chat.
+
+**Environments:** dev/sandbox and production are separate registrations with
+separate credentials — a localhost redirect URI implies a sandbox
+registration, not a flag on your production one. Request both up front:
+sandbox credentials let you run the §4 checklist against a test deployment
+before any production user is involved.
+
+Send us:
 
 | Item | Notes |
 |------|-------|
@@ -44,6 +56,15 @@ Plus these fixed endpoints:
 | MCP server (alternative surface) | `https://fgac.ai/api/mcp` |
 | OAuth discovery metadata | `https://fgac.ai/.well-known/oauth-authorization-server` |
 
+> ⚠️ **Do not auto-configure your OAuth client from the discovery document.**
+> It advertises the underlying identity provider's `authorization_endpoint`
+> (`clerk.fgac.ai/oauth/authorize`) — starting the flow there bypasses the
+> FGAC consent screen and produces a connection that is **pending forever**:
+> the handoff will appear to succeed, then every API call will refuse (see
+> §5). Use the discovery document for `token_endpoint` and `jwks_uri` only,
+> and always start the handoff at the literal URL
+> **`https://fgac.ai/oauth/authorize`** from the table above.
+
 ## 3. What you build
 
 ### 3.1 The handoff (OAuth 2.0 authorization code + PKCE)
@@ -63,6 +84,15 @@ https://fgac.ai/oauth/authorize
 
 The user sees **one** consent screen (ours), picks which mailbox to share, and
 approves or denies. You do not need to build any consent UI.
+
+**What must be true of the user:** nothing in advance. If they are not signed
+in to FGAC, they are routed through sign-in first and returned to the consent
+screen. A brand-new user completes the entire bootstrap mid-handoff — sign up
+with Google (which is also where FGAC obtains its Gmail authorization), then
+land on your consent screen; their FGAC account is created automatically. For
+your UX copy: "you'll sign in with Google, then approve access on FGAC" covers
+both new and existing users. The mailbox picker shows the user's own Gmail
+address plus any mailboxes delegated to them inside FGAC.
 
 **Step 2 — handle the callback** at your redirect URI:
 
@@ -157,17 +187,32 @@ Your receiver MUST:
 3. **Be idempotent.** Delivery is at-least-once; dedup on `delivery_id` (or
    `message_id` per account).
 
-Delivery semantics: a failed delivery (non-2xx or timeout) retries on a
-backoff ladder (1m → 5m → 15m → 1h → 6h → 24h, then dead-lettered; retry
-timing may be coarser depending on platform scheduling). Repeated dead
-deliveries **suspend the subscription** and we notify your ops contact —
-re-enabling triggers a catch-up sweep. Ordering is not guaranteed; because
-pings carry only IDs, out-of-order arrival is harmless.
+Delivery semantics: the **first delivery attempt is immediate** (seconds from
+mail arrival). If your endpoint fails (non-2xx or timeout), **retries are
+currently batched into a daily drain** — design your recovery around "a
+failed delivery retries within ~24h", not minutes. (The design target is a
+1m → 5m → 15m → 1h → 6h → 24h ladder and we expect to tighten to it; we will
+notify partners when the cadence changes.) After repeated failures a delivery
+is dead-lettered, and repeated dead deliveries **suspend the subscription** —
+we notify your ops contact, and re-enabling triggers a catch-up sweep, so no
+mail is silently lost. Ordering is not guaranteed; because pings carry only
+IDs, out-of-order arrival is harmless.
 
 **What you will never receive:** subject lines, bodies, snippets, or sender
 addresses in a webhook — and no ping at all for messages the user's rules
 exclude from your access. Content always comes from your own authenticated
 fetch, where rules are enforced again at read time.
+
+### 3.4 Rate limits & bulk operations
+
+No hard rate limits are enforced on the Gmail proxy or token endpoints today —
+underlying Google API quotas still apply and are shared, so be gentle:
+sustained request rates in the low single digits per second per user are safe.
+**Coordinate with us before bulk backfills** (e.g. "list and read the whole
+mailbox" on first connect — the most common first workload); we'd rather
+provision for it than have you discover a ceiling mid-migration. Explicit
+limits, when introduced, will be announced with lead time and signaled with
+standard `429` + `Retry-After`.
 
 ## 4. Testing your integration
 
@@ -208,8 +253,9 @@ Work through this checklist with us on a test account before going live:
 
 ## 6. Support
 
-Registration changes (redirect URIs, webhook URL, logo, requested access) go
-through your FGAC contact — access-broadening changes require your users to
-re-consent by design. Include your `connection_id` (from webhook payloads or
-`get_my_permissions`) in support requests; never send us your `client_secret`
-or `webhook_secret`.
+All support and registration changes go through **fgac-ai@googlegroups.com** —
+including questions from teams who have not registered yet. Registration
+changes (redirect URIs, webhook URL, logo, requested access) are handled
+there; access-broadening changes require your users to re-consent by design.
+Include your `connection_id` (from webhook payloads or `get_my_permissions`)
+in support requests; never send us your `client_secret` or `webhook_secret`.

--- a/docs/partner_onboarding_runbook.md
+++ b/docs/partner_onboarding_runbook.md
@@ -45,8 +45,24 @@ Before the FIRST partner in an environment can use notifications:
 
 ## 1. Intake & review
 
+**Channel & SLA (published in the guide — honor them):** registration requests
+and pre-registration questions arrive at **fgac-ai@googlegroups.com**; respond
+within 2 business days. Credentials go back to the ops contact via a
+**one-time secret link** (e.g. 1Password share) — never in email body, chat,
+issues, or any committed file.
+
 Collect from the partner (see the integration guide §1): name, logo URL,
-redirect URIs, webhook URL, requested access, ops contact.
+redirect URIs, webhook URL, requested access, ops contact. Partners should be
+offered a **sandbox registration** (dev Clerk instance) alongside production —
+sandbox testing runs against a dev deployment of the app, so coordinate which
+dev/preview URL they'll target.
+
+> **Known trap (documented in the guide, fix tracked):** the public discovery
+> document advertises Clerk's `authorization_endpoint`, which bypasses the
+> consent interstitial if a partner's OAuth library auto-configures from it
+> (RFC 8414). The guide warns against this; the durable fix — serving
+> `https://fgac.ai/oauth/authorize` as the advertised endpoint without
+> breaking the MCP/DCR channel that legitimately uses Clerk's — is backlog.
 
 Review gate — decline or escalate if any of these fail:
 

--- a/docs/partner_packet_gaps.md
+++ b/docs/partner_packet_gaps.md
@@ -1,0 +1,119 @@
+# Partner packet gaps — findings from the DDJS pilot integration
+
+> **Resolution status (2026-08-06):** all six gaps addressed in
+> `partner_integration_guide.md` / `partner_onboarding_runbook.md` in the same
+> change that committed this file. Gap 1 is mitigated with a prominent warning
+> in the guide (§2); the durable fix — serving the FGAC interstitial as the
+> advertised `authorization_endpoint` without breaking the MCP/DCR channel —
+> is tracked as backlog. Gap 4's stated behavior (mid-handoff bootstrap via
+> Google sign-up, automatic account creation) reflects implemented behavior;
+> DDJS should still confirm empirically during live validation as planned.
+
+> **Source:** DDJS (first external-style partner integration, 2026-08-06) built
+> its integration harness against `partner_integration_guide.md` ONLY, then
+> audited every piece of knowledge it needed against where that knowledge
+> actually came from. This file lists what a real partner could NOT have known
+> from the guide alone, so the packet can be fixed before the next partner.
+
+## Verdict
+
+The technical core of the guide is self-sufficient: endpoints, PKCE parameters,
+token-exchange shapes, refresh rotation, proxy-key exchange, Gmail proxy call
+shapes, status handling, and the §4 checklist were all buildable with no
+internal knowledge. The gaps below are onboarding-process holes and one
+documentation trap.
+
+## Gap 1 (trap, fix first): the discovery document contradicts the guide
+
+`https://fgac.ai/.well-known/oauth-authorization-server` advertises:
+
+```
+"authorization_endpoint": "https://clerk.fgac.ai/oauth/authorize"
+```
+
+but the guide (§3.1) requires starting the handoff at
+`https://fgac.ai/oauth/authorize` — and §5 explains that driving the Clerk
+endpoint directly yields a **pending** connection whose API calls all refuse.
+
+Any partner who feeds the discovery URL to a standards-compliant OAuth client
+library (RFC 8414 auto-configuration — the default in many stacks) will silently
+bypass the FGAC consent interstitial and ship a broken integration with
+confusing symptoms (handoff "succeeds", every API call refuses). DDJS only
+avoided this because the guide's literal URL was used instead of discovery.
+
+**Packet fix options (either works):**
+- Add a warning box to §2: "Use the discovery document for `token_endpoint`
+  and `jwks_uri` ONLY. The `authorization_endpoint` it advertises is the
+  underlying IdP and must not be used — always start at
+  `https://fgac.ai/oauth/authorize`."
+- Better: serve a discovery document whose `authorization_endpoint` is the
+  FGAC interstitial, so auto-configuration does the right thing.
+
+## Gap 2: §1 says "send us" — but not where, or what happens next
+
+The registration table lists what to send but the packet never says:
+
+- **Where** to send it (email address? form? portal?).
+- **Turnaround expectation** for registration.
+- **How credentials arrive** ("over a secure channel" — §2 — but which one?
+  Partners will ask; deciding it per-partner in email threads won't scale).
+- **Who to contact when stuck** (§6 says "your FGAC contact" — a partner who
+  arrived via the public guide has no contact yet).
+
+**Packet fix:** one short "How to register" paragraph with a real channel and
+SLA, and make §6's support path reachable for not-yet-registered partners.
+
+## Gap 3: no sandbox/dev environment offer
+
+Internally, dev and prod are separate Clerk instances and a partner must be
+registered in each — but the guide never mentions a sandbox. A partner reading
+the packet doesn't know they can (or should) get dev credentials before
+touching their production registration, or that localhost redirect URIs
+("your dev builds", §1) imply a second registration rather than a flag on the
+prod one.
+
+**Packet fix:** state explicitly whether FGAC offers a sandbox registration,
+that credentials are per-environment, and that partners should request both.
+
+## Gap 4: user-precondition for the consent screen is unstated
+
+§3.1 says the user "picks which mailbox to share". The guide never says what
+must be true of that user beforehand: do they need an existing FGAC account?
+Must the mailbox already be connected to FGAC (Google OAuth completed) before
+the partner handoff, or does the consent flow bootstrap it? A partner building
+their "Connect Gmail" onboarding needs this to write accurate UX copy and to
+know what an un-onboarded user will experience mid-handoff.
+
+*(DDJS will confirm the actual behavior empirically during live validation and
+this section should then be updated with the answer — the point is the packet
+must state it.)*
+
+## Gap 5: retry cadence expectation is vaguer than reality
+
+§3.3 gives a backoff ladder (1m → 5m → … → 24h) with the caveat "retry timing
+may be coarser depending on platform scheduling." In the current deployment,
+failed-delivery retries are batched into a **daily** drain — that is not a
+slightly-coarser ladder, it is a different SLO. A partner designing recovery
+logic (e.g. "if we 500, the retry lands within minutes") will be misled.
+
+**Packet fix:** state the current real cadence plainly ("first delivery is
+immediate; retries of failed deliveries are currently batched daily") and
+treat the ladder as aspirational/plan-dependent.
+
+## Gap 6 (minor): no rate limits or quotas documented
+
+The guide is silent on request rate limits for the Gmail proxy and token
+endpoints, and on any cap for backfill-style bursts (a new partner's most
+likely first workload is "list and read the whole mailbox"). Even a
+placeholder ("no enforced limits today; be gentle; ask us before bulk
+backfills") prevents the partner from having to guess.
+
+## Non-gaps (things that worked from the guide alone)
+
+For completeness — all verified live against production by DDJS with no
+internal knowledge: authorize URL parameter set incl. PKCE S256 and state;
+deny-path shape; token exchange body; refresh-token rotation semantics;
+partner-token exchange request/response; Gmail REST proxy call shape and SDK
+endpoint-override examples; blocked/pending status semantics; webhook payload,
+signature scheme, timestamp check, and dedup key documentation (receiver
+implemented from §3.3 without questions).


### PR DESCRIPTION
Closes all six gaps found by the DDJS pilot integration (docs/partner_packet_gaps.md, committed here with resolution annotations):

1. ⚠️ warning against RFC 8414 auto-configuration (the advertised authorization_endpoint bypasses the consent interstitial) — durable discovery-document fix tracked separately
2. Real registration channel + SLA + one-time-secret-link credential delivery
3. Sandbox/per-environment registration documented
4. User precondition: mid-handoff bootstrap via Google sign-up, automatic account creation
5. Honest webhook retry cadence (immediate first attempt; daily retry drain today; ladder is the design target)
6. Rate limits / bulk-backfill guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)