### PR TITLE
Switch support contact to support@fgac.ai

### DIFF
--- a/docs/connector_submission/listing_copy.md
+++ b/docs/connector_submission/listing_copy.md
@@ -70,7 +70,7 @@ Recommended: #1 (both differentiators, then the safety hook).
 
 **Documentation URL**: `https://fgac.ai/docs`
 **Privacy policy URL**: `https://fgac.ai/privacy`
-**Support contact**: `fgac-ai@googlegroups.com`
+**Support contact**: `support@fgac.ai`
 
 **Icon**: square PNG, 512×512, cropped from `public/logo-v2.png` (the current
 brand mark — the only logo asset in the repo; older variants were removed).

--- a/docs/connector_submission/reviewer_runbook.md
+++ b/docs/connector_submission/reviewer_runbook.md
@@ -43,7 +43,7 @@ Send the account ~8-10 emails so every demo prompt has something to find:
 2. Default profile → **+ Expose a sheet** → pick "Team Budget (Demo)" → set
    **Read & Write**.
 3. Rules (create on the profile):
-   - **Send whitelist**: pattern `fgac-ai@googlegroups.com` (so a reviewer can
+   - **Send whitelist**: pattern `support@fgac.ai` (so a reviewer can
      send exactly one place — us; everything else demonstrates the deny).
    - **Content read blacklist**: rule name `Block verification codes`, pattern
      `verification code` (blocks the 2FA fixture).
@@ -83,7 +83,7 @@ between this doc and reality before submission day.
 |---|---|---|
 | 1 | "Summarize my unread email." | Summaries of the ordinary fixtures. The message whose subject contains a verification code, and the one labeled Confidential, are NOT readable — Claude reports an "Access restricted" notice for them. |
 | 2 | "Read the email about my verification code." | Denied: `🚫 Access restricted: Content blocked by rule 'Block verification codes'`. |
-| 3 | "Email fgac-ai@googlegroups.com that the review test succeeded." | Sends successfully (that address is whitelisted); Claude returns the Gmail message id. |
+| 3 | "Email support@fgac.ai that the review test succeeded." | Sends successfully (that address is whitelisted); Claude returns the Gmail message id. |
 | 4 | "Email anyone@example.com hello." | Denied: unauthorized recipient. The denial includes a single-use approval link the account owner could use to whitelist that recipient in one click. Nothing is sent. |
 | 5 | "What's in the Budget tab of the Team Budget spreadsheet?" then "Append a row to the Tracking tab: today, 42." | Both succeed (sheet is exposed Read & Write). |
 | 6 | "Request permission to send email to demo@example.com." | The `request_access` tool returns an approval link and states nothing is granted until the user approves. A follow-up send to that address still fails (the link was not approved). |
@@ -95,4 +95,4 @@ between this doc and reality before submission day.
   paths; try `google_api_get` with `drive/v3/files` to see the deny-by-default
   behavior (unsupported APIs are refused server-side).
 - Public docs: `https://fgac.ai/docs` · Privacy: `https://fgac.ai/privacy`
-- Support / questions: `fgac-ai@googlegroups.com`
+- Support / questions: `support@fgac.ai`

--- a/docs/partner_integration_guide.md
+++ b/docs/partner_integration_guide.md
@@ -14,7 +14,7 @@
 
 ## 1. What you provide us (one-time registration)
 
-**How to register:** email the table below to **fgac-ai@googlegroups.com**
+**How to register:** email the table below to **support@fgac.ai**
 (also the support channel for partners not yet registered). During the pilot
 phase expect a response within **2 business days**. Credentials are delivered
 to your ops contact via a **one-time secret link** — never over email body or
@@ -253,7 +253,7 @@ Work through this checklist with us on a test account before going live:
 
 ## 6. Support
 
-All support and registration changes go through **fgac-ai@googlegroups.com** —
+All support and registration changes go through **support@fgac.ai** —
 including questions from teams who have not registered yet. Registration
 changes (redirect URIs, webhook URL, logo, requested access) are handled
 there; access-broadening changes require your users to re-consent by design.

--- a/docs/partner_onboarding_runbook.md
+++ b/docs/partner_onboarding_runbook.md
@@ -46,7 +46,7 @@ Before the FIRST partner in an environment can use notifications:
 ## 1. Intake & review
 
 **Channel & SLA (published in the guide — honor them):** registration requests
-and pre-registration questions arrive at **fgac-ai@googlegroups.com**; respond
+and pre-registration questions arrive at **support@fgac.ai**; respond
 within 2 business days. Credentials go back to the ops contact via a
 **one-time secret link** (e.g. 1Password share) — never in email body, chat,
 issues, or any committed file.

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -270,10 +270,10 @@ export default function DocsPage() {
           <p className="mx-auto mb-4 max-w-md text-sm leading-relaxed text-muted-foreground">
             Questions, bug reports, or access issues — email{" "}
             <a
-              href="mailto:fgac-ai@googlegroups.com"
+              href="mailto:support@fgac.ai"
               className="text-primary underline underline-offset-2"
             >
-              fgac-ai@googlegroups.com
+              support@fgac.ai
             </a>
             . See also the{" "}
             <Link href="/privacy" className="text-primary underline underline-offset-2">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -73,7 +73,7 @@ export default function PrivacyPolicy() {
             <h2 className="text-xl font-bold text-gray-900 mb-3">7. Contact Us</h2>
             <p>
               If you have any questions or concerns about this privacy policy, or want to exercise your rights over your data, contact us at{' '}
-              <a href="mailto:fgac-ai@googlegroups.com" className="text-blue-600 hover:text-blue-800 underline">fgac-ai@googlegroups.com</a>.
+              <a href="mailto:support@fgac.ai" className="text-blue-600 hover:text-blue-800 underline">support@fgac.ai</a>.
             </p>
           </section>
         </div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -77,7 +77,7 @@ export default function TermsOfService() {
             <h2 className="text-xl font-bold text-gray-900 mb-3">9. Contact</h2>
             <p>
               Questions about these terms or the Service can be sent to{' '}
-              <a href="mailto:fgac-ai@googlegroups.com" className="text-blue-600 hover:text-blue-800 underline">fgac-ai@googlegroups.com</a>.
+              <a href="mailto:support@fgac.ai" className="text-blue-600 hover:text-blue-800 underline">support@fgac.ai</a>.
             </p>
           </section>
         </div>


### PR DESCRIPTION
The branded support mailbox is now live. Flips every current surface — /privacy, /terms, /docs, connector listing copy, reviewer runbook (incl. the reviewer-account send-whitelist target), partner docs — from the Google Group address to support@fgac.ai. The plugin manifest already used this address, making everything consistent. Historical implementation-plan docs intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)