### PR TITLE
Listing paste-sheet corrections before submission

### DIFF
--- a/docs/connector_submission/listing_copy.md
+++ b/docs/connector_submission/listing_copy.md
@@ -78,6 +78,11 @@ brand mark — the only logo asset in the repo; older variants were removed).
 **URL slug** (PERMANENT — cannot change after publication)
 > Recommended: `fgac` (short, matches domain). Alternative: `fgac-ai`.
 
+**Allowed link URIs** (optional field): one entry — `https://fgac.ai`. We
+don't call `ui/open-link` today (links are plain text in tool results), but
+the declaration is inert, we own the origin, and it pre-clears any future
+embedded-approval-card upgrade. Never list domains we don't own.
+
 ## Connection step
 
 - Server URL: `https://fgac.ai/api/mcp` (https ✓)
@@ -135,8 +140,9 @@ brand mark — the only logo asset in the repo; older variants were removed).
 - Use docs/connector_submission/reviewer_runbook.md Part 2 verbatim, with real
   credentials filled in from 1Password.
 - Attestation "you have run every tool yourself": true — QA runs exercised all
-  13 tools through the MCP endpoint (docs/QA_Acceptance_Test/qa-results.json);
-  do one final custom-connector pass from Claude.ai before submitting.
+  14 tools (including request_access) through the MCP endpoint
+  (docs/QA_Acceptance_Test/qa-results.json); do one final custom-connector
+  pass from Claude.ai before submitting.
 
 ## Compliance step (7 acknowledgments)
 
@@ -147,10 +153,11 @@ collection beyond tool needs ✓; public documentation live at fgac.ai/docs ✓.
 
 ## Pre-submission checklist (final pass)
 
-- [ ] Google Group accepts posts from non-members (tested with an outside email)
-- [ ] fgac.ai/docs live in production
+- [ ] support@fgac.ai delivery tested with an email from an outside address
+- [x] fgac.ai/docs live in production
 - [ ] Reviewer account built + dry-run (reviewer_runbook.md Part 1, step 5)
-- [ ] Icon cropped square, 512×512 PNG
+- [x] Icon cropped square, 512×512 PNG (from logo-v2.png)
 - [ ] No Vercel firewall/challenge rules blocking 160.79.104.0/21
-- [ ] Final custom-connector smoke test from Claude.ai (all tools listed with
-      annotations; one read, one denied read, one send, one denied send)
+- [ ] Final custom-connector smoke test from Claude.ai (all 14 tools listed
+      with annotations; one read, one denied read, one send, one denied send,
+      one request_access)

--- a/docs/connector_submission/listing_copy.md
+++ b/docs/connector_submission/listing_copy.md
@@ -23,14 +23,22 @@ we get surfaced.
 **Server name** (≤100 chars)
 > FGAC.ai
 
-**Tagline** (≤55 chars — pick one)
-> 1. `Multiple Gmail accounts & editable Sheets, safely` (49)
-> 2. `Gmail & Sheets for agents — on your terms` (41)
-> 3. `Read mail, update Sheets — with guardrails` (42)
+**Tagline** (≤55 chars) — DECIDED (user, 2026-08-15):
+> `Manage Multiple Gmail Accounts & Edit Google Sheets` (51)
 
-Recommended: #1 (both differentiators, then the safety hook).
+**Description** (≤2,000 chars) — DECIDED (user, 2026-08-15):
 
-**Description** (≤2,000 chars)
+> Connect Claude to Multiple Gmail Accounts, Work, School and Personal and
+> let it update Google Sheets for you! Through FGAC.ai you can give Claude
+> precise access to the specific sheets and senders you want.
+>
+> More Google Workspace Connections Coming Soon!
+
+(Earlier keyword-first draft kept below for reference — its bullet points
+remain useful raw material if the description is ever expanded; the
+use-cases step still carries the remaining search-phrase clusters.)
+
+<details><summary>Superseded draft (v2 keyword-first)</summary>
 
 > Connect one or many Gmail accounts — work, personal, and delegated team
 > inboxes — and let Claude read mail, send guarded email, and update your
@@ -63,7 +71,7 @@ Recommended: #1 (both differentiators, then the safety hook).
 >
 > Free for personal use. Connected in under a minute.
 
-(~1,750 chars.)
+</details>
 
 **Categories** (1-5): Productivity; Email; Spreadsheets/Data; Developer Tools
 (pick what the portal's actual taxonomy offers — Productivity first).

--- a/docs/connector_submission/reviewer_runbook.md
+++ b/docs/connector_submission/reviewer_runbook.md
@@ -14,10 +14,14 @@ can go end-to-end in ~10 minutes.
 
 ### 1. Create the Google account (human step — not automatable)
 
-- Fresh Gmail account, e.g. `fgac.reviewer@gmail.com` (any available name).
-- Password stored in 1Password (vault `FGAC`, item `connector-reviewer`).
-- Turn OFF 2-step verification (reviewers can't complete our 2FA), or use an
-  account where it's not enforced. No recovery phone tied to personal numbers.
+- ✅ DONE (2026-08-16): a dedicated reviewer Gmail account exists. Its
+  address, password, and 2FA live in 1Password (vault `FGAC`, item
+  `connector-reviewer`) — referenced here only as `<REVIEWER_EMAIL>`,
+  `<REVIEWER_PASSWORD>`, `<1PASSWORD_2FA_LINK>`.
+- The account HAS 2-step verification; reviewers get codes via a 1Password
+  shared link included in the portal submission. **The password and the
+  1Password share link are secrets — the share link mints live 2FA codes.
+  Neither may ever appear in this repo, an issue/PR, or any committed doc.**
 
 ### 2. Populate the inbox (fixtures)
 
@@ -60,22 +64,30 @@ doc and reality before submission day.
 
 ---
 
-## Part 2 — Paste into the portal's "Test & launch" step
+## Part 2 — Portal "Test & launch" instructions
 
-> **Credentials**: Google account `<REVIEWER_EMAIL>` / password
-> `<REVIEWER_PASSWORD>` (no 2FA). This account is pre-loaded with email
-> fixtures, two Gmail labels, one Google Sheet, and pre-configured FGAC rules.
+**Submitted version (2026-08-16)** — this is the text that went into the
+portal, with secrets as placeholders (real values in the portal + 1Password
+only; never commit them):
 
-**Setup (~3 min)**
+> **Step 1: Log in to google.com**
+> User Name: `<REVIEWER_EMAIL>`
+> Password: `<REVIEWER_PASSWORD>`
+> 1Password link for 2FA code: `<1PASSWORD_2FA_LINK>`
+>
+> **Step 2: Log in to FGAC.ai using Google OAuth**
+> Visit https://fgac.ai/ and click Sign up. Select "Continue with Google"
+> and use the `<REVIEWER_EMAIL>` account. This logs you in with Google OAuth.
+>
+> **Step 3: Connect Claude**
+> Add the connector `https://fgac.ai/api/mcp` in Claude. Approve the
+> connector in the FGAC.ai OAuth flow.
+>
+> The MCP is ready to use immediately — signing in attaches the agent to the
+> account's read-only Default Profile; no manual approval step.
 
-1. In Claude, add the connector (or as a custom connector:
-   `https://fgac.ai/api/mcp`). When the OAuth window opens, choose
-   **Sign in with Google** and use the credentials above.
-2. Ask Claude: *"List my email accounts."* — Expected: the account list,
-   immediately. Signing in attached the agent to the account's read-only
-   **Default Profile** — no manual approval step is needed, and the
-   dashboard (`https://fgac.ai/dashboard`) shows the new connection with
-   review/block controls.
+**Suggested functional script** (richer optional addition for the same portal
+field — gives reviewers expected outcomes per prompt):
 
 **Functional tests (~7 min)**
 

--- a/docs/connector_submission/reviewer_runbook.md
+++ b/docs/connector_submission/reviewer_runbook.md
@@ -55,8 +55,8 @@ Send the account ~8-10 emails so every demo prompt has something to find:
 ### 5. Dry-run before submitting
 
 Run the whole Part 2 script ourselves from a clean Claude.ai account:
-connect → approve → all 5 prompts → confirm outcomes match. Fix any drift
-between this doc and reality before submission day.
+connect → all 6 prompts → confirm outcomes match. Fix any drift between this
+doc and reality before submission day.
 
 ---
 


### PR DESCRIPTION
Adds the allowed-link-URIs entry (https://fgac.ai) we decided on, corrects the tool count to 14 (request_access), swaps the stale Google Group checklist item for a support@fgac.ai delivery test, and checks off completed items. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)