### PR TITLE
MCP: user-recoverable Google failures return guidance, not isError

### DIFF
--- a/docs/implementation_plans/mcp-recoverable-google-errors_v1.md
+++ b/docs/implementation_plans/mcp-recoverable-google-errors_v1.md
@@ -1,0 +1,50 @@
+# Recoverable Google Errors — non-error MCP results (v1)
+
+Branch: `claude/mcp-recoverable-google-errors` · Date: 2026-08-17
+Follow-up to: `connector-approval-audit_v2.md` Q1 (error handling protects the
+directory health metric) and the 2026-08-16 QA-harness directory audit.
+
+## Problem
+
+The connectors directory health metric counts request-level 4xx/5xx and tool
+results with `isError: true`. FGAC policy denials were already returned as
+success-shaped `textResult`s (`🚫`/`⏳` prefixes), but **every** upstream Google
+failure went through `errorResult` (`isError: true`) — including states only
+the user can fix and that our own UX treats as normal flows:
+
+- Google 401: the user's Google grant expired or was revoked → "reconnect".
+- Google 403: a spreadsheet not shared with the connected account, or a
+  missing OAuth scope → "share the sheet / re-grant". This is exactly the
+  add-a-sheet-you-haven't-granted-us flow being built — its guidance messages
+  must not read as connector malfunctions.
+- Google 404: wrong resource id → "check the id".
+
+Inconsistency aside (a dead Google grant detected at token-fetch time was
+already a non-error `textResult`, but detected at request time it was
+`isError`), these are the connector guiding the user, not failing.
+
+## Change (src/app/api/mcp/route.ts)
+
+1. `GoogleFetchResult` failure arm gains `recoverable: boolean`;
+   `RECOVERABLE_GOOGLE_STATUSES = {401, 403, 404}`. Network errors, 429, and
+   5xx stay non-recoverable.
+2. New `upstreamResult` helper: recoverable → `textResult` (leading `❌`,
+   PostHog outcome `failed`); non-recoverable → `errorResult` (`isError`,
+   outcome `error`). All upstream-failure call sites route through it.
+3. 403 message enriched with the actionable fix: share the spreadsheet with
+   the connected account, or reconnect Google to grant scopes.
+
+## Non-changes / invariants
+
+- Policy denials, pending-approval, and magic-link flows: untouched.
+- PostHog `$mcp_tool_call` outcome taxonomy: unchanged set (capability 16 A3
+  still holds); recoverable upstream failures move from `error` to `failed`.
+- Protocol-level auth (HTTP 401 on expired FGAC OAuth tokens): untouched —
+  required by the MCP/OAuth spec.
+- The REST proxy route is out of scope (not a directory metrics surface).
+
+## Validation
+
+- `npx tsc --noEmit` + `npm run lint` (includes `mcp:lint`).
+- Targeted QA: sheets management / raw Google API capabilities exercise the
+  403/404 paths; full re-run not required for this change per QA impact.

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -201,6 +201,13 @@ const textResult = (text: string) => ({ content: [{ type: 'text' as const, text 
  * health metrics) see it as a genuine tool error. */
 const errorResult = (text: string) => ({ content: [{ type: 'text' as const, text }], isError: true });
 
+/** Upstream Google failure → tool result. States the user can fix (expired
+ * Google auth, a sheet not shared with the connected account, a bad resource
+ * id) are the connector guiding the user, not malfunctioning — returned as
+ * plain text, so only genuine failures (network, 429, 5xx) carry isError. */
+const upstreamResult = (r: { error: string; recoverable: boolean }) =>
+  r.recoverable ? textResult(r.error) : errorResult(r.error);
+
 const jsonResult = (data: unknown) => textResult(JSON.stringify(data, null, 2));
 
 // ─── Pending Approval Message ───────────────────────────────────────────────
@@ -372,7 +379,11 @@ async function sendDenialWithLinks(
 
 type GoogleFetchResult =
   | { ok: true; data: unknown }
-  | { ok: false; error: string };
+  | { ok: false; error: string; recoverable: boolean };
+
+/** Statuses a user can fix themselves (reconnect Google, share the sheet,
+ * correct an id). Everything else — network, 429, 5xx — is a genuine failure. */
+const RECOVERABLE_GOOGLE_STATUSES = new Set([401, 403, 404]);
 
 function describeGoogleError(status: number, data: unknown, targetEmail: string): string {
   const detail = (data as { error?: { message?: string } })?.error?.message
@@ -381,7 +392,7 @@ function describeGoogleError(status: number, data: unknown, targetEmail: string)
     case 401:
       return `❌ Google authorization expired for '${targetEmail}'. The account owner needs to reconnect Google in the FGAC dashboard, then retry.`;
     case 403:
-      return `❌ Google denied the request (403): ${detail || 'insufficient permissions or missing OAuth scope for this operation'}.`;
+      return `❌ Google denied the request (403): ${detail || 'insufficient permissions or missing OAuth scope for this operation'}.${targetEmail ? ` If this is a spreadsheet, share it with '${targetEmail}' and retry; otherwise the account owner may need to reconnect Google from the FGAC dashboard to grant the needed scopes.` : ''}`;
     case 404:
       return `❌ Google resource not found (404)${detail ? `: ${detail}` : ''}. Check the ID and try again.`;
     case 429:
@@ -405,7 +416,7 @@ async function googleFetch(
       body,
     });
   } catch (err) {
-    return { ok: false, error: `❌ Could not reach the Google API: ${err instanceof Error ? err.message : 'network error'}.` };
+    return { ok: false, error: `❌ Could not reach the Google API: ${err instanceof Error ? err.message : 'network error'}.`, recoverable: false };
   }
 
   const text = await res.text();
@@ -413,7 +424,11 @@ async function googleFetch(
   try { data = text ? JSON.parse(text) : {}; } catch { /* non-JSON body: keep text */ }
 
   if (!res.ok) {
-    return { ok: false, error: describeGoogleError(res.status, data, targetEmail) };
+    return {
+      ok: false,
+      error: describeGoogleError(res.status, data, targetEmail),
+      recoverable: RECOVERABLE_GOOGLE_STATUSES.has(res.status),
+    };
   }
   return { ok: true, data };
 }
@@ -687,7 +702,7 @@ async function executeRawGoogleCall(
 
     const url = `https://sheets.googleapis.com/${cleanPath.replace(/^sheets\//, '')}`;
     const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
-    if (!result.ok) return errorResult(result.error);
+    if (!result.ok) return upstreamResult(result);
     return jsonResult(result.data);
   }
 
@@ -700,7 +715,7 @@ async function executeRawGoogleCall(
 
   const url = `https://www.googleapis.com/${cleanPath}`;
   const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
-  if (!result.ok) return errorResult(result.error);
+  if (!result.ok) return upstreamResult(result);
 
   if (cls.kind === 'gmail_read') {
     const restriction = checkReadRestrictions(rules, result.data);
@@ -775,7 +790,7 @@ const handler = createMcpHandler(
         params.set('maxResults', String(max || 10));
 
         const result = await gmailFetch(resolved.token, resolved.targetEmail, `messages?${params}`);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
         return jsonResult(result.data);
       }
     );
@@ -798,7 +813,7 @@ const handler = createMcpHandler(
         // Read-time enforcement: label blacklist/whitelist + content blacklist
         const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
         const result = await gmailFetch(resolved.token, resolved.targetEmail, `messages/${messageId}?format=${format || 'full'}`);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
 
         const restriction = checkReadRestrictions(rules, result.data);
         if (restriction) {
@@ -834,7 +849,7 @@ const handler = createMcpHandler(
         // an attachment is only as readable as the email that carries it
         const rules = await loadApplicableRules(conn.user.id, resolved.proxyKeyId, resolved.targetEmail);
         const parentResult = await gmailFetch(resolved.token, resolved.targetEmail, `messages/${messageId}?format=full`);
-        if (!parentResult.ok) return errorResult(parentResult.error);
+        if (!parentResult.ok) return upstreamResult(parentResult);
 
         const restriction = checkReadRestrictions(rules, parentResult.data);
         if (restriction) {
@@ -847,7 +862,7 @@ const handler = createMcpHandler(
           resolved.targetEmail,
           `messages/${messageId}/attachments/${attachmentId}`
         );
-        if (!attachmentResult.ok) return errorResult(attachmentResult.error);
+        if (!attachmentResult.ok) return upstreamResult(attachmentResult);
 
         const attachment = attachmentResult.data as { size?: number; data?: string };
         if (attachment.data && attachment.data.length > MAX_ATTACHMENT_CHARS) {
@@ -885,7 +900,7 @@ const handler = createMcpHandler(
         ).toString('base64url');
 
         const result = await gmailFetch(resolved.token, resolved.targetEmail, 'messages/send', 'POST', JSON.stringify({ raw }));
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
         return jsonResult(result.data);
       }
     );
@@ -904,7 +919,7 @@ const handler = createMcpHandler(
         if ('error' in resolved) return textResult(resolved.error);
 
         const result = await gmailFetch(resolved.token, resolved.targetEmail, 'labels');
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
         return jsonResult(result.data);
       }
     );
@@ -927,7 +942,7 @@ const handler = createMcpHandler(
         if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, false));
 
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}`, 'GET', undefined, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
         return jsonResult(result.data);
       }
     );
@@ -952,7 +967,7 @@ const handler = createMcpHandler(
 
         const encodedRange = encodeURIComponent(range);
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`, 'GET', undefined, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
         return jsonResult(result.data);
       }
     );
@@ -979,7 +994,7 @@ const handler = createMcpHandler(
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values, range });
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}?valueInputOption=USER_ENTERED`, 'PUT', body, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
         return jsonResult(result.data);
       }
     );
@@ -1006,7 +1021,7 @@ const handler = createMcpHandler(
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values });
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return upstreamResult(result);
         return jsonResult(result.data);
       }
     );


### PR DESCRIPTION
## Why

The connectors directory health metric counts tool results with `isError: true` (plus request-level 4xx/5xx). FGAC policy denials were already correctly returned as success-shaped text — but every upstream Google failure was marked `isError`, including states only the user can fix:

- **401** — Google grant expired/revoked → "reconnect Google"
- **403** — spreadsheet not shared with the connected account, or missing OAuth scope → "share the sheet / re-grant". This is the exact path behind the in-progress add-a-sheet flow, so its guidance must not read as connector malfunction.
- **404** — bad resource id → "check the id"

These are the connector guiding the user, not failing. It was also inconsistent: a dead Google grant caught at token-fetch time was already non-error text, but caught at request time it was `isError`.

## What

- `GoogleFetchResult` failure arm gains `recoverable: boolean` (401/403/404 recoverable; network, 429, 5xx stay genuine errors).
- New `upstreamResult` helper routes all upstream-failure call sites: recoverable → `textResult` (PostHog outcome `failed`), genuine → `errorResult` (outcome `error`).
- 403 message now names the account to share the spreadsheet with and points at reconnecting from the dashboard.
- Policy denials, pending-approval, magic links, protocol-level 401s, and the $mcp_tool_call outcome taxonomy (capability 16) are all unchanged.

Plan: docs/implementation_plans/mcp-recoverable-google-errors_v1.md

## Validation

- `npx tsc --noEmit` clean; `eslint src/app/api/mcp/route.ts` clean (repo-wide lint failures are pre-existing in scripts/ and public/skills/, untouched here).
- Runtime 403/404 paths not yet exercised — suggest preview validation via the sheets-management / raw-Google-API capability suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)