### PR TITLE
Sheets grant recovery: picker-first approvals, verification, and honest errors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,8 +35,7 @@
       "Bash(npx vercel cancel:*)",
       "Bash(vercel link:*)",
       "Bash(npx vercel link:*)",
-      "Bash(git commit --no-verify:*)",
-      "Bash(npx tsx scripts/cleanup-neon-branches.ts:*)"
+      "Bash(git commit --no-verify:*)"
     ],
     "allow": [
       "Bash(git pull:*)",
@@ -64,7 +63,9 @@
       "Bash(npx vercel project ls:*)",
       "Bash(npx @playwright/cli:*)",
       "Bash(curl -s http://localhost:9222/json/version)",
-      "Bash(curl -sf http://localhost:3000:*)"
+      "Bash(curl -sf http://localhost:3000:*)",
+      "Bash(npx tsx scripts/cleanup-neon-branches.ts:*)",
+      "Bash(bash scripts/cleanup-neon-branches.sh)"
     ]
   },
   "hooks": {

--- a/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
+++ b/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
@@ -212,17 +212,23 @@ curl -s $BASE_URL/api/mcp -X POST \
 
 - A1: `sheets_get_spreadsheet` on the fresh sheet via hosted MCP → capture
   the denial text and its `/dashboard/approve` link.
-- A2: open the link, approve Read Only → assert the recovery ("one more
-  step") state, not the plain success copy; rule exists via
-  `GET /api/rules/grant-sheets-access`.
-- A3: assert the picker launch affordance AND the Descript embed
-  (`iframe[src*='Fv9pwXugLUa']`) on the recovery page.
-- A4: full pick via Playwright CDP path (capability 09 harness note); else
-  app-API seam + re-verify, marking the pick itself `skip` with reason.
-  Retry the MCP call → success.
+- A2: open the link → assert the pick-first state (`sheets-flow-pick-first`
+  testid): no approve/submit control rendered, no rule created, link not
+  consumed (reload still shows the flow).
+- A3: assert the pick button AND the Descript embed
+  (`iframe[src*='Fv9pwXugLUa']`) on the approve page's pick-first state.
+- A4: full pick (of the requested sheet) via Playwright CDP path
+  (capability 09 harness note) → confirm step shows the real title →
+  approve Read Only → success page; retry the MCP call → success. Legacy
+  path: `/dashboard/sheets-setup?sid=…` still picks→verifies for stranded
+  rules.
 - A5: mint a denial for the standing fixture sheet (delete its FGAC rule
-  first if present), approve → plain success state, no picker step; retried
-  read succeeds.
+  first if present), open link → straight confirm (no pick step) → approve
+  → success; retried read succeeds.
+- A9: from the pick-first state pick a DIFFERENT owned sheet → substitution
+  confirm (`sheets-flow-substitution` testid) → approve → rule for picked id
+  only; requested id has no rule; retry on requested id still errors
+  honestly (A7) while the picked sheet's call succeeds.
 - A6: `/dashboard` and `/dashboard/accounts` → "needs Google access" chip on
   the stranded rule only; recovery panel opens from the chip.
 - A7: retry the sheets call while stranded → error text names FGAC approval

--- a/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
+++ b/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
@@ -204,6 +204,33 @@ curl -s $BASE_URL/api/mcp -X POST \
 - A11: unauthenticated POST to `/api/webhooks/gmail` → 401.
 - A12: `setup-gmail-push.ts --project dev-fgac-ai` dry run → all ✔.
 
+## Capability: Sheets Grant Recovery (→ capabilities/17_sheets_grant_recovery.md)
+
+> Needs a spreadsheet that has NEVER been picked in this environment (create
+> a fresh one as USER_A) plus the standing picked QA fixture sheet. Browser
+> assertions run in the built-in browser signed in as USER_A.
+
+- A1: `sheets_get_spreadsheet` on the fresh sheet via hosted MCP → capture
+  the denial text and its `/dashboard/approve` link.
+- A2: open the link, approve Read Only → assert the recovery ("one more
+  step") state, not the plain success copy; rule exists via
+  `GET /api/rules/grant-sheets-access`.
+- A3: assert the picker launch affordance AND the Descript embed
+  (`iframe[src*='Fv9pwXugLUa']`) on the recovery page.
+- A4: full pick via Playwright CDP path (capability 09 harness note); else
+  app-API seam + re-verify, marking the pick itself `skip` with reason.
+  Retry the MCP call → success.
+- A5: mint a denial for the standing fixture sheet (delete its FGAC rule
+  first if present), approve → plain success state, no picker step; retried
+  read succeeds.
+- A6: `/dashboard` and `/dashboard/accounts` → "needs Google access" chip on
+  the stranded rule only; recovery panel opens from the chip.
+- A7: retry the sheets call while stranded → error text names FGAC approval
+  vs Google setup and points at the dashboard; no "Check the ID" copy.
+- A8: covered by the capability-16 event script:
+  `qa-posthog-events.ts --event sheets_grant_verification` and
+  `--event sheets_grant_recovered` scoped to the run window.
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/agents/02_claude_code_mcp.md
+++ b/docs/QA_Acceptance_Test/agents/02_claude_code_mcp.md
@@ -173,6 +173,17 @@ tmux kill-session -t fgac-qa
 > Channel-inapplicable here: server-side pipeline, executed once per cycle via
 > agents/01_hosted_mcp.md. Record as skip with reason "runs in hosted-mcp runbook".
 
+## Capability: Sheets Grant Recovery (→ capabilities/17_sheets_grant_recovery.md)
+
+- A1/A7: issue `sheets_get_spreadsheet` through the Claude Code MCP
+  connection (tmux session) on the never-picked fixture sheet; capture the
+  denial link (A1) and, post-approval, the honest stranded-sheet error (A7).
+- A2–A6: browser-side and identical to the hosted-MCP runbook — execute
+  there or re-run here with this runtime's denial links; either satisfies
+  coverage as long as qa-results.json attributes the environment that ran it.
+- A4 retry + A8 events: retry via this MCP connection; events via the
+  capability-16 script with `--environment development`.
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/agents/03_claude_code_cli.md
+++ b/docs/QA_Acceptance_Test/agents/03_claude_code_cli.md
@@ -160,6 +160,15 @@ No tmux sessions to clean up. Results are saved to `test/qa-envs/cc-cli/evals/re
 > Channel-inapplicable here: server-side pipeline, executed once per cycle via
 > agents/01_hosted_mcp.md. Record as skip with reason "runs in hosted-mcp runbook".
 
+## Capability: Sheets Grant Recovery (→ capabilities/17_sheets_grant_recovery.md)
+
+- A1/A7: headless `claude -p` evals calling `sheets_get_spreadsheet` on the
+  never-picked fixture sheet — assert the denial link in the transcript
+  (A1) and the stranded-sheet error text after approval (A7).
+- A2–A6 are browser assertions; run them from the hosted-MCP runbook (or
+  `skip` here with reason "browser assertions covered by 01_hosted_mcp").
+- A4 retry: re-run the eval post-recovery → success payload in transcript.
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/agents/04_openclaw.md
+++ b/docs/QA_Acceptance_Test/agents/04_openclaw.md
@@ -139,6 +139,15 @@ curl -X POST http://localhost:18790/api/chat \
 docker compose -f test/qa-envs/openclaw/docker-compose.yml down
 ```
 
+## Capability: Sheets Grant Recovery (→ capabilities/17_sheets_grant_recovery.md)
+
+- A1/A7: drive the OpenClaw instance to call `sheets_get_spreadsheet` on the
+  never-picked fixture sheet; assert the denial link surfaces to the end
+  user intact (A9 of capability 14 applies) and the stranded-sheet error is
+  relayed verbatim (A7).
+- A2–A6: browser assertions — cover via 01_hosted_mcp or `skip` with reason.
+- A4 retry: repeat the OpenClaw task after recovery → success.
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/capabilities/14_magic_link_approvals.md
+++ b/docs/QA_Acceptance_Test/capabilities/14_magic_link_approvals.md
@@ -2,9 +2,12 @@
 
 > Phase C of `connector-growth_v1.md`. Send and Sheets denials carry a signed
 > deep link that pre-fills the fix; the owning user approves in one click at
-> the moment of need. Links are signed, single-use, expire (~15 min), and
-> require the owning user's session — an agent can mint the request, only the
-> human can approve. Read-block denials deliberately carry NO link.
+> the moment of need. Links are signed, single-use, expire (15 min; sheets
+> links 30 min — their approval can include a Picker pick + first-time
+> drive.file consent round-trip), and require the owning user's session — an
+> agent can mint the request, only the human can approve. Read-block denials
+> deliberately carry NO link. Sheets approvals run picker-first when Google
+> lacks a grant for the sheet — see capability 17.
 
 ## Assertions
 
@@ -26,8 +29,10 @@
 - Call `sheets_read_range` on an unexposed spreadsheet; open the denial link
   as the owning user
 - **Expected**: Approval UI shows the spreadsheet (id and, where resolvable,
-  name) with an explicit Read-only vs Read & Write choice; choosing Read-only
-  exposes it; the retried read succeeds and a write still fails
+  name) with an explicit Read-only vs Read & Write choice. When Google
+  already grants the sheet, approval is one click; when it does not, the
+  Picker pick comes first (capability 17 A2/A4). After approving Read-only,
+  the retried read succeeds and a write still fails
 
 ### A4: Links are single-use and expire
 - Reuse the already-approved A2 link; separately, open a link older than its

--- a/docs/QA_Acceptance_Test/capabilities/17_sheets_grant_recovery.md
+++ b/docs/QA_Acceptance_Test/capabilities/17_sheets_grant_recovery.md
@@ -44,38 +44,60 @@ sheet tells the truth.
   incident. (This assertion pins the replication baseline; A2–A8 assert the
   new behavior on top of it.)
 
-### A2: Approving a sheet without a Google grant does NOT claim success
-- Open the A1 link signed in as USER_A; choose Read Only; approve.
-- **Expected**: The FGAC rule is created (visible via
-  `GET /api/rules/grant-sheets-access`), but the result page does NOT say
-  the agent can retry now. It shows the "one more step" recovery state
-  naming the spreadsheet and explaining Google hasn't shared this sheet
-  with FGAC yet.
+### A2: A missing Google grant makes the pick come FIRST — no blind approve
+- Open the A1 link signed in as USER_A.
+- **Expected**: The page verifies the Google-side grant on load (fires
+  `sheets_grant_verification {via: link_open, result: missing}`) and shows
+  the picker-first state: an explanation that Google hasn't shared the
+  sheet, a "Step 1 — Pick the sheet in Google Picker" button, and **no
+  approve/submit control** until a pick happens. No FGAC rule exists yet
+  (`GET /api/rules/grant-sheets-access` unchanged) and the link is NOT
+  consumed by merely opening the page.
 
-### A3: The recovery state offers the Picker and embeds the setup video
-- On the A2 recovery page.
-- **Expected**: A button launches the Google Picker flow (the
+### A3: The pick-first state embeds the setup video
+- On the A2 page.
+- **Expected**: The pick button launches the Google Picker flow (the
   `.picker-dialog` iframe opens, or the first-time `drive.file` consent
-  redirect per capability 09 A2), AND the Sheets demo video
-  (Descript embed `Fv9pwXugLUa`, rendered via `TrackedVideoEmbed`) is
-  present on the page. Playing it fires `video_played` with the approve
-  page's `page` property.
+  redirect per capability 09 A2 — which must return to the approve page
+  WITH the token still in the URL), AND the Sheets demo video (Descript
+  embed `Fv9pwXugLUa`, rendered via `TrackedVideoEmbed`) is present.
+  Playing it fires `video_played` with the approve page's `page` property.
 
-### A4: Completing the pick flips the recovery page to verified success
-- Complete a pick for a grant-carrying sheet (Playwright CDP path for the
-  real pick; app-API seam otherwise — see Pre-requisites).
-- **Expected**: The page re-verifies and shows the verified success state
-  ("the agent can retry"), and a `sheets_grant_recovered` event fires. The
-  retried MCP call succeeds (`$mcp_tool_call` outcome=success) with no new
-  approval link minted.
+### A4: Picking the requested sheet leads to confirm → approve → success
+- Complete a pick that includes the requested sheet (Playwright CDP path
+  for the real pick; app-API seam otherwise — see Pre-requisites), then
+  approve (Read Only) on the confirm step that appears.
+- **Expected**: The confirm step shows the sheet's real title; approval
+  creates the rule and lands on the success page. The retried MCP call
+  succeeds (`$mcp_tool_call` outcome=success) with no new approval link
+  minted. The legacy recovery page at `/dashboard/sheets-setup` still
+  performs pick → `sheets_grant_recovered` → verified for rules stranded
+  before this flow existed (dashboard-chip entry path).
 
-### A5: Approving a sheet that already has a Google grant skips recovery
+### A5: Approving a sheet that already has a Google grant skips the pick
 - Mint a fresh denial link for a spreadsheet that HAS been picked before
   (standing QA fixture sheet) by calling `sheets_read_range` on it before
-  any FGAC rule exists; approve the link as USER_A.
-- **Expected**: Straight to the normal success state ("the agent can retry
-  its request now") with no picker step, and `sheets_grant_verification`
-  fires with `result=ok`; the retried read succeeds.
+  any FGAC rule exists; open and approve the link as USER_A.
+- **Expected**: The page goes straight to the one-click confirm (no pick
+  step), showing the sheet's title resolved from Google; approving lands
+  on the success state and `sheets_grant_verification` fires with
+  `result=ok` (once via `link_open`, once via `magic_link`); the retried
+  read succeeds.
+
+### A9: Picking a DIFFERENT sheet becomes an explicit substitution
+- From the A2 pick-first state, pick a sheet that is NOT the requested id
+  (any real sheet USER_A owns).
+- **Expected**: An explicit substitution confirmation appears — naming
+  both the picked sheet and the agent's wrong id — and approving creates
+  rule(s) for the PICKED sheet only; the requested id gets NO rule
+  (`GET /api/rules/grant-sheets-access` shows no row for it, and no
+  "needs Google access" chip appears later). `approval_link_approved`
+  carries `substituted: true`. The agent's retry on the wrong id gets a
+  fresh not-exposed denial (no phantom rule means no misleading A7 state),
+  while `get_my_permissions` lists the picked sheet, and a call on the
+  picked sheet succeeds. Server-side guard: a
+  forged `picked` payload naming a sheet Google does NOT grant creates
+  nothing and leaves the link unconsumed (retryable).
 
 ### A6: Dashboard flags rules whose sheets lack a Google grant
 - With the A2 rule present but its sheet still un-picked, load `/dashboard`

--- a/docs/QA_Acceptance_Test/capabilities/17_sheets_grant_recovery.md
+++ b/docs/QA_Acceptance_Test/capabilities/17_sheets_grant_recovery.md
@@ -1,0 +1,105 @@
+# Capability: Sheets Grant Recovery (Approval → Google Grant → Verified Success)
+
+## Overview
+Models the real connector-directory user journey observed in production
+(2026-08-16 launch cohort): an agent calls a sheets tool on a sheet the user
+never exposed, the denial mints a `sheets_expose` magic link, the user
+approves — and, before this capability existed, every retry then failed with
+a generic Google 404/403 because approving created only the FGAC rule, never
+the Google-side `drive.file` per-file grant (which registers only via a
+Google Picker pick). Production data: 3 of 3 users who approved churned on
+post-approval errors; zero external users ever reached a successful sheets
+call.
+
+This capability asserts the whole loop is now honest and recoverable: the
+approval page verifies the Google half, walks the user through the Picker
+with the embedded Sheets demo video when the grant is missing, the dashboard
+flags stranded rules, and the MCP error for a rule-covered-but-ungranted
+sheet tells the truth.
+
+## Pre-requisites
+* `/qa-setup` complete; dev server running; USER_A signed in (built-in browser).
+* An MCP connection with an approved proxy key for USER_A (hosted MCP or
+  Claude Code MCP per the agent runbook).
+* A fixture spreadsheet owned by USER_A that has **never** been picked via
+  the FGAC Google Picker in this environment (a fresh Neon branch resets
+  FGAC rules but NOT Google-side drive.file grants — prefer a
+  freshly-created spreadsheet to guarantee the ungranted state).
+* Picker automation limits per capability 09's harness note: the picker
+  iframe is cross-origin; use the app-API seam
+  (`POST /api/rules/grant-sheets-access` cannot register a Google grant, so
+  the *granted* end-state is simulated with a sheet that HAS been picked
+  before — e.g. the standing QA fixture sheet — while the *ungranted* path
+  uses the fresh sheet) or the Playwright CDP path for full fidelity.
+
+## Assertions
+
+### A1: The production failure sequence is reproducible up to the fix
+- With the fresh (never-picked) spreadsheet: call `sheets_get_spreadsheet`
+  via MCP → expect a denial whose text contains a `/dashboard/approve` link
+  (token action `sheets_expose`, per capability 14 A10).
+- **Expected**: The denial fires `$mcp_tool_call` with
+  `outcome=denied_by_policy` and an `approval_link_minted` event with
+  `action=sheets_expose` — the same event signature as the production
+  incident. (This assertion pins the replication baseline; A2–A8 assert the
+  new behavior on top of it.)
+
+### A2: Approving a sheet without a Google grant does NOT claim success
+- Open the A1 link signed in as USER_A; choose Read Only; approve.
+- **Expected**: The FGAC rule is created (visible via
+  `GET /api/rules/grant-sheets-access`), but the result page does NOT say
+  the agent can retry now. It shows the "one more step" recovery state
+  naming the spreadsheet and explaining Google hasn't shared this sheet
+  with FGAC yet.
+
+### A3: The recovery state offers the Picker and embeds the setup video
+- On the A2 recovery page.
+- **Expected**: A button launches the Google Picker flow (the
+  `.picker-dialog` iframe opens, or the first-time `drive.file` consent
+  redirect per capability 09 A2), AND the Sheets demo video
+  (Descript embed `Fv9pwXugLUa`, rendered via `TrackedVideoEmbed`) is
+  present on the page. Playing it fires `video_played` with the approve
+  page's `page` property.
+
+### A4: Completing the pick flips the recovery page to verified success
+- Complete a pick for a grant-carrying sheet (Playwright CDP path for the
+  real pick; app-API seam otherwise — see Pre-requisites).
+- **Expected**: The page re-verifies and shows the verified success state
+  ("the agent can retry"), and a `sheets_grant_recovered` event fires. The
+  retried MCP call succeeds (`$mcp_tool_call` outcome=success) with no new
+  approval link minted.
+
+### A5: Approving a sheet that already has a Google grant skips recovery
+- Mint a fresh denial link for a spreadsheet that HAS been picked before
+  (standing QA fixture sheet) by calling `sheets_read_range` on it before
+  any FGAC rule exists; approve the link as USER_A.
+- **Expected**: Straight to the normal success state ("the agent can retry
+  its request now") with no picker step, and `sheets_grant_verification`
+  fires with `result=ok`; the retried read succeeds.
+
+### A6: Dashboard flags rules whose sheets lack a Google grant
+- With the A2 rule present but its sheet still un-picked, load `/dashboard`
+  (profile Sheets card) and `/dashboard/accounts`.
+- **Expected**: That rule's row carries a visible "needs Google access"
+  indicator with a working recovery affordance (opens the same picker +
+  video panel). Rules whose sheets verify OK show no indicator. The
+  indicator never blocks the rest of the dashboard from rendering (a
+  Google outage degrades to no-indicator, not a broken page).
+
+### A7: Post-policy Google 403/404 on a sheets call returns an honest error
+- With the A2 rule present and the sheet still un-picked, retry
+  `sheets_get_spreadsheet` via MCP.
+- **Expected**: The error is NOT the generic "Google resource not found
+  (404). Check the ID and try again." It states that the sheet is approved
+  in FGAC but Google access is not set up yet, and points the user at the
+  dashboard to finish setup. `$mcp_tool_call` still records
+  `outcome=error` (it IS an error) — but the text is actionable.
+
+### A8: Recovery analytics distinguish the funnel stages
+- Replay A1→A4 and inspect captured events (PostHog debug/local capture per
+  capability 16 conventions).
+- **Expected**: The sequence contains `approval_link_minted(sheets_expose)`
+  → `approval_link_approved(sheets_expose)` → `sheets_grant_verification`
+  `{result: 'missing'}` → `sheets_grant_recovered` → `$mcp_tool_call`
+  success — each stage attributable to the same person, so the production
+  dashboard can measure recovery rate directly.

--- a/docs/QA_Acceptance_Test/capabilities/README.md
+++ b/docs/QA_Acceptance_Test/capabilities/README.md
@@ -30,3 +30,4 @@
 | 14 | `14_magic_link_approvals.md` | Magic approval links: signing, expiry, single-use, owner-only |
 | 15 | `15_request_access_tool.md` | Conversational permission upgrades via `request_access` |
 | 16 | `16_analytics_events.md` | PostHog events arrive with canonical schema (`$mcp_tool_call` + tool names, outcomes, environment tags) |
+| 17 | `17_sheets_grant_recovery.md` | Sheets approval verifies the Google-side grant; picker + video recovery when missing; honest post-policy errors |

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -36,15 +36,20 @@ keep internal/QA traffic out of the numbers.
 | `account_linked` | server (dashboard action) | `target_email`, `delegated`, `via` |
 | `approval_link_minted` | server (`/api/mcp`) | `action` |
 | `read_restriction_enforced` | server (`/api/mcp`) | `via` (tool name), `restriction` |
-| `sheets_grant_verification` | server (magic-link approval, `actions.ts`) | `result` (`ok`/`missing`/`unknown`), `via`, `spreadsheet_id` |
+| `sheets_grant_verification` | server (approve-page load via `/api/rules/verify-sheets-access`, and approval in `actions.ts`) | `result` (`ok`/`missing`/`unknown`), `via` (`link_open`/`magic_link`), `spreadsheet_id` |
 | `sheets_grant_recovered` | server (`/api/rules/verify-sheets-access`) | `spreadsheet_id` |
 
-The two `sheets_grant_*` events instrument the **sheets grant-recovery loop**
-(`/dashboard/sheets-setup`): approving a sheets magic link verifies the
-Google-side `drive.file` grant before claiming success; `result=missing`
-routes the user into the Picker + demo-video recovery page, and a verified
-re-check from that page fires `sheets_grant_recovered`. Recovery rate =
-`sheets_grant_recovered` / `sheets_grant_verification{result=missing}`.
+The two `sheets_grant_*` events instrument the **picker-first sheets
+approval funnel**: opening a sheets approval link verifies the Google-side
+`drive.file` grant (`via=link_open`); `result=missing` puts the Picker +
+demo-video step BEFORE the approve button, and the approval itself re-fires
+with `via=magic_link`. Picking a different sheet than the agent asked for is
+an explicit substitution — `approval_link_approved` then carries
+`substituted: true` and `granted_count`, making wrong-agent-id frequency
+measurable. `/dashboard/sheets-setup` remains the recovery path for
+pre-existing stranded rules (dashboard chips, MCP error links); a verified
+re-check there fires `sheets_grant_recovered`. Funnel health =
+`link_open{missing}` → `magic_link{ok}` conversion.
 
 `$mcp_tool_call` uses PostHog's **canonical MCP Analytics schema** (event and
 `$mcp_*` property names) so PostHog's built-in MCP views resolve the tool name.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -36,6 +36,15 @@ keep internal/QA traffic out of the numbers.
 | `account_linked` | server (dashboard action) | `target_email`, `delegated`, `via` |
 | `approval_link_minted` | server (`/api/mcp`) | `action` |
 | `read_restriction_enforced` | server (`/api/mcp`) | `via` (tool name), `restriction` |
+| `sheets_grant_verification` | server (magic-link approval, `actions.ts`) | `result` (`ok`/`missing`/`unknown`), `via`, `spreadsheet_id` |
+| `sheets_grant_recovered` | server (`/api/rules/verify-sheets-access`) | `spreadsheet_id` |
+
+The two `sheets_grant_*` events instrument the **sheets grant-recovery loop**
+(`/dashboard/sheets-setup`): approving a sheets magic link verifies the
+Google-side `drive.file` grant before claiming success; `result=missing`
+routes the user into the Picker + demo-video recovery page, and a verified
+re-check from that page fires `sheets_grant_recovered`. Recovery rate =
+`sheets_grant_recovered` / `sheets_grant_verification{result=missing}`.
 
 `$mcp_tool_call` uses PostHog's **canonical MCP Analytics schema** (event and
 `$mcp_*` property names) so PostHog's built-in MCP views resolve the tool name.

--- a/docs/implementation_plans/sheets-access-error-analysis_v1.md
+++ b/docs/implementation_plans/sheets-access-error-analysis_v1.md
@@ -1,0 +1,111 @@
+# Sheets Grant Recovery — Implementation Plan v1
+
+Branch: `claude/sheets-access-error-analysis-86fef7`
+
+## Why (production evidence, 2026-08-15 → 08-17 UTC)
+
+PostHog shows the sheets funnel is a dead end for every real user since the
+connector-directory launch:
+
+- 5 external users called a sheets tool → all hit `denied_by_policy`, each
+  denial minting a `sheets_expose` magic link (that part works).
+- 3 of the 5 opened the link and approved (`approval_link_approved`).
+- **All 3 then got `error` on every retry and churned.** One retried across
+  four sessions over ~10 hours, minting six links. Zero external users have
+  ever had a successful sheets tool call in production; the only successes
+  are the internal test account.
+
+## Root cause (confirmed in code)
+
+Sheets access has TWO halves, and the magic-link approval only completes one:
+
+1. **FGAC half** — `approveMagicLink` (`src/app/dashboard/actions.ts`)
+   inserts an `accessRules` row for the spreadsheet id and tells the user
+   "The agent can retry its request now."
+2. **Google half** — the app never requests a Sheets OAuth scope. All sheets
+   API access rides on per-file `drive.file` grants, which Google registers
+   ONLY when the user picks the file in the Google Picker with our `appId`
+   set (`src/app/dashboard/useGooglePicker.ts`). The approval page never
+   launches the Picker.
+
+So after approval: FGAC policy passes → Sheets API called with a token that
+has no grant for that file → Google 404/403 → generic
+"❌ Google resource not found (404). Check the ID and try again." — which is
+actively misleading (the id is fine; the grant is missing).
+
+Secondary finding: an approval assigns the rule to the payload's proxy key;
+one user was back to `denied_by_policy` in a later session (new connection /
+different key), minting fresh links for a sheet they had already approved.
+
+## Fix design
+
+### A. Shared verifier (server)
+
+`src/lib/sheetsGrantCheck.ts` — `verifySheetsGrant(token, spreadsheetId)`:
+metadata GET `https://sheets.googleapis.com/v4/spreadsheets/{id}?fields=properties.title`.
+Returns `{ state: 'ok', title }` | `{ state: 'missing' }` (403/404 — no
+Google-side grant) | `{ state: 'unknown', status }` (network/5xx/429 — do not
+alarm the user). Reuses the same token-resolution helper the MCP path uses
+(`getGoogleToken(ownerEmail, user)`).
+
+### B. Approval flow verifies before declaring success
+
+`approveMagicLink` for `sheets_expose` / `sheets_write`: after inserting the
+rule, run the verifier with the owner's token.
+
+- Verified → today's success page (unchanged).
+- Missing → redirect to `result=picker` state: rule was created, but the
+  page now says **"One more step — let Google share this sheet with FGAC"**
+  and renders `SheetsGrantRecovery` (client component):
+  - Launches the Google Picker via the existing `useGooglePicker` flow
+    (including first-time `drive.file` consent round-trip; the approve page
+    consumes `autoOpenPicker` on the return leg).
+  - Embeds the Sheets demo video (`TrackedVideoEmbed`,
+    `https://share.descript.com/embed/Fv9pwXugLUa`) so a confused user can
+    watch the exact setup.
+  - After a pick, POSTs `/api/rules/grant-sheets-access` (upsert — the rule
+    exists; the pick is what registers the Google grant), re-verifies, and
+    flips to "✓ Verified — the agent can retry now."
+- Analytics: `sheets_grant_verification` `{ result: 'ok' | 'missing' }` at
+  approval; `sheets_grant_recovered` when the recovery pick verifies.
+
+### C. Dashboard detects stranded rules
+
+Sheets rules whose spreadsheet fails verification get a
+"⚠ Needs Google access" chip in `ExposedSheetsManager` and a recovery panel
+(same component: picker + video). Verification results come from a new
+`GET /api/rules/verify-sheets-access` (server-side check per rule, small N,
+cached per page load). This catches the users stranded *today* and the
+sheet-picked-on-wrong-account case.
+
+### D. Honest MCP error when the grant is missing
+
+In the sheets tool paths (`sheets_*` and raw `google_api_*` sheets family),
+when policy ALLOWED the call but Google returns 403/404, say what is true:
+the sheet is approved in FGAC but Google hasn't shared it with FGAC yet, and
+the user must finish setup on the dashboard (`{DASHBOARD_URL}/dashboard` —
+the chip from C). No more "Check the ID and try again" for this case.
+
+### E. QA capability 17 + agent docs
+
+`docs/QA_Acceptance_Test/capabilities/17_sheets_grant_recovery.md` models the
+real user journey (assertions in `### A<n>:` form for
+`scripts/qa-coverage-check.ts`), and all four `agents/*.md` runbooks gain a
+capability-17 section. Local replication of the production event sequence
+(denied_by_policy → approval_link_approved → error) is assertion A1.
+
+## Out of scope (noted for later)
+
+- Multi-account: the Picker grants on the browser's signed-in Google account
+  via the token bridge; delegated/linked secondary accounts may still miss
+  grants. The recovery panel names the account it is granting for.
+- The approval→key-scoping gap (approved rule not applying to a later
+  connection's key) is real but separate; capability 17 records it as a
+  known-issue assertion, fix tracked separately.
+
+## Validation
+
+- Replicate locally first (dev server + MCP): unexposed sheet → denial link
+  → approve → confirm post-approval `error` and the same PostHog sequence.
+- Then with the fix: approve → picker state → pick → verified success; MCP
+  retry succeeds. Run capability 17 via the hosted-MCP runbook; lint + build.

--- a/docs/implementation_plans/sheets-access-error-analysis_v2.md
+++ b/docs/implementation_plans/sheets-access-error-analysis_v2.md
@@ -1,0 +1,58 @@
+# Sheets Grant Recovery — Implementation Plan v2 (picker-first approvals)
+
+Supersedes v1's approve→discover→recover sequencing for magic-link approvals.
+v1 shipped: grant verification, `/dashboard/sheets-setup` recovery page
+(picker + demo video), dashboard "Needs Google access" chips, honest MCP
+stranded-sheet errors, `sheets_grant_*` analytics. All validated end-to-end
+locally (denial → approve → recover → pick → verified → MCP success).
+
+## What changes in v2
+
+v1 still let the user approve a rule for a sheet we could not reach — the
+recovery page caught it afterwards. v2 moves the pick BEFORE the approval
+when verification says the grant is missing, because the pick is the real
+authorization moment: it registers the Google grant AND confirms the file's
+identity (title + true id). Consequences:
+
+1. **Approve page becomes a small state machine** (client component
+   `SheetsApprovalFlow` for sheets tokens; non-sheets tokens unchanged):
+   - `checking`: on load, `verify-sheets-access?sid=…&context=link_open`
+     (fires `sheets_grant_verification {via: link_open}`).
+   - `ok` → straight RO/RW confirm (today's one-click path).
+   - `missing` → **Step 1: pick the sheet** — picker button + demo video,
+     NO approve button yet. After the pick:
+     - picked includes the token's id → RO/RW confirm for it;
+     - picked ≠ token id → explicit **substitution** confirm: grant what
+       was picked, never the unverifiable id.
+   - `unknown` (Google hiccup) → degrade to the v1 flow (approve, server
+     fallback still routes to /dashboard/sheets-setup if needed).
+2. **No phantom rules.** Server-side, substituted grants are created only
+   for picked ids that verify `ok` with the owner's token — the client
+   cannot smuggle in an arbitrary id. The token's id gets NO rule unless it
+   verifies. `approveMagicLink(token, rw, pickedSheets?)` implements this;
+   token consumption (jti) stays at final confirm, so picking and
+   abandoning does not burn the link.
+3. **Token lifetime**: sheets approval links get 30 min (others stay 15) —
+   the pick plus a first-time drive.file consent round-trip can exceed 15.
+   Denial messages state the right number.
+4. **Consent round-trip keeps the token**: `useGooglePicker` now preserves
+   the page's existing query params in the OAuth redirect and its cleanup,
+   so the approve page's `token` survives the drive.file consent leg.
+5. **Recovery page stays** for dashboard chips + MCP error deep links
+   (pre-existing stranded rules); picker-first stops new ones being minted.
+
+## Agent-side story for substitution
+
+The agent asked for id X; the user granted picked sheet Y. The agent's
+retry on X gets the honest stranded-sheet error; `get_my_permissions` now
+lists Y with its id (capability 09 A5), so the agent self-corrects.
+`approval_link_approved` carries `substituted: true` + `granted_count` so
+wrong-id frequency is measurable.
+
+## QA capability 17 updates
+
+A2 asserts the picker-first state (approve button absent while the grant is
+missing); A4 asserts pick→confirm→approve ordering; new A9 covers
+substitution (different file picked → rule for picked id only, none for the
+requested id, server rejects unverified substitutes). A5 (grant already
+ok → straight confirm) unchanged in spirit. Agent runbooks updated.

--- a/scripts/cleanup-neon-branches.sh
+++ b/scripts/cleanup-neon-branches.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Agent-safe entry point for the Neon stale-branch cleanup.
+#
+# Exists so the allowlisted invocation is ONE literal command with no
+# environment prefix: permission rules are prefix matches, so
+# `export PATH=... && npx tsx scripts/cleanup-neon-branches.ts` does NOT
+# match a rule for the bare npx command — the classic way an agent ends up
+# classifier-blocked despite the script being allowlisted. This wrapper
+# resolves Node 22 itself (system Node may be too old for tsx).
+#
+# Safety properties live in cleanup-neon-branches.ts: never deletes
+# main/primary, deletes only Neon branches with no matching remote git
+# branch, and deletes nothing at all when git refs can't be fetched.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if [ -d "$HOME/local/node22/bin" ]; then
+  export PATH="$HOME/local/node22/bin:$PATH"
+fi
+
+exec npx tsx scripts/cleanup-neon-branches.ts "$@"

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -30,7 +30,7 @@ import { loadApplicableRules, checkReadRestrictions, type ApplicableRules } from
 import { captureServerEvent } from '@/lib/posthogServer';
 import { runWithToolCallProps, addToolCallProps, getToolCallProps } from '@/lib/toolCallContext';
 import { ensureDefaultProfile } from '@/db/defaultProfile';
-import { mintApprovalUrl, type ApprovalAction } from '@/lib/approvalLinks';
+import { mintApprovalUrl, approvalLinkMinutes, type ApprovalAction } from '@/lib/approvalLinks';
 import { TOOL_DEFS, toolAnnotations, type FgacToolDef } from './toolDefs';
 import {
   classifyGoogleApiCall, extractSendRecipients, sheetsApprovalAction,
@@ -316,9 +316,11 @@ function checkSendWhitelist(rules: ApplicableRules, recipients: string[] | null)
 
 /**
  * Magic-link denial (connector-growth Phase C): policy denials that a user
- * would plausibly want to approve carry a signed, single-use, 15-minute link
- * that pre-fills exactly that grant. Explicit blocks and read restrictions
- * never get links — weakening those stays a deliberate dashboard act.
+ * would plausibly want to approve carry a signed, single-use, short-lived
+ * link that pre-fills exactly that grant (15 min; sheets 30 — the approval
+ * can include a Picker pick + consent round-trip). Explicit blocks and read
+ * restrictions never get links — weakening those stays a deliberate
+ * dashboard act.
  */
 async function policyDenialWithLink(
   conn: ConnectionApproved,
@@ -331,7 +333,7 @@ async function policyDenialWithLink(
     const url = await mintApprovalUrl(DASHBOARD_URL, conn.user.id, proxyKeyId, action);
     captureServerEvent(conn.user.clerkUserId, 'approval_link_minted', { action: action.action });
     return textResult(
-      `${message}\n👉 Share this link with the user to approve it in one click (single-use, expires in 15 minutes): ${url}`,
+      `${message}\n👉 Share this link with the user to approve it in one click (single-use, expires in ${approvalLinkMinutes(action.action)} minutes): ${url}`,
     );
   } catch (err) {
     console.error('[MCP] Failed to mint approval link:', err);

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -372,7 +372,7 @@ async function sendDenialWithLinks(
 
 type GoogleFetchResult =
   | { ok: true; data: unknown }
-  | { ok: false; error: string };
+  | { ok: false; error: string; status?: number };
 
 function describeGoogleError(status: number, data: unknown, targetEmail: string): string {
   const detail = (data as { error?: { message?: string } })?.error?.message
@@ -413,9 +413,30 @@ async function googleFetch(
   try { data = text ? JSON.parse(text) : {}; } catch { /* non-JSON body: keep text */ }
 
   if (!res.ok) {
-    return { ok: false, error: describeGoogleError(res.status, data, targetEmail) };
+    return { ok: false, error: describeGoogleError(res.status, data, targetEmail), status: res.status };
   }
   return { ok: true, data };
+}
+
+/**
+ * Post-policy Google failure on a sheets call. A 403/404 HERE — after FGAC's
+ * own permission check passed — almost always means the FGAC rule exists but
+ * Google never registered a drive.file grant for the sheet (it was approved
+ * via magic link but never picked in the Google Picker; a mistyped id looks
+ * identical from outside). The generic "check the ID" text sent the whole
+ * 2026-08 connector cohort into a retry loop; say what is actually wrong and
+ * where the one-click fix lives.
+ */
+function sheetsErrorResult(result: { error: string; status?: number }, spreadsheetId: string) {
+  if (result.status === 403 || result.status === 404) {
+    return errorResult(
+      `❌ FGAC allows this spreadsheet, but Google hasn't shared the sheet itself with FGAC yet, so Google rejected the call (${result.status}). ` +
+      `This is a one-time setup step only the user can do: they must pick this sheet in Google's file picker. ` +
+      `👉 Send the user here to finish setup (includes a short how-to video): ${DASHBOARD_URL}/dashboard/sheets-setup?sid=${encodeURIComponent(spreadsheetId)} ` +
+      `Note: a wrong spreadsheet ID produces this same error — the setup page verifies real access before reporting success, so it resolves either case. Retry after the user confirms.`,
+    );
+  }
+  return errorResult(result.error);
 }
 
 async function gmailFetch(token: string, email: string, path: string, method = 'GET', body?: string): Promise<GoogleFetchResult> {
@@ -687,7 +708,7 @@ async function executeRawGoogleCall(
 
     const url = `https://sheets.googleapis.com/${cleanPath.replace(/^sheets\//, '')}`;
     const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
-    if (!result.ok) return errorResult(result.error);
+    if (!result.ok) return sheetsErrorResult(result, cls.spreadsheetId);
     return jsonResult(result.data);
   }
 
@@ -927,7 +948,7 @@ const handler = createMcpHandler(
         if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, false));
 
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}`, 'GET', undefined, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
     );
@@ -952,7 +973,7 @@ const handler = createMcpHandler(
 
         const encodedRange = encodeURIComponent(range);
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`, 'GET', undefined, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
     );
@@ -979,7 +1000,7 @@ const handler = createMcpHandler(
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values, range });
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}?valueInputOption=USER_ENTERED`, 'PUT', body, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
     );
@@ -1006,7 +1027,7 @@ const handler = createMcpHandler(
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values });
         const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body, resolved.targetEmail);
-        if (!result.ok) return errorResult(result.error);
+        if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
     );

--- a/src/app/api/rules/verify-sheets-access/route.ts
+++ b/src/app/api/rules/verify-sheets-access/route.ts
@@ -41,6 +41,13 @@ export async function GET(request: NextRequest) {
       if (context === 'recovery' && result.state === 'ok') {
         captureServerEvent(clerkUserId, 'sheets_grant_recovered', { spreadsheet_id: sid });
       }
+      // link_open = the approve page checking the grant before showing the
+      // flow — the top of the picker-first funnel.
+      if (context === 'link_open') {
+        captureServerEvent(clerkUserId, 'sheets_grant_verification', {
+          result: result.state, via: 'link_open', spreadsheet_id: sid,
+        });
+      }
       return NextResponse.json({ spreadsheetId: sid, ...result });
     }
 

--- a/src/app/api/rules/verify-sheets-access/route.ts
+++ b/src/app/api/rules/verify-sheets-access/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { db } from '@/db';
+import { users, accessRules } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { verifySheetsGrant, getOwnerGoogleToken, SheetsGrantState } from '@/lib/sheetsGrantCheck';
+import { captureServerEvent } from '@/lib/posthogServer';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/rules/verify-sheets-access[?sid=<spreadsheetId>][&context=recovery]
+ *
+ * For the signed-in user, checks whether Google actually grants us access to
+ * the spreadsheet(s) behind their sheets rules (FGAC rule ≠ Google grant —
+ * see sheetsGrantCheck.ts). Without `sid`, verifies every sheets rule and
+ * returns a map; with `sid`, verifies just that spreadsheet (it does not need
+ * an existing rule — the approval flow verifies before the page settles).
+ *
+ * `context=recovery` marks a re-check issued by the recovery UI right after a
+ * Picker pick; a verified `ok` in that context is the "user completed the
+ * recovery loop" signal and fires `sheets_grant_recovered`.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const sid = searchParams.get('sid');
+    const context = searchParams.get('context');
+
+    const token = await getOwnerGoogleToken(clerkUserId);
+
+    if (sid) {
+      const result: SheetsGrantState = token
+        ? await verifySheetsGrant(token, sid)
+        : { state: 'missing' };
+      if (context === 'recovery' && result.state === 'ok') {
+        captureServerEvent(clerkUserId, 'sheets_grant_recovered', { spreadsheet_id: sid });
+      }
+      return NextResponse.json({ spreadsheetId: sid, ...result });
+    }
+
+    const dbUser = await db.select().from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1).then(r => r[0]);
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const rules = await db.select().from(accessRules).where(
+      and(eq(accessRules.userId, dbUser.id), eq(accessRules.service, 'sheets')),
+    );
+
+    // Distinct spreadsheet ids only — several rules can share one sheet.
+    const ids = [...new Set(rules.map(r => r.targetResourceId).filter((v): v is string => !!v))];
+    const entries = await Promise.all(ids.map(async id => {
+      const result: SheetsGrantState = token
+        ? await verifySheetsGrant(token, id)
+        : { state: 'missing' };
+      return [id, result] as const;
+    }));
+
+    return NextResponse.json({ grants: Object.fromEntries(entries) });
+  } catch (error) {
+    console.error('Error verifying sheets access:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/ExposedSheetsManager.tsx
+++ b/src/app/dashboard/ExposedSheetsManager.tsx
@@ -21,6 +21,12 @@ export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKe
   const [sheetsRules, setSheetsRules] = useState<SheetsRule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  // spreadsheetId → Google-side grant state ('ok' | 'missing' | 'unknown').
+  // A rule can exist without Google ever having shared the sheet (approved
+  // via magic link, never picked) — those rows get a "Needs Google access"
+  // chip. Verification failing entirely degrades to no chips, never a
+  // broken card.
+  const [grantStates, setGrantStates] = useState<Record<string, { state: string }>>({});
 
   const fetchSheetsRules = useCallback(async () => {
     try {
@@ -33,6 +39,13 @@ export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKe
       console.error('Failed to load sheets rules:', err);
     } finally {
       setIsLoading(false);
+    }
+    try {
+      const res = await fetch('/api/rules/verify-sheets-access');
+      const data = await res.json();
+      setGrantStates(data.grants ?? {});
+    } catch {
+      setGrantStates({});
     }
   }, []);
 
@@ -158,6 +171,15 @@ export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKe
                       <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
                     </svg>
                     <span>{rule.resourceName || rule.ruleName}</span>
+                    {grantStates[rule.targetResourceId]?.state === 'missing' && (
+                      <a
+                        href={`/dashboard/sheets-setup?sid=${encodeURIComponent(rule.targetResourceId)}${rule.resourceName ? `&name=${encodeURIComponent(rule.resourceName)}` : ''}`}
+                        className="inline-flex items-center gap-1 rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-800 hover:bg-amber-100 transition-colors flex-shrink-0"
+                        title="FGAC has this rule, but Google hasn't shared the sheet with FGAC yet — agents get errors until you pick it in the Google Picker."
+                      >
+                        ⚠ Needs Google access — finish setup
+                      </a>
+                    )}
                   </td>
                   <td className="py-3 px-4 font-mono text-xs text-slate-600">
                     {rule.targetResourceId ? (

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -661,6 +661,10 @@ export type MagicApprovalResult =
 export async function approveMagicLink(
   token: string,
   sheetsWriteChoice?: boolean,
+  /** Sheets the user just picked in the Google Picker (picker-first flow).
+   * Client-supplied and therefore untrusted: rules are created only for
+   * picked ids that verify against Google with the owner's token. */
+  pickedSheets?: { id: string; name?: string }[],
 ): Promise<MagicApprovalResult> {
   const { verifyApprovalToken, describeApproval } = await import("@/lib/approvalLinks");
   const { approvalConsumptions } = await import("@/db/schema");
@@ -691,13 +695,24 @@ export async function approveMagicLink(
   }
 
   // Single-use: the PK on jti turns a replay into a unique violation.
-  try {
-    await db.insert(approvalConsumptions).values({ jti: p.jti, userId: dbUser.id });
-  } catch {
-    return { ok: false, reason: "This approval link was already used. Each link works exactly once." };
-  }
+  // Consumption is deferred per-branch so read-only pre-checks (Google grant
+  // verification in the picker-first sheets path) can fail WITHOUT burning
+  // the link — only a branch that is about to write rules consumes it.
+  const consume = async (): Promise<boolean> => {
+    try {
+      await db.insert(approvalConsumptions).values({ jti: p.jti, userId: dbUser.id });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const alreadyUsed = {
+    ok: false as const,
+    reason: "This approval link was already used. Each link works exactly once.",
+  };
 
   if (p.action === "send_whitelist" && p.recipient) {
+    if (!(await consume())) return alreadyUsed;
     const escaped = p.recipient.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
     const [rule] = await db.insert(accessRules).values({
       userId: dbUser.id,
@@ -708,27 +723,78 @@ export async function approveMagicLink(
     }).returning();
     await db.insert(keyRuleAssignments).values({ proxyKeyId: key.id, accessRuleId: rule.id });
   } else if (p.action === "send_all") {
+    if (!(await consume())) return alreadyUsed;
     // Idempotent: an already-granted key still consumes the token and reports
     // success — the agent's retry will work either way.
     await grantSendToAnyone(dbUser.id, key.id);
   } else if ((p.action === "sheets_expose" || p.action === "sheets_write") && p.spreadsheetId) {
     const readWrite = p.action === "sheets_write" || sheetsWriteChoice === true;
-    const [rule] = await db.insert(accessRules).values({
-      userId: dbUser.id,
-      ruleName: `${readWrite ? "Read & Write" : "Read Only"}: ${p.resourceName || p.spreadsheetId}`,
-      service: "sheets",
-      actionType: readWrite ? "sheet_read_write" : "sheet_read",
-      targetResourceId: p.spreadsheetId,
-      resourceName: p.resourceName || null,
-    }).returning();
-    await db.insert(keyRuleAssignments).values({ proxyKeyId: key.id, accessRuleId: rule.id });
-
-    // The rule is only half of sheets access: Google grants the file via
-    // drive.file ONLY after a Picker pick. Verify before telling the user
-    // the agent can retry — an unverified "success" here is exactly the
-    // approve→retry→404 dead end the 2026-08 launch cohort churned on.
     const { verifySheetsGrant, getOwnerGoogleToken } = await import("@/lib/sheetsGrantCheck");
     const googleToken = await getOwnerGoogleToken(dbUser.clerkUserId);
+
+    const insertSheetRule = async (id: string, name: string | null) => {
+      const [rule] = await db.insert(accessRules).values({
+        userId: dbUser.id,
+        ruleName: `${readWrite ? "Read & Write" : "Read Only"}: ${name || id}`,
+        service: "sheets",
+        actionType: readWrite ? "sheet_read_write" : "sheet_read",
+        targetResourceId: id,
+        resourceName: name,
+      }).returning();
+      await db.insert(keyRuleAssignments).values({ proxyKeyId: key.id, accessRuleId: rule.id });
+    };
+
+    if (pickedSheets && pickedSheets.length > 0) {
+      // Picker-first path. The pick is the real authorization moment — it
+      // registers the Google-side drive.file grant AND confirms the file's
+      // identity. Rules are created only for picked ids Google confirms the
+      // owner's token can reach; the token's id gets NO rule unless it is
+      // among them (no phantom rules for ids the agent guessed wrong).
+      const verified: { id: string; name: string | null }[] = [];
+      for (const s of pickedSheets.slice(0, 10)) {
+        if (typeof s?.id !== "string" || !s.id) continue;
+        const check = googleToken
+          ? await verifySheetsGrant(googleToken, s.id)
+          : { state: "missing" as const };
+        if (check.state === "ok") {
+          verified.push({ id: s.id, name: (typeof s.name === "string" && s.name) || ("title" in check ? check.title : null) });
+        }
+      }
+      if (verified.length === 0) {
+        // Read-only failure — the link was NOT consumed; the user can retry.
+        return {
+          ok: false,
+          reason: "Google hasn't finished sharing the picked sheet(s) with FGAC yet. Wait a few seconds and try the pick again — the link is still valid.",
+        };
+      }
+      if (!(await consume())) return alreadyUsed;
+      for (const v of verified) await insertSheetRule(v.id, v.name);
+
+      const substituted = !verified.some(v => v.id === p.spreadsheetId);
+      captureServerEvent(dbUser.clerkUserId, "sheets_grant_verification", {
+        result: "ok", via: "magic_link", spreadsheet_id: verified[0].id,
+      });
+      captureServerEvent(dbUser.clerkUserId, "approval_link_approved", {
+        action: p.action, substituted, granted_count: verified.length,
+      });
+      revalidatePath("/dashboard");
+      const names = verified.map(v => v.name || v.id).join(", ");
+      const level = readWrite ? "read & write" : "read-only";
+      return {
+        ok: true,
+        description: substituted
+          ? `Granted ${level} access to ${names}. That's the sheet you picked — not the ID the agent originally sent, which you don't appear to have. The agent will find the right sheet in its permissions.`
+          : `Granted ${level} access to ${names}.`,
+      };
+    }
+
+    // Fallback path (no pick info — verification was inconclusive at page
+    // load, or a client without the picker flow). Create the rule, verify
+    // the Google half, and route to the recovery page when it's missing —
+    // never claim "retry now" for a sheet Google can't reach (the
+    // approve→retry→404 dead end the 2026-08 launch cohort churned on).
+    if (!(await consume())) return alreadyUsed;
+    await insertSheetRule(p.spreadsheetId, p.resourceName || null);
     const grant = googleToken
       ? await verifySheetsGrant(googleToken, p.spreadsheetId)
       : { state: "missing" as const };

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -641,7 +641,14 @@ export async function enableSendToAnyone(keyId: string) {
 // ─── Magic-Link Approvals (connector-growth Phase C) ───────────────────────
 
 export type MagicApprovalResult =
-  | { ok: true; description: string }
+  | {
+      ok: true;
+      description: string;
+      /** Set when the FGAC rule was created but Google has no drive.file
+       * grant for the sheet yet — the approve page must route the user into
+       * the Picker recovery flow instead of claiming the agent can retry. */
+      needsSheetsGrant?: { spreadsheetId: string; resourceName?: string };
+    }
   | { ok: false; reason: string };
 
 /**
@@ -715,6 +722,33 @@ export async function approveMagicLink(
       resourceName: p.resourceName || null,
     }).returning();
     await db.insert(keyRuleAssignments).values({ proxyKeyId: key.id, accessRuleId: rule.id });
+
+    // The rule is only half of sheets access: Google grants the file via
+    // drive.file ONLY after a Picker pick. Verify before telling the user
+    // the agent can retry — an unverified "success" here is exactly the
+    // approve→retry→404 dead end the 2026-08 launch cohort churned on.
+    const { verifySheetsGrant, getOwnerGoogleToken } = await import("@/lib/sheetsGrantCheck");
+    const googleToken = await getOwnerGoogleToken(dbUser.clerkUserId);
+    const grant = googleToken
+      ? await verifySheetsGrant(googleToken, p.spreadsheetId)
+      : { state: "missing" as const };
+    captureServerEvent(dbUser.clerkUserId, "sheets_grant_verification", {
+      result: grant.state,
+      via: "magic_link",
+      spreadsheet_id: p.spreadsheetId,
+    });
+    if (grant.state === "missing") {
+      captureServerEvent(dbUser.clerkUserId, "approval_link_approved", { action: p.action });
+      revalidatePath("/dashboard");
+      return {
+        ok: true,
+        description: describeApproval(p),
+        needsSheetsGrant: {
+          spreadsheetId: p.spreadsheetId,
+          resourceName: p.resourceName || undefined,
+        },
+      };
+    }
   } else {
     return { ok: false, reason: "This approval link is malformed." };
   }

--- a/src/app/dashboard/approve/SheetsApprovalFlow.tsx
+++ b/src/app/dashboard/approve/SheetsApprovalFlow.tsx
@@ -90,7 +90,7 @@ export function SheetsApprovalFlow({
   if (state.step === "need_pick") {
     return (
       <div className="flex flex-col gap-4" data-testid="sheets-flow-pick-first">
-        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground">
+        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
           Google hasn&apos;t shared <strong>{sheetLabel}</strong> with FGAC yet, so
           there&apos;s nothing to approve until you pick it. Google only shares a
           sheet when you choose it in Google&apos;s own file picker — that per-file
@@ -137,7 +137,7 @@ export function SheetsApprovalFlow({
       {picked && <input type="hidden" name="picked" value={JSON.stringify(picked)} />}
 
       {substituting && (
-        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground" data-testid="sheets-flow-substitution">
+        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]" data-testid="sheets-flow-substitution">
           You picked <strong>{grantTargets}</strong>, but the agent asked for a
           different sheet ID (<code className="font-mono text-xs">{spreadsheetId}</code>)
           that Google says you don&apos;t have. Most likely the agent had the wrong
@@ -147,7 +147,7 @@ export function SheetsApprovalFlow({
         </div>
       )}
       {!substituting && (
-        <div className="rounded-md border border-border bg-secondary/30 px-4 py-3 text-sm text-foreground">
+        <div className="rounded-md border border-border bg-secondary/30 px-4 py-3 text-sm text-foreground [overflow-wrap:anywhere]">
           Granting access to <strong>{grantTargets}</strong>
           {state.title && resourceName === null ? " (verified with Google)" : ""}.
         </div>

--- a/src/app/dashboard/approve/SheetsApprovalFlow.tsx
+++ b/src/app/dashboard/approve/SheetsApprovalFlow.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useGooglePicker, PickedSheet } from "../useGooglePicker";
+import { TrackedVideoEmbed } from "@/components/TrackedVideoEmbed";
+
+const SHEETS_DEMO_EMBED = "https://share.descript.com/embed/Fv9pwXugLUa";
+
+type FlowState =
+  | { step: "checking" }
+  // Grant verified (or verification inconclusive) — straight to confirm.
+  | { step: "confirm"; picked: PickedSheet[] | null; title: string | null }
+  // No Google grant: the pick comes FIRST. The pick registers the grant and
+  // confirms the file's identity; only then does approving mean anything.
+  | { step: "need_pick"; pickFailed: boolean }
+  // User picked file(s) that don't include the id the agent asked for.
+  | { step: "substitute"; picked: PickedSheet[] };
+
+/**
+ * Picker-first approval flow for sheets magic links.
+ *
+ * Sequence: verify the Google-side grant on load. If Google can already
+ * reach the sheet, approving is one click (title shown, since we can now
+ * resolve it). If not, the user picks the sheet in Google's Picker BEFORE
+ * any FGAC rule exists — approving blind on a raw id is how the connector
+ * launch cohort ended up with rules for sheets Google couldn't serve. A
+ * different-file pick becomes an explicit substitution: the grant follows
+ * what the user actually picked, never the unverifiable id.
+ */
+export function SheetsApprovalFlow({
+  token,
+  spreadsheetId,
+  resourceName,
+  action,
+  approveAction,
+}: {
+  token: string;
+  spreadsheetId: string;
+  resourceName: string | null;
+  action: "sheets_expose" | "sheets_write";
+  approveAction: (formData: FormData) => Promise<void>;
+}) {
+  const [state, setState] = useState<FlowState>({ step: "checking" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/rules/verify-sheets-access?sid=${encodeURIComponent(spreadsheetId)}&context=link_open`)
+      .then(r => r.json())
+      .then(data => {
+        if (cancelled) return;
+        if (data.state === "ok") {
+          setState({ step: "confirm", picked: null, title: data.title ?? null });
+        } else if (data.state === "missing") {
+          setState({ step: "need_pick", pickFailed: false });
+        } else {
+          // Verification inconclusive (Google hiccup) — don't block the
+          // approval; the server falls back to the recovery page if needed.
+          setState({ step: "confirm", picked: null, title: null });
+        }
+      })
+      .catch(() => { if (!cancelled) setState({ step: "confirm", picked: null, title: null }); });
+    return () => { cancelled = true; };
+  }, [spreadsheetId]);
+
+  const handleSheetsPicked = (picked: PickedSheet[]) => {
+    if (picked.length === 0) {
+      setState({ step: "need_pick", pickFailed: true });
+      return;
+    }
+    if (picked.some(s => s.id === spreadsheetId)) {
+      setState({ step: "confirm", picked, title: picked.find(s => s.id === spreadsheetId)?.name ?? null });
+    } else {
+      setState({ step: "substitute", picked });
+    }
+  };
+
+  const { triggerAddSheets, isLoading: pickerLoading } = useGooglePicker(handleSheetsPicked);
+
+  const sheetLabel = resourceName || spreadsheetId;
+  const levelChoice = action === "sheets_expose";
+
+  if (state.step === "checking") {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="sheets-flow-checking">
+        Checking whether Google already shares this sheet with FGAC…
+      </p>
+    );
+  }
+
+  if (state.step === "need_pick") {
+    return (
+      <div className="flex flex-col gap-4" data-testid="sheets-flow-pick-first">
+        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground">
+          Google hasn&apos;t shared <strong>{sheetLabel}</strong> with FGAC yet, so
+          there&apos;s nothing to approve until you pick it. Google only shares a
+          sheet when you choose it in Google&apos;s own file picker — that per-file
+          permission is all FGAC runs on (nothing else in your Drive is shared).
+        </div>
+        {state.pickFailed && (
+          <p className="text-sm text-muted-foreground">
+            No sheet was selected. Open the picker and choose the sheet the
+            agent should reach.
+          </p>
+        )}
+        <button
+          onClick={() => triggerAddSheets(spreadsheetId)}
+          disabled={pickerLoading}
+          className="rounded-sm bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {pickerLoading ? "Opening Google Picker…" : "Step 1 — Pick the sheet in Google Picker"}
+        </button>
+        <p className="text-xs text-subtle">
+          First time? Google will ask you to allow FGAC&apos;s file picker
+          (drive.file) and then bring you straight back here.
+        </p>
+        <div className="rounded-lg border border-border bg-card p-2">
+          <div className="px-1.5 pb-1.5 pt-0.5 text-sm font-semibold text-foreground">
+            Watch how it works (2 min)
+          </div>
+          <div className="relative aspect-video w-full overflow-hidden rounded-sm bg-surface-inverse">
+            <TrackedVideoEmbed src={SHEETS_DEMO_EMBED} title="FGAC Google Sheets demo" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const picked = state.picked;
+  const substituting = state.step === "substitute";
+  const grantTargets = state.step === "substitute"
+    ? state.picked.map(s => s.name || s.id).join(", ")
+    : (state.title || sheetLabel);
+
+  return (
+    <form action={approveAction} className="flex flex-col gap-4" data-testid="sheets-flow-confirm">
+      <input type="hidden" name="token" value={token} />
+      {picked && <input type="hidden" name="picked" value={JSON.stringify(picked)} />}
+
+      {substituting && (
+        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground" data-testid="sheets-flow-substitution">
+          You picked <strong>{grantTargets}</strong>, but the agent asked for a
+          different sheet ID (<code className="font-mono text-xs">{spreadsheetId}</code>)
+          that Google says you don&apos;t have. Most likely the agent had the wrong
+          ID. Approving grants access to <strong>what you picked</strong> — and
+          nothing for the ID the agent sent; the agent will find the right
+          sheet in its permissions.
+        </div>
+      )}
+      {!substituting && (
+        <div className="rounded-md border border-border bg-secondary/30 px-4 py-3 text-sm text-foreground">
+          Granting access to <strong>{grantTargets}</strong>
+          {state.title && resourceName === null ? " (verified with Google)" : ""}.
+        </div>
+      )}
+
+      {levelChoice && (
+        <fieldset className="flex flex-col gap-2 text-sm text-foreground">
+          <label className="flex items-center gap-2">
+            <input type="radio" name="permission" value="read_only" defaultChecked />
+            Read only
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="radio" name="permission" value="read_write" />
+            Read &amp; write
+          </label>
+        </fieldset>
+      )}
+
+      <button
+        type="submit"
+        className="rounded-sm bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+      >
+        {substituting ? "Grant access to what I picked" : "Approve this grant"}
+      </button>
+      {picked && !substituting && (
+        <button
+          type="button"
+          onClick={() => triggerAddSheets(spreadsheetId)}
+          className="text-xs text-subtle underline hover:text-foreground self-start"
+        >
+          Pick again
+        </button>
+      )}
+      {substituting && (
+        <button
+          type="button"
+          onClick={() => triggerAddSheets(spreadsheetId)}
+          disabled={pickerLoading}
+          className="text-xs text-subtle underline hover:text-foreground self-start disabled:opacity-50"
+        >
+          That&apos;s not right — pick a different sheet
+        </button>
+      )}
+    </form>
+  );
+}

--- a/src/app/dashboard/approve/page.tsx
+++ b/src/app/dashboard/approve/page.tsx
@@ -1,17 +1,25 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { verifyApprovalToken, describeApproval } from "@/lib/approvalLinks";
+import { verifyApprovalToken, describeApproval, approvalLinkMinutes } from "@/lib/approvalLinks";
 import { approveMagicLink } from "../actions";
+import { SheetsApprovalFlow } from "./SheetsApprovalFlow";
 
 /* ─── Magic-link approval page (connector-growth Phase C) ────────────────
    Reached from a signed, single-use link embedded in an agent's denial (or
    minted by the request_access tool). Shows exactly one grant and applies it
    only on explicit confirmation by the owning, signed-in user. The dashboard
-   route group is Clerk-protected, so a signed-out visitor signs in first. */
+   route group is Clerk-protected, so a signed-out visitor signs in first.
+
+   Sheets grants run picker-first (SheetsApprovalFlow): the page verifies the
+   Google-side drive.file grant on load, and when it's missing the user picks
+   the sheet in Google's Picker BEFORE anything is approved — the pick is
+   what registers Google access and confirms the file's identity. Approving a
+   raw, unverifiable id is how users ended up with rules for sheets Google
+   couldn't serve. */
 
 function Card({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mx-auto mt-16 max-w-lg px-6">
+    <div className="mx-auto mt-16 max-w-lg px-6 pb-16">
       <div className="rounded-lg border border-border bg-card p-8">{children}</div>
       <p className="mt-4 text-center text-xs text-subtle">
         <Link href="/dashboard" className="underline hover:text-foreground">
@@ -69,7 +77,7 @@ export default async function ApprovePage({
         </h1>
         <p className="text-sm text-muted-foreground">
           {verified.reason === "expired"
-            ? "Approval links last 15 minutes. Ask the agent to request access again."
+            ? "This approval link has expired (links last 15–30 minutes). Ask the agent to request access again."
             : "This link is not valid. If an agent gave it to you, ask it to request access again."}
         </p>
       </Card>
@@ -77,16 +85,24 @@ export default async function ApprovePage({
   }
 
   const p = verified.payload;
+  const linkMinutes = approvalLinkMinutes(p.action);
 
   async function approve(formData: FormData) {
     "use server";
     const rw = formData.get("permission") === "read_write";
-    const result = await approveMagicLink(formData.get("token") as string, rw);
+    let picked: { id: string; name?: string }[] | undefined;
+    const rawPicked = formData.get("picked");
+    if (typeof rawPicked === "string" && rawPicked) {
+      try {
+        const parsed: unknown = JSON.parse(rawPicked);
+        if (Array.isArray(parsed)) picked = parsed as { id: string; name?: string }[];
+      } catch { /* malformed picked payload → treated as no pick info */ }
+    }
+    const result = await approveMagicLink(formData.get("token") as string, rw, picked);
     if (result.ok) {
       if (result.needsSheetsGrant) {
-        // FGAC rule created, but Google has no drive.file grant for this
-        // sheet yet — "retry now" would be a lie (the 404 dead end the
-        // connector-launch cohort hit). Route into the Picker recovery flow.
+        // Fallback only (verification was inconclusive at page load): the
+        // rule exists but Google can't reach the sheet — finish in recovery.
         const q = new URLSearchParams({ sid: result.needsSheetsGrant.spreadsheetId, from: "approval" });
         if (result.needsSheetsGrant.resourceName) q.set("name", result.needsSheetsGrant.resourceName);
         redirect(`/dashboard/sheets-setup?${q.toString()}`);
@@ -95,6 +111,8 @@ export default async function ApprovePage({
     }
     redirect(`/dashboard/approve?result=error&message=${encodeURIComponent(result.reason)}`);
   }
+
+  const isSheets = (p.action === "sheets_expose" || p.action === "sheets_write") && p.spreadsheetId;
 
   return (
     <Card>
@@ -105,31 +123,29 @@ export default async function ApprovePage({
       <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm font-medium text-warning-foreground">
         {describeApproval(p)}
       </div>
-      <form action={approve} className="flex flex-col gap-4">
-        <input type="hidden" name="token" value={token} />
-        {p.action === "sheets_expose" && (
-          <fieldset className="flex flex-col gap-2 text-sm text-foreground">
-            <label className="flex items-center gap-2">
-              <input type="radio" name="permission" value="read_only" defaultChecked />
-              Read only
-            </label>
-            <label className="flex items-center gap-2">
-              <input type="radio" name="permission" value="read_write" />
-              Read &amp; write
-            </label>
-          </fieldset>
-        )}
-        <button
-          type="submit"
-          className="rounded-sm bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
-        >
-          Approve this grant
-        </button>
-        <p className="text-xs text-subtle">
-          Single-use link · expires 15 minutes after it was created · grants
-          only what is shown above, scoped to the requesting agent&apos;s profile.
-        </p>
-      </form>
+      {isSheets ? (
+        <SheetsApprovalFlow
+          token={token}
+          spreadsheetId={p.spreadsheetId!}
+          resourceName={p.resourceName || null}
+          action={p.action as "sheets_expose" | "sheets_write"}
+          approveAction={approve}
+        />
+      ) : (
+        <form action={approve} className="flex flex-col gap-4">
+          <input type="hidden" name="token" value={token} />
+          <button
+            type="submit"
+            className="rounded-sm bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+          >
+            Approve this grant
+          </button>
+        </form>
+      )}
+      <p className="mt-4 text-xs text-subtle">
+        Single-use link · expires {linkMinutes} minutes after it was created · grants
+        only what is shown above, scoped to the requesting agent&apos;s profile.
+      </p>
     </Card>
   );
 }

--- a/src/app/dashboard/approve/page.tsx
+++ b/src/app/dashboard/approve/page.tsx
@@ -83,6 +83,14 @@ export default async function ApprovePage({
     const rw = formData.get("permission") === "read_write";
     const result = await approveMagicLink(formData.get("token") as string, rw);
     if (result.ok) {
+      if (result.needsSheetsGrant) {
+        // FGAC rule created, but Google has no drive.file grant for this
+        // sheet yet — "retry now" would be a lie (the 404 dead end the
+        // connector-launch cohort hit). Route into the Picker recovery flow.
+        const q = new URLSearchParams({ sid: result.needsSheetsGrant.spreadsheetId, from: "approval" });
+        if (result.needsSheetsGrant.resourceName) q.set("name", result.needsSheetsGrant.resourceName);
+        redirect(`/dashboard/sheets-setup?${q.toString()}`);
+      }
       redirect(`/dashboard/approve?result=ok&message=${encodeURIComponent(result.description)}`);
     }
     redirect(`/dashboard/approve?result=error&message=${encodeURIComponent(result.reason)}`);

--- a/src/app/dashboard/approve/page.tsx
+++ b/src/app/dashboard/approve/page.tsx
@@ -120,7 +120,7 @@ export default async function ApprovePage({
       <p className="mb-5 text-sm text-muted-foreground">
         An AI agent connected to your account is asking for exactly this grant:
       </p>
-      <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm font-medium text-warning-foreground">
+      <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm font-medium text-warning-foreground [overflow-wrap:anywhere]">
         {describeApproval(p)}
       </div>
       {isSheets ? (

--- a/src/app/dashboard/sheets-setup/SheetsGrantRecovery.tsx
+++ b/src/app/dashboard/sheets-setup/SheetsGrantRecovery.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useGooglePicker, PickedSheet } from "../useGooglePicker";
+import { TrackedVideoEmbed } from "@/components/TrackedVideoEmbed";
+
+const SHEETS_DEMO_EMBED = "https://share.descript.com/embed/Fv9pwXugLUa";
+
+type GrantStatus = "checking" | "needs_grant" | "verified" | "picked_other";
+
+/**
+ * Recovery UI for the "FGAC approved, Google grant missing" state.
+ *
+ * Approving a sheet in FGAC only creates our rule; Google shares the file
+ * with FGAC exclusively through a Google Picker pick (per-file drive.file
+ * grant). Production showed users approving and then retrying into 404s
+ * with no way out — this page IS the way out: one button that opens the
+ * Picker, the demo video for anyone unsure, and a live verification check
+ * so we never again say "done" without Google agreeing.
+ */
+export function SheetsGrantRecovery({
+  spreadsheetId,
+  resourceName,
+  fromApproval,
+}: {
+  spreadsheetId: string | null;
+  resourceName: string | null;
+  fromApproval: boolean;
+}) {
+  const [status, setStatus] = useState<GrantStatus>(spreadsheetId ? "checking" : "needs_grant");
+  const [busy, setBusy] = useState(false);
+
+  const verify = useCallback(async (recovery: boolean): Promise<boolean> => {
+    if (!spreadsheetId) return false;
+    try {
+      const res = await fetch(
+        `/api/rules/verify-sheets-access?sid=${encodeURIComponent(spreadsheetId)}${recovery ? "&context=recovery" : ""}`,
+      );
+      const data = await res.json();
+      return data.state === "ok";
+    } catch {
+      return false;
+    }
+  }, [spreadsheetId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!spreadsheetId) return;
+    verify(false).then(ok => {
+      if (!cancelled) setStatus(ok ? "verified" : "needs_grant");
+    });
+    return () => { cancelled = true; };
+  }, [spreadsheetId, verify]);
+
+  const handleSheetsPicked = async (picked: PickedSheet[]) => {
+    setBusy(true);
+    try {
+      // Upsert rules only for picked sheets that have none yet — re-POSTing
+      // an existing rule would silently reset its Read/Write choice.
+      const existing = await fetch("/api/rules/grant-sheets-access")
+        .then(r => r.json())
+        .then(d => new Set((d.sheetsRules ?? []).map((r: { targetResourceId: string }) => r.targetResourceId)))
+        .catch(() => new Set());
+      for (const sheet of picked) {
+        if (existing.has(sheet.id)) continue;
+        await fetch("/api/rules/grant-sheets-access", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            targetResourceId: sheet.id,
+            resourceName: sheet.name,
+            actionType: "sheet_read",
+          }),
+        });
+      }
+
+      if (!spreadsheetId) {
+        // No specific sheet to verify — a pick is all setup requires.
+        setStatus(picked.length > 0 ? "verified" : "needs_grant");
+        return;
+      }
+      const ok = await verify(true);
+      if (ok) {
+        setStatus("verified");
+      } else {
+        // The pick registered grants, just not for the sheet the agent asked
+        // for — most likely the agent had the wrong id. Say so.
+        setStatus(picked.length > 0 ? "picked_other" : "needs_grant");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const { triggerAddSheets, isLoading: pickerLoading } = useGooglePicker(handleSheetsPicked);
+
+  const sheetLabel = resourceName || spreadsheetId || "your spreadsheet";
+
+  return (
+    <div className="mx-auto mt-12 max-w-2xl px-6 pb-16">
+      <div className="rounded-lg border border-border bg-card p-8">
+        {status === "verified" ? (
+          <>
+            <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ Sheet access verified</h1>
+            <p className="text-sm text-muted-foreground">
+              Google now shares {resourceName ? <strong>{sheetLabel}</strong> : "the selected sheet"} with
+              FGAC and your access rule is active. The agent can retry its request now.
+            </p>
+          </>
+        ) : (
+          <>
+            <h1 className="mb-2 text-xl font-bold text-foreground">
+              {fromApproval ? "Approved — one more step" : "Finish setting up sheet access"}
+            </h1>
+            <p className="mb-1 text-sm text-muted-foreground">
+              {fromApproval
+                ? <>Your FGAC rule for <strong>{sheetLabel}</strong> is saved, but Google hasn&apos;t shared the sheet itself with FGAC yet.</>
+                : <>FGAC has a rule for <strong>{sheetLabel}</strong>, but Google hasn&apos;t shared the sheet itself with FGAC yet.</>}
+            </p>
+            <p className="mb-5 text-sm text-muted-foreground">
+              Google only shares a sheet when you pick it in Google&apos;s own file
+              picker — that&apos;s the per-file permission FGAC runs on (nothing else
+              in your Drive is shared). Pick the sheet below and you&apos;re done.
+            </p>
+
+            {status === "picked_other" && (
+              <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground">
+                The sheet(s) you picked are now shared with FGAC — but none of them
+                matched the exact spreadsheet the agent asked for
+                {spreadsheetId ? <> (ID <code className="font-mono text-xs">{spreadsheetId}</code>)</> : null}.
+                If the agent guessed a wrong ID, that&apos;s fine: ask it to retry using
+                the sheet you just picked. Otherwise, pick the exact sheet again.
+              </div>
+            )}
+
+            <button
+              onClick={() => triggerAddSheets(spreadsheetId ?? undefined)}
+              disabled={pickerLoading || busy || status === "checking"}
+              className="w-full rounded-sm bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {status === "checking"
+                ? "Checking current access…"
+                : busy
+                  ? "Saving…"
+                  : pickerLoading
+                    ? "Opening Google Picker…"
+                    : "Pick the sheet in Google Picker"}
+            </button>
+            <p className="mt-2 text-xs text-subtle">
+              First time? Google will ask you to allow FGAC&apos;s file picker
+              (drive.file) and then bring you straight back here.
+            </p>
+          </>
+        )}
+      </div>
+
+      {status !== "verified" && (
+        <div className="mt-6 rounded-lg border border-border bg-card p-2.5">
+          <div className="px-1.5 pb-2 pt-1 text-sm font-semibold text-foreground">
+            Watch how it works (2 min)
+          </div>
+          <div className="relative aspect-video w-full overflow-hidden rounded-sm bg-surface-inverse">
+            <TrackedVideoEmbed src={SHEETS_DEMO_EMBED} title="FGAC Google Sheets demo" />
+          </div>
+        </div>
+      )}
+
+      <p className="mt-4 text-center text-xs text-subtle">
+        <Link href="/dashboard" className="underline hover:text-foreground">
+          Back to dashboard
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/dashboard/sheets-setup/SheetsGrantRecovery.tsx
+++ b/src/app/dashboard/sheets-setup/SheetsGrantRecovery.tsx
@@ -113,7 +113,7 @@ export function SheetsGrantRecovery({
             <h1 className="mb-2 text-xl font-bold text-foreground">
               {fromApproval ? "Approved — one more step" : "Finish setting up sheet access"}
             </h1>
-            <p className="mb-1 text-sm text-muted-foreground">
+            <p className="mb-1 text-sm text-muted-foreground [overflow-wrap:anywhere]">
               {fromApproval
                 ? <>Your FGAC rule for <strong>{sheetLabel}</strong> is saved, but Google hasn&apos;t shared the sheet itself with FGAC yet.</>
                 : <>FGAC has a rule for <strong>{sheetLabel}</strong>, but Google hasn&apos;t shared the sheet itself with FGAC yet.</>}
@@ -125,7 +125,7 @@ export function SheetsGrantRecovery({
             </p>
 
             {status === "picked_other" && (
-              <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground">
+              <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
                 The sheet(s) you picked are now shared with FGAC — but none of them
                 matched the exact spreadsheet the agent asked for
                 {spreadsheetId ? <> (ID <code className="font-mono text-xs">{spreadsheetId}</code>)</> : null}.

--- a/src/app/dashboard/sheets-setup/page.tsx
+++ b/src/app/dashboard/sheets-setup/page.tsx
@@ -1,0 +1,31 @@
+import { SheetsGrantRecovery } from "./SheetsGrantRecovery";
+
+/* ─── Sheets setup / grant recovery ──────────────────────────────────────
+   The landing spot whenever a sheets FGAC rule exists (or was just approved
+   via magic link) but Google has no drive.file grant for the spreadsheet —
+   the state every connector-launch user stranded in. Walks the user through
+   the ONE action that registers the grant (picking the sheet in the Google
+   Picker) with the demo video alongside.
+
+   Reached from: the magic-link approve flow (`from=approval`), the
+   dashboard's "needs Google access" chip, and the MCP stranded-sheet error.
+
+   The first-time drive.file consent redirect returns to this pathname with
+   `autoOpenPicker=true&pickerContext=<sid>` (and nothing else), so the sid
+   is restored from pickerContext on that leg. */
+
+export default async function SheetsSetupPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sid?: string; name?: string; from?: string; pickerContext?: string }>;
+}) {
+  const params = await searchParams;
+  const sid = params.sid || params.pickerContext || null;
+  return (
+    <SheetsGrantRecovery
+      spreadsheetId={sid}
+      resourceName={params.name || null}
+      fromApproval={params.from === "approval"}
+    />
+  );
+}

--- a/src/app/dashboard/useGooglePicker.ts
+++ b/src/app/dashboard/useGooglePicker.ts
@@ -88,7 +88,10 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?
         }
 
         // Return to the page the user is on, and re-open the picker there.
-        const params = new URLSearchParams({ autoOpenPicker: 'true' });
+        // Existing query params ride along — the approve page's signed token
+        // must survive the consent round-trip or the flow dead-ends.
+        const params = new URLSearchParams(window.location.search);
+        params.set('autoOpenPicker', 'true');
         if (context) params.set('pickerContext', context);
         const autoRedirectUrl = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
         let verificationUrl: string | undefined;
@@ -170,8 +173,12 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get('autoOpenPicker') === 'true') {
       const context = urlParams.get('pickerContext') ?? undefined;
-      // Clean up URL parameters without page reload
-      const newUrl = window.location.pathname;
+      // Consume only our params; anything else (e.g. the approve page's
+      // token) must survive the cleanup.
+      urlParams.delete('autoOpenPicker');
+      urlParams.delete('pickerContext');
+      const rest = urlParams.toString();
+      const newUrl = `${window.location.pathname}${rest ? `?${rest}` : ''}`;
       window.history.replaceState({}, document.title, newUrl);
       // Auto-launch picker; fromOAuthReturn tolerates scope-propagation lag
       openPickerFlow(context, true);

--- a/src/lib/approvalLinks.ts
+++ b/src/lib/approvalLinks.ts
@@ -8,7 +8,9 @@
  *
  * Security properties (QA capability 12):
  *   - HMAC-signed; any tampering invalidates the token
- *   - 15-minute expiry
+ *   - short expiry: 15 minutes, except sheets grants get 30 — approving a
+ *     sheet can include a Google Picker pick plus a first-time drive.file
+ *     consent round-trip, which real users don't finish in 15
  *   - single-use (jti recorded on consumption)
  *   - approval requires the OWNING user's signed-in session — the token
  *     carries the FGAC userId and the approve path re-checks it
@@ -21,6 +23,12 @@
 import * as jose from 'jose';
 
 export const APPROVAL_LINK_TTL_SECONDS = 15 * 60;
+export const SHEETS_APPROVAL_LINK_TTL_SECONDS = 30 * 60;
+
+/** Link lifetime in minutes for user-facing copy — keep messages honest. */
+export function approvalLinkMinutes(action: ApprovalAction['action']): number {
+  return action.startsWith('sheets') ? SHEETS_APPROVAL_LINK_TTL_SECONDS / 60 : APPROVAL_LINK_TTL_SECONDS / 60;
+}
 
 export type ApprovalAction =
   | { action: 'send_whitelist'; recipient: string }
@@ -52,8 +60,10 @@ export async function mintApprovalToken(
   userId: string,
   proxyKeyId: string,
   action: ApprovalAction,
-  ttlSeconds: number = APPROVAL_LINK_TTL_SECONDS, // overridable for tests only
+  ttlSecondsOverride?: number, // for tests only
 ): Promise<string> {
+  const ttlSeconds = ttlSecondsOverride
+    ?? (action.action.startsWith('sheets') ? SHEETS_APPROVAL_LINK_TTL_SECONDS : APPROVAL_LINK_TTL_SECONDS);
   const key = await signingKey();
   return new jose.SignJWT({ userId, proxyKeyId, ...action })
     .setProtectedHeader({ alg: 'HS256' })

--- a/src/lib/sheetsGrantCheck.ts
+++ b/src/lib/sheetsGrantCheck.ts
@@ -1,0 +1,60 @@
+import { clerkClient } from '@clerk/nextjs/server';
+
+/**
+ * Sheets access has two halves: the FGAC rule (our database) and the
+ * Google-side grant. The app never requests a Sheets OAuth scope — API access
+ * rides on per-file `drive.file` grants, which Google registers ONLY when the
+ * user picks the file in the Google Picker with our appId. An FGAC rule whose
+ * sheet was never picked passes policy but 403/404s at Google, which is
+ * exactly the trap the 2026-08 connector-launch cohort fell into (approve →
+ * retry → generic error → churn). This module is the single source of truth
+ * for "does Google actually let us reach this spreadsheet right now?".
+ */
+export type SheetsGrantState =
+  | { state: 'ok'; title: string | null }
+  // 403/404 from Google: no drive.file grant for this file (or the id is
+  // wrong — indistinguishable from outside, and the Picker fixes both).
+  | { state: 'missing' }
+  // Network error / 5xx / 429: verification could not run. Callers must
+  // degrade to "no warning", never alarm the user on Google's bad day.
+  | { state: 'unknown'; status?: number };
+
+export async function verifySheetsGrant(
+  token: string,
+  spreadsheetId: string,
+): Promise<SheetsGrantState> {
+  let res: Response;
+  try {
+    res = await fetch(
+      `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(spreadsheetId)}?fields=properties.title`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+  } catch {
+    return { state: 'unknown' };
+  }
+
+  if (res.ok) {
+    const data = await res.json().catch(() => null) as { properties?: { title?: string } } | null;
+    return { state: 'ok', title: data?.properties?.title ?? null };
+  }
+  if (res.status === 403 || res.status === 404) return { state: 'missing' };
+  return { state: 'unknown', status: res.status };
+}
+
+/**
+ * The signed-in owner's Google access token (same token the MCP path uses for
+ * the owner's own mailbox). Null when Google is not connected — for grant
+ * verification purposes that reads as `missing`, since the Picker flow is
+ * also the fix for a not-yet-connected account (it triggers consent first).
+ */
+export async function getOwnerGoogleToken(clerkUserId: string): Promise<string | null> {
+  try {
+    const client = await clerkClient();
+    // Un-prefixed provider id — the `oauth_` form is deprecated (see
+    // googleAccess.ts).
+    const tokens = await client.users.getUserOauthAccessToken(clerkUserId, 'google');
+    return tokens.data?.[0]?.token || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Why

PostHog showed the connector-launch cohort's sheets funnel was a dead end: every user who approved a sheets magic link then hit generic Google 404/403 errors on retry, and zero external users ever completed a successful sheets call. Root cause: approving created the FGAC rule but never the Google-side per-file `drive.file` grant, which only registers when the user picks the sheet in the Google Picker.

## What

- **Grant verification everywhere it matters** (`src/lib/sheetsGrantCheck.ts`): a metadata GET with the owner's token distinguishes ok / missing / unknown.
- **Picker-first approvals** (`SheetsApprovalFlow`): opening a sheets approval link verifies the grant; when missing, the Google Picker step (with the embedded Sheets demo video) comes BEFORE the approve button. Picking a different file than the agent's id becomes an explicit, server-verified substitution — rules are created only for picked ids Google confirms, so phantom rules can no longer exist.
- **Recovery page** (`/dashboard/sheets-setup`): picker + demo video + live re-verification, for rules stranded before this change (reached via dashboard chips and MCP error links).
- **Dashboard chips**: sheets rules whose sheet Google can't reach get "⚠ Needs Google access — finish setup".
- **Honest MCP errors**: post-policy Google 403/404 on sheets calls now explains the missing Google grant and links the setup page instead of "Check the ID and try again".
- **Link lifetime**: sheets approval links last 30 min (others 15) to fit the pick + first-time consent round-trip; single-use consumption moved so an abandoned pick never burns the link.
- **Analytics**: `sheets_grant_verification` (via link_open / magic_link) and `sheets_grant_recovered`; `approval_link_approved` gains `substituted`/`granted_count`.
- **QA**: new capability 17 (9 assertions) + agent runbook sections; capability 14 updated.

## Validation (local, isolated Neon branch, hosted-MCP runtime via OAuth DCR + curl)

Replicated the production failure sequence exactly, then verified: pick-first state (no approve control, link unconsumed), substitution end-to-end (rule for the picked sheet only, MCP success on it, clean denial on the wrong id), fast path (verified title, one-click), recovery page pick → verified → MCP retry success, and the full PostHog funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)