### PR TITLE
Fix approval-link bugs from external tool validation

### DIFF
--- a/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
+++ b/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
@@ -9,12 +9,17 @@
 
 ## Assertions
 
-### A1: Raw pair is annotated; legacy tool is gone
+### A1: Raw pair is annotated; legacy tool is gone; descriptions state the real access model
 - Call `tools/list` on the hosted MCP endpoint
 - **Expected**: `google_api_get` present with `readOnlyHint: true`;
   `google_api_modify` present with `destructiveHint: true`; every listed tool
   has a `title`; `raw_google_api_call` is absent; `google_api_modify`'s input
   schema offers only POST/PUT/PATCH (no DELETE, no GET)
+- **Also expected** (description accuracy, 2026-08-15 tester finding):
+  `google_api_get` and `gmail_read` descriptions state that Gmail reads are
+  allowed by default and filtered by read-block rules (not that every
+  response is rule-gated), and `gmail_get_attachment`'s description states
+  the returned data is base64url-encoded (URL-safe alphabet, unpadded)
 
 ### A2: Raw Gmail read succeeds
 - `google_api_get` with path `gmail/v1/users/me/messages?maxResults=2`

--- a/docs/QA_Acceptance_Test/capabilities/13_default_profile_instant_start.md
+++ b/docs/QA_Acceptance_Test/capabilities/13_default_profile_instant_start.md
@@ -73,3 +73,14 @@
 - Block the A1 connection from the dashboard, then retry a read tool
 - **Expected**: "🚫 This connection has been blocked by the user." — one-click
   block is unchanged by instant-start
+
+### A12: get_my_permissions states the implicit access posture
+- Call `get_my_permissions` on a connection whose profile has an empty or
+  minimal ruleset
+- **Expected**: The response contains an explicit defaults/posture section
+  stating that Gmail read is ALLOWED by default (restricted only by
+  read-block rules), sending is DENIED without a send whitelist, Sheets are
+  DENIED without per-spreadsheet rules, and deletion is never available —
+  so an auditor reading `rules: []` cannot conclude the key reaches nothing
+- **Regression**: 2026-08-15 tester audit note — implicit Gmail read was
+  invisible in the permissions output

--- a/docs/QA_Acceptance_Test/capabilities/14_magic_link_approvals.md
+++ b/docs/QA_Acceptance_Test/capabilities/14_magic_link_approvals.md
@@ -50,3 +50,30 @@
 - Trigger a label- or content-blocked `gmail_read` denial
 - **Expected**: The restriction message contains no approval URL — weakening
   a read block remains a deliberate dashboard act
+
+### A9: Approval URLs are well-formed single-line links
+- Capture approval URLs from (a) a send denial, (b) a sheets denial, and
+  (c) `request_access`'s structured `approvalUrl` field
+- **Expected**: Each URL contains no whitespace or newline characters
+  anywhere in the string, and parses to the FGAC origin with path
+  `/dashboard/approve` and a non-empty `token` query parameter
+- **Regression**: 2026-08-15 tester finding — a trailing newline in the env
+  base URL shipped links as `https://fgac.ai\n/dashboard/...`, breaking the
+  entire approval loop
+
+### A10: Denial-minted tokens match the access level the operation needs
+- Decode the JWT payload (base64url, no verification needed) of the approval
+  link from each denied call in this matrix:
+  | Denied operation | Sheet state | Required token action |
+  |---|---|---|
+  | `sheets_read_range` | unexposed | `sheets_expose` |
+  | `sheets_update_range` | unexposed | `sheets_write` |
+  | `sheets_append_rows` | unexposed | `sheets_write` |
+  | `sheets_update_range` | exposed Read Only | `sheets_write` |
+  | `google_api_modify` (Sheets PUT) | unexposed | `sheets_write` |
+- **Expected**: The token's `action` claim equals the required action in
+  every row — a write denial must never mint a read-level (`sheets_expose`)
+  token, which would send the user through an approval that cannot satisfy
+  the retried operation
+- **Regression**: 2026-08-15 tester finding — write denials minted
+  `sheets_expose`, creating an approve→retry→fail loop with no signal

--- a/scripts/env-check.ts
+++ b/scripts/env-check.ts
@@ -119,4 +119,21 @@ if (strays.length) {
   console.log(`    Keep production credentials in .secrets/ instead (see CLAUDE.md).${RESET}`);
 }
 
+// ── Whitespace inside env values ────────────────────────────────────────────
+// Sibling of the quoted-value check above: a value pasted into Vercel with a
+// trailing newline survives `vercel env pull` and dotenv parsing, then breaks
+// whatever URL it gets concatenated into (approval links shipped as
+// "https://fgac.ai\n/dashboard/approve..." this way). Detect it at the source.
+const whitespaceOffenders = Object.entries(process.env)
+  .filter(([k]) => /URL|HOST|DOMAIN/i.test(k))
+  .filter(([, v]) => v !== undefined && v !== v.trim())
+  .map(([k]) => k);
+if (whitespaceOffenders.length) {
+  console.log('');
+  console.log(bad(`env values with leading/trailing whitespace or newlines: ${whitespaceOffenders.join(', ')}`));
+  console.log(`${DIM}    URLs built from these break at the stray character. Fix at the source:`);
+  console.log(`      npx vercel env rm <VAR> <environment>   # then re-add WITHOUT the newline`);
+  console.log(`      npx vercel env pull .env.local --environment=development${RESET}`);
+}
+
 console.log('');

--- a/scripts/test-approval-links.ts
+++ b/scripts/test-approval-links.ts
@@ -61,6 +61,16 @@ async function main() {
   const url = await mintApprovalUrl('https://fgac.ai', 'u', 'k', { action: 'send_whitelist', recipient: 'a@b.com' });
   check('url targets /dashboard/approve', url.startsWith('https://fgac.ai/dashboard/approve?token='));
 
+  // Regression (tester finding 2026-08-15): env base URLs have shipped with a
+  // trailing newline, producing "https://fgac.ai\n/dashboard/..." — unclickable.
+  for (const dirty of ['https://fgac.ai\n', 'https://fgac.ai \n', 'https://fgac.ai/', '  https://fgac.ai  ']) {
+    const u = await mintApprovalUrl(dirty, 'u', 'k', { action: 'send_whitelist', recipient: 'a@b.com' });
+    check(`no whitespace in url minted from ${JSON.stringify(dirty)}`, !/\s/.test(u));
+    const parsed = new URL(u);
+    check(`url parses to fgac.ai/dashboard/approve from ${JSON.stringify(dirty)}`,
+      parsed.host === 'fgac.ai' && parsed.pathname === '/dashboard/approve' && !!parsed.searchParams.get('token'));
+  }
+
   if (failures > 0) { console.error(`\n${failures} approval-link test(s) FAILED`); process.exit(1); }
   console.log('\nAll approval-link tests passed.');
 }

--- a/scripts/test-google-api-policy.ts
+++ b/scripts/test-google-api-policy.ts
@@ -3,7 +3,7 @@
  * (src/app/api/mcp/googleApiPolicy.ts). Run: npx tsx scripts/test-google-api-policy.ts
  */
 import {
-  classifyGoogleApiCall, extractSendRecipients, collectLabelIds,
+  classifyGoogleApiCall, extractSendRecipients, collectLabelIds, sheetsApprovalAction,
 } from '../src/app/api/mcp/googleApiPolicy';
 
 let failures = 0;
@@ -88,6 +88,27 @@ expect('nested thread messages',
   collectLabelIds({ messages: [{ labelIds: ['INBOX'] }, { labelIds: ['SECRET'] }] }),
   (l: string[]) => l.includes('SECRET') && l.includes('INBOX'));
 expect('no labels → empty', collectLabelIds({ messages: [{ id: 'a' }] }), (l: string[]) => l.length === 0);
+
+console.log('sheetsApprovalAction (denial -> approval action matrix):');
+// Regression (tester finding 2026-08-15): a WRITE denied on an unexposed
+// sheet must mint a write-level token — a read-only exposure under-grants
+// and traps the user in an approve/retry/fail loop.
+expect('read on unexposed -> sheets_expose',
+  sheetsApprovalAction('not_exposed', 'ss1', false),
+  (a: { action: string } | null) => a?.action === 'sheets_expose');
+expect('WRITE on unexposed -> sheets_write',
+  sheetsApprovalAction('not_exposed', 'ss1', true),
+  (a: { action: string } | null) => a?.action === 'sheets_write');
+expect('write on read-only -> sheets_write',
+  sheetsApprovalAction('read_only', 'ss1', true),
+  (a: { action: string } | null) => a?.action === 'sheets_write');
+expect('blocked mints nothing (read)',
+  sheetsApprovalAction('blocked', 'ss1', false), (a: unknown) => a === null);
+expect('blocked mints nothing (write)',
+  sheetsApprovalAction('blocked', 'ss1', true), (a: unknown) => a === null);
+expect('spreadsheetId carried through',
+  sheetsApprovalAction('not_exposed', 'ss-42', true),
+  (a: { spreadsheetId?: string } | null) => a?.spreadsheetId === 'ss-42');
 
 if (failures > 0) {
   console.error(`\n${failures} test(s) FAILED`);

--- a/src/app/api/mcp/googleApiPolicy.ts
+++ b/src/app/api/mcp/googleApiPolicy.ts
@@ -114,3 +114,25 @@ export function collectLabelIds(value: unknown, depth = 0): string[] {
   }
   return out;
 }
+
+// ─── Sheets denial → approval action (magic links) ──────────────────────────
+
+export type SheetsDenialKind = 'not_exposed' | 'blocked' | 'read_only';
+
+/**
+ * Which grant a denied Sheets operation should request. The action must match
+ * the access level the DENIED OPERATION requires — a write denied on an
+ * unexposed sheet must request write access; minting a read-only exposure
+ * there sends the user through an approval that cannot satisfy the retry
+ * (tester finding, 2026-08-15). Explicit blocks never mint an action:
+ * weakening a deliberate block stays a dashboard act.
+ */
+export function sheetsApprovalAction(
+  denial: SheetsDenialKind,
+  spreadsheetId: string,
+  isMutating: boolean,
+): { action: 'sheets_expose' | 'sheets_write'; spreadsheetId: string } | null {
+  if (denial === 'blocked') return null;
+  if (denial === 'read_only') return { action: 'sheets_write', spreadsheetId };
+  return { action: isMutating ? 'sheets_write' : 'sheets_expose', spreadsheetId };
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -32,11 +32,20 @@ import { ensureDefaultProfile } from '@/db/defaultProfile';
 import { mintApprovalUrl, type ApprovalAction } from '@/lib/approvalLinks';
 import { TOOL_DEFS, toolAnnotations, type FgacToolDef } from './toolDefs';
 import {
-  classifyGoogleApiCall, extractSendRecipients,
+  classifyGoogleApiCall, extractSendRecipients, sheetsApprovalAction,
 } from './googleApiPolicy';
 
-const DASHBOARD_URL = process.env.NEXT_PUBLIC_APP_URL
-  || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}` : null)
+/** Env URL values have shipped with trailing whitespace/newlines (pasted
+ * Vercel vars); a whitespace-only value must also not win the fallback chain.
+ * Sanitizing here fixes every consumer: approval links, pending-approval
+ * dashboard URLs, everything built on DASHBOARD_URL. */
+function cleanUrl(value: string | undefined | null): string | null {
+  const trimmed = value?.trim().replace(/\/+$/, '');
+  return trimmed || null;
+}
+
+const DASHBOARD_URL = cleanUrl(process.env.NEXT_PUBLIC_APP_URL)
+  || (process.env.VERCEL_PROJECT_PRODUCTION_URL ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL.trim()}` : null)
   || 'http://localhost:3000';
 
 // ─── Connection Resolution ──────────────────────────────────────────────────
@@ -420,12 +429,11 @@ async function checkSheetsPermission(userId: string, proxyKeyId: string, spreads
 
 type SheetsPermission = Awaited<ReturnType<typeof checkSheetsPermission>>;
 
-/** Map a sheets denial onto an approvable action (explicit blocks get none). */
-function sheetsDenialAction(perm: SheetsPermission, spreadsheetId: string): ApprovalAction | null {
+/** Map a sheets denial onto an approvable action matching the access level
+ * the denied operation requires (see sheetsApprovalAction in googleApiPolicy). */
+function sheetsDenialAction(perm: SheetsPermission, spreadsheetId: string, isMutating: boolean): ApprovalAction | null {
   if (perm.allowed) return null;
-  if (perm.denial === 'not_exposed') return { action: 'sheets_expose', spreadsheetId };
-  if (perm.denial === 'read_only') return { action: 'sheets_write', spreadsheetId };
-  return null;
+  return sheetsApprovalAction(perm.denial, spreadsheetId, isMutating);
 }
 
 // ─── Gmail Message Parsing (token-frugal responses) ─────────────────────────
@@ -627,7 +635,7 @@ async function executeRawGoogleCall(
 
   if (cls.kind === 'sheets') {
     const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, cls.spreadsheetId, cls.isMutating);
-    if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, cls.spreadsheetId));
+    if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, cls.spreadsheetId, cls.isMutating));
 
     const url = `https://sheets.googleapis.com/${cleanPath.replace(/^sheets\//, '')}`;
     const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
@@ -868,7 +876,7 @@ const handler = createMcpHandler(
         if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, false);
-        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId));
+        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, false));
 
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}`, 'GET', undefined, resolved.targetEmail);
         if (!result.ok) return errorResult(result.error);
@@ -892,7 +900,7 @@ const handler = createMcpHandler(
         if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, false);
-        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId));
+        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, false));
 
         const encodedRange = encodeURIComponent(range);
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`, 'GET', undefined, resolved.targetEmail);
@@ -918,7 +926,7 @@ const handler = createMcpHandler(
         if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, true);
-        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId));
+        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, true));
 
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values, range });
@@ -945,7 +953,7 @@ const handler = createMcpHandler(
         if ('error' in resolved) return textResult(resolved.error);
 
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, true);
-        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId));
+        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, true));
 
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values });
@@ -1069,6 +1077,15 @@ const handler = createMcpHandler(
           connection: { id: conn.connectionId, nickname: conn.nickname },
           proxyKey: { id: key?.id, label: key?.label },
           accessibleEmails: emails.map(e => e.targetEmail),
+          // Implicit posture, stated explicitly: an empty rules array does
+          // NOT mean "no access" — auditors reading this output must see
+          // what the key can reach by default (tester finding, 2026-08-15).
+          defaults: {
+            gmailRead: 'ALLOWED by default for every accessible email; read-block rules (label/content) below restrict it',
+            gmailSend: 'DENIED unless a send_whitelist rule matches the recipient',
+            sheets: 'DENIED unless a per-spreadsheet rule below exposes the sheet',
+            deletion: 'NEVER available through any tool',
+          },
           rules: applicableRules.map(r => ({
             name: r.ruleName,
             type: r.actionType,

--- a/src/app/api/mcp/toolDefs.ts
+++ b/src/app/api/mcp/toolDefs.ts
@@ -40,13 +40,13 @@ export const TOOL_DEFS = {
   gmail_read: {
     name: 'gmail_read',
     title: 'Read a Gmail message',
-    description: 'Read a Gmail message by ID. Returns parsed headers, body text, and attachment metadata. Reads are evaluated against the user\'s FGAC access rules, and work across every connected or delegated Gmail inbox via the "account" parameter.',
+    description: 'Read a Gmail message by ID. Returns parsed headers, body text, and attachment metadata. Reading is allowed by default; messages matching the user\'s read-block rules (labels or content patterns), if any, are withheld. Works across every connected or delegated Gmail inbox via the "account" parameter.',
     readOnly: true,
   },
   gmail_get_attachment: {
     name: 'gmail_get_attachment',
     title: 'Download a Gmail attachment',
-    description: 'Retrieve an email attachment by message ID and attachment ID. The parent message must pass the user\'s FGAC read rules.',
+    description: 'Retrieve an email attachment by message ID and attachment ID (allowed unless the parent message matches a read-block rule). Returns Gmail\'s base64url-encoded data (URL-safe alphabet, unpadded) — decode with a base64url decoder, not standard base64.',
     readOnly: true,
   },
   gmail_send: {
@@ -92,7 +92,7 @@ export const TOOL_DEFS = {
   google_api_get: {
     name: 'google_api_get',
     title: 'Raw Google API read',
-    description: 'Perform a read-only GET request against any endpoint of the Gmail API (https://developers.google.com/gmail/api/reference/rest) or Google Sheets API (https://developers.google.com/sheets/api/reference/rest). Every response is evaluated against the user\'s FGAC access rules before it is returned; other Google APIs and batch endpoints are denied.',
+    description: 'Perform a read-only GET request against any endpoint of the Gmail API (https://developers.google.com/gmail/api/reference/rest) or Google Sheets API (https://developers.google.com/sheets/api/reference/rest). Access model: Gmail reads are allowed by default and filtered by the user\'s read-block rules if any; Sheets require an explicit per-spreadsheet rule; other Google APIs and batch endpoints are denied.',
     readOnly: true,
     freeformMethods: ['GET'],
   },
@@ -114,7 +114,7 @@ export const TOOL_DEFS = {
   get_my_permissions: {
     name: 'get_my_permissions',
     title: 'Show my permissions',
-    description: 'Shows the access rules, accessible accounts, and proxy key that apply to this connection.',
+    description: 'Shows the access rules, accessible accounts, proxy key, and default access posture (including implicit Gmail read access) that apply to this connection.',
     readOnly: true,
   },
 } as const satisfies Record<string, FgacToolDef>;

--- a/src/lib/approvalLinks.ts
+++ b/src/lib/approvalLinks.ts
@@ -68,8 +68,13 @@ export async function mintApprovalUrl(
   proxyKeyId: string,
   action: ApprovalAction,
 ): Promise<string> {
+  // Env-sourced base URLs have shipped with a trailing newline before (a
+  // pasted Vercel env var), which breaks every link at the client — most
+  // clients truncate at the newline and land on the site root. Sanitize here
+  // so every caller is covered, whatever the env value looks like.
+  const origin = baseUrl.trim().replace(/\/+$/, '');
   const token = await mintApprovalToken(userId, proxyKeyId, action);
-  return `${baseUrl}/dashboard/approve?token=${encodeURIComponent(token)}`;
+  return `${origin}/dashboard/approve?token=${encodeURIComponent(token)}`;
 }
 
 export type VerifyResult =


### PR DESCRIPTION
## Summary

Fixes all four findings from the 2026-08-15 external tool-validation pass:

- **BUG 1 (high) — newline in approval URLs**: base URL sanitized in `mintApprovalUrl` AND in `DASHBOARD_URL`'s fallback chain (whitespace-only values lose the race too). `env:check` now flags URL-ish env vars carrying whitespace, with remediation. *Note: the underlying `NEXT_PUBLIC_APP_URL` value in Vercel still carries the newline — harmless now, but re-add it clean when convenient.*
- **BUG 2 (medium) — write denials minted read-only tokens**: denial actions derive from the denied operation (`sheetsApprovalAction(denial, id, isMutating)`, pure + unit-tested); write on unexposed sheet → `sheets_write`.
- **BUG 3 (low)**: `gmail_get_attachment` documents base64url (URL-safe, unpadded) passthrough.
- **BUG 4 (low) + audit note**: `gmail_read`/`google_api_get` descriptions state the real access model (Gmail read default-allow, filtered by read-block rules); `get_my_permissions` gains a `defaults` block so `rules: []` can't be read as "no access".

## Regression guards

- Build gate (`mcp:lint`): dirty-base-URL matrix (no whitespace, parses to origin+path+token) and the denial-action matrix (read/write × unexposed/read-only/blocked).
- QA capability assertions: 14/A9 (well-formed URLs from all three mint paths), 14/A10 (JWT action matrix), 13/A12 (defaults block), 10/A1 extended (description accuracy incl. base64url).

## Test plan

- [x] Unit tests + tool lint + tsc clean
- [x] Live hosted-MCP QA of the four new assertions: all pass (send/sheets/request_access URLs whitespace-free; all 5 token-matrix rows correct; defaults block present; descriptions accurate). Coverage: 112 assertions accounted, 0 fail.
- [ ] Preview deployment validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)