### PR TITLE
Gate production QA behind explicit per-session user confirmation

### DIFF
--- a/.claude/commands/qa-production.md
+++ b/.claude/commands/qa-production.md
@@ -1,11 +1,27 @@
 ---
-description: Validate production via real distribution channels (all 4 agents)
-allowed-tools: Task, Bash(npx tsx scripts/qa-coverage-check.ts:*), Bash(ls:*), Read, Glob
+description: USER-CONFIRMED — validate production via real distribution channels (all 4 agents)
+allowed-tools: Task, Bash(npx tsx scripts/qa-coverage-check.ts:*), Bash(ls:*), Read, Glob, AskUserQuestion
 ---
 
 # Production QA
 
-Requires: production deployment live at fgac.ai.
+> **CRITICAL AGENT RULE — explicit confirmation gate.** Do NOT invoke or automate
+> this command on your own initiative or as a step of another workflow. Routine
+> validation is local + preview (`/deploy-pr-preview`) only; production QA is a
+> rare, deliberate event.
+>
+> Even when the user typed `/qa-production` themselves, confirm scope BEFORE
+> dispatching any runner: state that the suite (a) runs lifecycle mutations
+> (key revoke/roll, connection block/detach, rule changes) on the shared
+> production QA account — the same account that can back live claude.ai
+> connectors, where breakage generates real disconnect events against the
+> connector directory's health metric — and (b) deliberately triggers denials
+> and 401s against `fgac.ai`. Ask via AskUserQuestion and proceed only on an
+> explicit yes given in THIS session. A confirmation from a previous session,
+> a standing instruction, or "the user probably wants this" does not count.
+> On anything short of a clear yes, stop and report instead.
+
+Requires: production deployment live at fgac.ai, and the confirmation above.
 
 > **Read-only against production.** This workflow validates a deployment that
 > already exists. Never trigger a production deploy from here — `vercel
@@ -26,10 +42,14 @@ ls docs/QA_Acceptance_Test/production/0[1-4]_*.md | sort
 
 For each doc in order, dispatch a fresh **qa-env-runner** subagent:
 
-> Execute runbook `docs/QA_Acceptance_Test/production/<NN_agent>.md`. This
+> The user explicitly confirmed production QA in this session. Execute runbook
+> `docs/QA_Acceptance_Test/production/<NN_agent>.md`. This
 > installs from the REAL distribution channel (ClawHub, plugin marketplace,
 > SKILL.md) and runs all capabilities against production URLs (fgac.ai,
 > gmail.fgac.ai). Strictly no deploy commands and no direct DB access.
+
+(The first sentence is required — the production runbooks refuse to run
+without it. Never include it unless the confirmation actually happened.)
 
 Run them one at a time — they share the production QA accounts, and lifecycle
 capabilities mutate shared state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ QA execution is delegated to cost-tiered subagents defined in `.claude/agents/`:
 `docs/QA_Acceptance_Test/qa-results.json`; `qa-smoke` and `deploy-watcher` (Haiku) handle
 mechanical polling and smoke checks; `qa-coverage-auditor` (Sonnet) adversarially reviews
 results; `qa-setup-driver` (inherits the session model) drives the browser setup flows.
-Two rules bind this architecture:
+Three rules bind this architecture:
 
 1. **Only the orchestrator (main session) edits source, schema, or config.** Runners
    execute and report; a runner that hits a code problem records it, never fixes it.
@@ -29,6 +29,14 @@ Two rules bind this architecture:
    parses the `### A<n>:` assertions in `docs/QA_Acceptance_Test/capabilities/` and
    validates `qa-results.json` (schema in `docs/QA_Acceptance_Test/README.md`). Prose
    assertion counts are informational.
+3. **Production QA is user-confirmed, every time.** Routine validation is local +
+   preview (`/deploy-pr-preview`) only. `/qa-production` and the
+   `docs/QA_Acceptance_Test/production/` runbooks never run autonomously or as a step
+   of another workflow, and even a user-typed `/qa-production` requires an in-session
+   scope confirmation before any runner is dispatched (the suite mutates the shared
+   production QA account, which can back live claude.ai connectors — breakage there
+   registers as connector-directory disconnect/health events). Expect production QA
+   to be rare.
 
 QA environments run sequentially (they share one dev server, one Neon branch, and the QA
 accounts/keys — lifecycle capabilities mutate that shared state). Targeted re-tests

--- a/docs/QA_Acceptance_Test/production/01_hosted_mcp.md
+++ b/docs/QA_Acceptance_Test/production/01_hosted_mcp.md
@@ -1,5 +1,12 @@
 # Production: Hosted MCP
 
+> **GATED — user-confirmed production QA only.** Do not execute this runbook
+> unless the dispatching prompt states the user explicitly confirmed production
+> QA in the current session (see `/qa-production`). If that sentence is absent,
+> stop and report instead of running. This suite mutates the shared production
+> QA account and deliberately triggers denials against production endpoints.
+
+
 > Install: Direct curl against `https://fgac.ai/api/mcp`
 > Runs ALL capabilities against production.
 

--- a/docs/QA_Acceptance_Test/production/02_claude_code_mcp.md
+++ b/docs/QA_Acceptance_Test/production/02_claude_code_mcp.md
@@ -1,5 +1,12 @@
 # Production: Claude Code MCP (Plugin Marketplace)
 
+> **GATED — user-confirmed production QA only.** Do not execute this runbook
+> unless the dispatching prompt states the user explicitly confirmed production
+> QA in the current session (see `/qa-production`). If that sentence is absent,
+> stop and report instead of running. This suite mutates the shared production
+> QA account and deliberately triggers denials against production endpoints.
+
+
 > Install: Via Claude Code plugin marketplace or `claude mcp add`
 > Runs ALL capabilities against `https://fgac.ai/api/mcp`
 

--- a/docs/QA_Acceptance_Test/production/03_claude_code_cli.md
+++ b/docs/QA_Acceptance_Test/production/03_claude_code_cli.md
@@ -1,5 +1,12 @@
 # Production: Claude Code CLI (Marketplace Install)
 
+> **GATED — user-confirmed production QA only.** Do not execute this runbook
+> unless the dispatching prompt states the user explicitly confirmed production
+> QA in the current session (see `/qa-production`). If that sentence is absent,
+> stop and report instead of running. This suite mutates the shared production
+> QA account and deliberately triggers denials against production endpoints.
+
+
 > Install: Via Claude Code plugin marketplace
 > Runs ALL capabilities against `https://gmail.fgac.ai`
 

--- a/docs/QA_Acceptance_Test/production/04_openclaw.md
+++ b/docs/QA_Acceptance_Test/production/04_openclaw.md
@@ -1,5 +1,12 @@
 # Production: OpenClaw (ClawHub)
 
+> **GATED — user-confirmed production QA only.** Do not execute this runbook
+> unless the dispatching prompt states the user explicitly confirmed production
+> QA in the current session (see `/qa-production`). If that sentence is absent,
+> stop and report instead of running. This suite mutates the shared production
+> QA account and deliberately triggers denials against production endpoints.
+
+
 > Install: Via `clawhub skill install fgac`
 > Runs ALL capabilities against `https://gmail.fgac.ai`
 


### PR DESCRIPTION
## Why

Audit of the QA harness against the connector directory's health metrics found that `/qa-production` was one slash command away from running lifecycle mutations (key revoke/roll, connection block/detach, global rule changes) on the shared production QA account — the same account that can back live claude.ai directory connectors. Breaking that connection generates real disconnect events against the directory health metric (30-day disconnect rate ≤ 5% = Healthy), on a launch-day denominator where a single disconnect matters.

Production QA is expected to be rare; routine validation stays local + preview.

## What

- `/qa-production`: USER-CONFIRMED gate — never self-invoked, and even a user-typed invocation confirms scope (via AskUserQuestion) before any runner is dispatched. The runner dispatch prompt must carry the confirmation sentence.
- Production runbooks 01–04: GATED banner — runners stop and report if the dispatching prompt lacks the confirmation sentence.
- CLAUDE.md: third binding rule for the QA subagent architecture documenting the gate.
- `qa-smoke` / runbook 00 stay ungated on purpose: strictly read-only health checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)