### PR TITLE
docs(workflows): 90s deploy wait expectation

### DIFF
--- a/.claude/agents/deploy-watcher.md
+++ b/.claude/agents/deploy-watcher.md
@@ -11,7 +11,11 @@ the branch name and, if known, the commit SHA that was just pushed.
 
 ## Procedure
 
-1. Poll every ~30 seconds (`sleep 30` between checks, up to 30 minutes):
+1. Poll every ~15 seconds (`sleep 15` between checks). Successful builds
+   typically go Ready in under 1 minute; if nothing has completed after
+   **90 seconds**, note the state as unusually slow in your report and keep
+   polling at ~30s intervals up to a 5-minute hard cap before returning
+   TIMEOUT.
    ```bash
    npx vercel ls fine-grain-access-control | head -20
    ```

--- a/.claude/commands/deploy-prod.md
+++ b/.claude/commands/deploy-prod.md
@@ -18,11 +18,21 @@ allowed-tools: Bash(gh:*), Bash(npx vercel ls:*), Bash(npx vercel inspect:*), Ba
    gh pr merge --auto --merge
    ```
 
-2. **Wait for the production deployment** (~5 minutes):
+2. **Wait for the production deployment.** Successful builds typically go
+   Ready in under 1 minute — poll every ~15 seconds for up to **90 seconds**
+   instead of one long sleep:
 
    ```bash
-   sleep 300
+   for i in 1 2 3 4 5 6; do
+     npx vercel ls fine-grain-access-control --prod --limit 1 2>&1 | grep -E "Ready|Error|Building|Queued"
+     sleep 15
+   done
    ```
+
+   (Pipe through `grep` rather than picking lines positionally — the CLI
+   splits its output across stdout and stderr, so line numbers shift.)
+   If it still isn't Ready after 90 seconds, treat that as unusual: check the
+   status once more and move to step 5 rather than waiting longer blindly.
 
 3. **Validate the deployment**:
 


### PR DESCRIPTION
Successful builds consistently go Ready in under a minute (46–50s across today's deploys). This encodes that expectation in the deploy workflows:

- `/deploy-prod` step 2: poll every 15s up to 90s instead of `sleep 300`; treat >90s as unusual and move to diagnostics.
- `deploy-watcher` agent: 15s polling, flag builds as unusually slow past 90s, 5-minute hard cap (down from 30).
- Both: grep for status rather than positional line picks (vercel ls splits stdout/stderr, shifting line numbers).

Docs-only — no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)