### PR TITLE
fix(sheets): settle drive.file grant race; measure pre-Clerk connector install funnel

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -36,8 +36,9 @@ keep internal/QA traffic out of the numbers.
 | `account_linked` | server (dashboard action) | `target_email`, `delegated`, `via` |
 | `approval_link_minted` | server (`/api/mcp`) | `action` |
 | `read_restriction_enforced` | server (`/api/mcp`) | `via` (tool name), `restriction` |
-| `sheets_grant_verification` | server (approve-page load via `/api/rules/verify-sheets-access`, and approval in `actions.ts`) | `result` (`ok`/`missing`/`unknown`), `via` (`link_open`/`magic_link`), `spreadsheet_id` |
+| `sheets_grant_verification` | server (approve-page load via `/api/rules/verify-sheets-access`, and approval in `actions.ts`) | `result` (`ok`/`missing`/`unknown`), `via` (`link_open`/`magic_link`/`post_approval`), `spreadsheet_id` |
 | `sheets_grant_recovered` | server (`/api/rules/verify-sheets-access`) | `spreadsheet_id` |
+| `connector_install_started` | server (`.well-known` OAuth discovery routes, `/api/mcp` auth layer) | `touchpoint` (`oauth_discovery`/`mcp_401`), `endpoint`, `reason` (`no_token`/`invalid_token`), `method`, `user_agent` |
 
 The two `sheets_grant_*` events instrument the **picker-first sheets
 approval funnel**: opening a sheets approval link verifies the Google-side
@@ -66,6 +67,24 @@ Unauthenticated calls attribute to the `anonymous-mcp` / `anonymous-proxy` perso
 > name (they read `$mcp_tool_name`). The old events still exist under the old
 > name — insights spanning the rename must query both. Nothing in this codebase
 > should ever emit `mcp_tool_call` again; QA capability 16 asserts this.
+
+**Failure detail (2026-08 grant-race fixes):** every non-OK Google response
+adds `error_status` (HTTP status, or `network`) to the `$mcp_tool_call` event.
+Sheets failures whose matching FGAC rule is fresh also carry
+`sheets_grant_age_seconds`, and when the post-approval grace retry engaged,
+`sheets_grace_retries` + `sheets_grace_recovered` — `recovered=true` volume is
+the direct measure of how often the drive.file propagation race would have
+surfaced an error to an agent.
+
+**`connector_install_started` is a rate metric, not an identity metric.** It
+fires anonymously (distinct_id `anonymous-mcp`) from the only FGAC-owned
+touchpoints that exist before a Clerk account: the OAuth discovery endpoints
+(`touchpoint=oauth_discovery`, recurs on reconnects) and unauthenticated MCP
+requests (`touchpoint=mcp_401`; `reason=no_token` on POST ≈ fresh install
+attempts, `invalid_token` ≈ token-expiry noise from established clients).
+Estimate Clerk-step abandonment by comparing daily `mcp_401{no_token,POST}`
+volume against `mcp_connection_created`. Filter obvious crawlers by
+`user_agent`.
 
 Payload capture is deliberately **off**: we never send `$mcp_parameters` or
 `$mcp_response` (they would carry customer mail/sheet content into PostHog).

--- a/docs/implementation_plans/sheets-grant-race-install-funnel_v1.md
+++ b/docs/implementation_plans/sheets-grant-race-install-funnel_v1.md
@@ -1,0 +1,107 @@
+# Sheets grant-race fixes + connector install-funnel measurement — v1
+
+Branch: `claude/sheets-grant-race-install-funnel`
+
+## Problem
+
+PostHog timeline analysis (2026-08-18) of the post-PR#71 Sheets errors showed two residual
+failure shapes, plus a measurement blind spot at the very top of the connector funnel:
+
+1. **Grant-propagation race.** Google's per-file `drive.file` grant is eventually
+   consistent. Even though the picker-first approval verifies the grant with the owner's
+   token before creating rules, the agent's next MCP call can still 403/404 for
+   ~10–60 s (observed: one error immediately post-approval, success seconds later, for
+   three separate users; one user's MCP path 403'd five minutes after the dashboard-side
+   verify passed).
+2. **No error detail.** `$mcp_tool_call` failures carry only `outcome='error'` — no HTTP
+   status, no grant age. Diagnosis required event-timeline archaeology.
+3. **Invisible pre-auth funnel.** The Claude connector flow authenticates on Clerk's
+   hosted pages; people who click "Add connector" but never finish Clerk sign-up leave
+   zero events anywhere. We cannot even estimate that abandonment rate.
+
+## Changes
+
+### Fix 1 — settle the grant before telling the user "retry now"
+
+- `approveMagicLink` (src/app/dashboard/actions.ts) returns the granted spreadsheet id
+  (`grantedSpreadsheetId`) on successful sheets approvals.
+- The approve page's success redirect carries `&sid=` for sheets approvals; the
+  `result=ok` card becomes a client component (`ApprovedSettling`) that polls
+  `GET /api/rules/verify-sheets-access?sid=…&context=post_approval` every 2 s (max 15 s):
+  - verifying → "Approved — confirming Google has finished sharing the sheet…"
+  - `ok` → "✓ Approved & verified with Google. The agent can retry now."
+  - timeout/`missing` → approved-but-unconfirmed note linking to
+    `/dashboard/sheets-setup?sid=…` (the existing recovery loop).
+- `verify-sheets-access` captures `sheets_grant_verification` with `via: 'post_approval'`
+  for this context, mirroring the existing `link_open` capture.
+
+Net effect: the user stays on the page through most of the propagation window and is
+never told "retry now" on an unconfirmed grant.
+
+### Fix 2 — server-side grace retry on fresh 403/404 (the load-bearing fix)
+
+- `checkSheetsPermission` (src/app/api/mcp/route.ts) additionally returns
+  `newestRuleAt` — the max `createdAt` of the rules that matched the spreadsheet.
+- New `sheetsFetchWithGrace(...)`: runs `sheetsFetch`; when the result is 403/404 AND the
+  matching rule is younger than 120 s, waits 3.5 s and retries, up to 2 times, before
+  returning the failure. Applied to all five `sheets_*` tools and the raw
+  `google_api_*` sheets path.
+- `export const maxDuration = 60` on the MCP route so the added ≤7 s cannot hit the
+  function timeout.
+- Retry attempts are recorded on the analytics event (`sheets_grace_retries`).
+
+Net effect: an agent that retries (or first-calls) inside the propagation window gets a
+slightly slower success instead of an error. Outside the 120 s window behavior is
+unchanged — a genuine missing grant still errors immediately with the setup-page message.
+
+### Fix 3 — error detail on tool-call analytics
+
+- `googleFetch` records `error_status` (HTTP status, or `'network'`) into the tool-call
+  AsyncLocalStorage bag on every non-OK Google response → rides into `$mcp_tool_call`.
+- `sheetsFetchWithGrace` records `sheets_grant_age_seconds` (age of the newest matching
+  rule) on sheets failures, and `sheets_grace_retries` when retries ran.
+
+### Option 1 — connector install-funnel measurement (pre-Clerk)
+
+Two FGAC-owned touchpoints exist before any Clerk account: the OAuth discovery
+endpoints and the unauthenticated MCP request that triggers the 401 + WWW-Authenticate
+handshake. Both now capture an anonymous server event `connector_install_started`
+(distinct_id `anonymous-mcp`, already excluded from user metrics):
+
+- `.well-known/oauth-protected-resource/mcp` and `.well-known/oauth-authorization-server`
+  GETs → `{ touchpoint: 'oauth_discovery', endpoint, user_agent }`.
+- MCP request with missing/invalid bearer → `{ touchpoint: 'mcp_401',
+  reason: 'no_token' | 'invalid_token', user_agent, method }`.
+
+Interpretation notes (documented in docs/analytics.md): this is a **rate** metric, not an
+identity metric. `reason='no_token'` on POST approximates fresh install attempts;
+`invalid_token` is mostly expiry/refresh noise; discovery fetches recur on
+reconnects. Compare daily `no_token` POST volume against `mcp_connection_created` to
+estimate Clerk-step abandonment.
+
+## Explicitly out of scope
+
+Self-hosting the Clerk sign-in page (separate investigation, running in parallel);
+no-auth demo toolset (needs a product spike).
+
+## Test plan
+
+- `npm run build` + `npx tsc --noEmit` + lint clean.
+- Local dev server, dev Neon branch, dev Clerk:
+  - Discovery endpoints return unchanged JSON; `connector_install_started` appears in
+    PostHog with `environment='development'`.
+  - Unauthenticated `POST /api/mcp` still returns 401 + WWW-Authenticate; event fires.
+  - Authenticated MCP call (QA account) unchanged; no stray install events.
+  - Sheets approval flow end-to-end via browser (QA account): deny → link → picker →
+    approve → settling state → verified card. Rules created identically to before.
+  - Sheets tool call with fresh rule: force a 404 (wrong id) → confirm no grace retry
+    for old rules, grace retry engages only for fresh rules (observable via event props
+    and server logs).
+  - Gmail read/list flows unchanged (error_status only added on failures).
+- Preview: /deploy-pr-preview, re-run discovery + 401 checks against the preview URL,
+  run the applicable QA_Acceptance_Test sheets capability.
+
+## Rollback
+
+All changes are additive (new event, new props, retry-on-failure path, settling UI on
+top of the existing ok card). Revert the branch; no schema or data migrations.

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -12,9 +12,22 @@ import {
   authServerMetadataHandlerClerk,
   metadataCorsOptionsRequestHandler,
 } from '@clerk/mcp-tools/next';
+import { captureServerEvent } from '@/lib/posthogServer';
 
 const handler = authServerMetadataHandlerClerk();
 const corsHandler = metadataCorsOptionsRequestHandler();
 
-export const GET = handler;
+// Install-funnel measurement: fetched when a client begins the connector
+// OAuth handshake — pre-Clerk-account visibility. Anonymous rate metric
+// (recurs on reconnects). The Clerk helper handles the response itself.
+const trackedGet = (req: Request) => {
+  captureServerEvent('anonymous-mcp', 'connector_install_started', {
+    touchpoint: 'oauth_discovery',
+    endpoint: 'authorization-server',
+    user_agent: req.headers.get('user-agent') ?? undefined,
+  });
+  return handler(req);
+};
+
+export const GET = trackedGet;
 export const OPTIONS = corsHandler;

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -26,7 +26,7 @@ const trackedGet = (req: Request) => {
     endpoint: 'authorization-server',
     user_agent: req.headers.get('user-agent') ?? undefined,
   });
-  return handler(req);
+  return handler();
 };
 
 export const GET = trackedGet;

--- a/src/app/.well-known/oauth-protected-resource/mcp/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/mcp/route.ts
@@ -15,8 +15,18 @@ import {
   corsHeaders,
 } from '@clerk/mcp-tools/server';
 import { metadataCorsOptionsRequestHandler } from '@clerk/mcp-tools/next';
+import { captureServerEvent } from '@/lib/posthogServer';
 
 export function GET(req: Request) {
+  // Install-funnel measurement: clients fetch this metadata when they begin
+  // the connector OAuth handshake — the earliest FGAC-owned touchpoint before
+  // any Clerk account exists. Anonymous rate metric (recurs on reconnects).
+  captureServerEvent('anonymous-mcp', 'connector_install_started', {
+    touchpoint: 'oauth_discovery',
+    endpoint: 'protected-resource',
+    user_agent: req.headers.get('user-agent') ?? undefined,
+  });
+
   const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
   if (!publishableKey) {
     return Response.json({ error: 'server_misconfigured' }, { status: 500 });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -492,7 +492,11 @@ async function withSheetsGrace(
   }
   if (retries > 0) {
     addToolCallProps({ sheets_grace_retries: retries, sheets_grace_recovered: result.ok });
-    if (result.ok) console.log(`[MCP] Sheets grace retry recovered after ${retries} attempt(s) (rule age ${grantAgeSeconds()}s)`);
+    if (result.ok) {
+      // Don't let the first attempt's transient status ride on a success event.
+      addToolCallProps({ error_status: undefined });
+      console.log(`[MCP] Sheets grace retry recovered after ${retries} attempt(s) (rule age ${grantAgeSeconds()}s)`);
+    }
   }
   return result;
 }

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -407,6 +407,7 @@ async function googleFetch(
       body,
     });
   } catch (err) {
+    addToolCallProps({ error_status: 'network' });
     return { ok: false, error: `❌ Could not reach the Google API: ${err instanceof Error ? err.message : 'network error'}.` };
   }
 
@@ -415,6 +416,7 @@ async function googleFetch(
   try { data = text ? JSON.parse(text) : {}; } catch { /* non-JSON body: keep text */ }
 
   if (!res.ok) {
+    addToolCallProps({ error_status: res.status });
     return { ok: false, error: describeGoogleError(res.status, data, targetEmail), status: res.status };
   }
   return { ok: true, data };
@@ -450,6 +452,51 @@ async function sheetsFetch(token: string, path: string, method = 'GET', body?: s
   return googleFetch(`https://sheets.googleapis.com/v4/spreadsheets/${path}`, token, method, body, targetEmail);
 }
 
+/** How recently a matching sheets rule must have been created for a 403/404 to
+ * be treated as grant propagation rather than a genuinely missing grant. */
+const SHEETS_GRACE_WINDOW_MS = 120_000;
+const SHEETS_GRACE_RETRIES = 2;
+const SHEETS_GRACE_DELAY_MS = 3_500;
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * sheetsFetch with a propagation grace window. Approval-time verification
+ * passes with the owner's token, yet the MCP call path can still see 403/404
+ * for tens of seconds while Google's per-file drive.file grant settles
+ * (observed on three launch-cohort users: one error immediately after
+ * approval, success seconds later). When the matching rule is younger than
+ * the grace window, a 403/404 is retried with a short pause instead of being
+ * surfaced — the agent sees a slower success, not an error. Rules older than
+ * the window fail fast exactly as before.
+ */
+async function withSheetsGrace(
+  perm: SheetsPermission,
+  doFetch: () => Promise<GoogleFetchResult>,
+): Promise<GoogleFetchResult> {
+  let result = await doFetch();
+  const ruleAt = perm.allowed ? perm.newestRuleAt : null;
+  if (!ruleAt) return result;
+
+  const grantAgeSeconds = () => Math.round((Date.now() - ruleAt.getTime()) / 1000);
+  const inGrace = () => Date.now() - ruleAt.getTime() < SHEETS_GRACE_WINDOW_MS;
+  const retriable = () => !result.ok && (result.status === 403 || result.status === 404);
+
+  if (retriable()) addToolCallProps({ sheets_grant_age_seconds: grantAgeSeconds() });
+
+  let retries = 0;
+  while (retriable() && inGrace() && retries < SHEETS_GRACE_RETRIES) {
+    await sleep(SHEETS_GRACE_DELAY_MS);
+    retries += 1;
+    result = await doFetch();
+  }
+  if (retries > 0) {
+    addToolCallProps({ sheets_grace_retries: retries, sheets_grace_recovered: result.ok });
+    if (result.ok) console.log(`[MCP] Sheets grace retry recovered after ${retries} attempt(s) (rule age ${grantAgeSeconds()}s)`);
+  }
+  return result;
+}
+
 async function checkSheetsPermission(userId: string, proxyKeyId: string, spreadsheetId: string, isMutating: boolean) {
   const allRules = await db.select().from(accessRules).where(eq(accessRules.userId, userId));
   const keyAssignments = await db.select().from(keyRuleAssignments).where(eq(keyRuleAssignments.proxyKeyId, proxyKeyId));
@@ -480,7 +527,13 @@ async function checkSheetsPermission(userId: string, proxyKeyId: string, spreads
     }
   }
 
-  return { allowed: true as const };
+  // Newest matching rule's age drives the post-approval grace retry: a rule
+  // created seconds ago means Google's drive.file grant may still be
+  // propagating even though approval-time verification passed.
+  const newestRuleAt = sheetsRules.reduce<Date | null>(
+    (acc, r) => (!acc || r.createdAt > acc ? r.createdAt : acc), null,
+  );
+  return { allowed: true as const, newestRuleAt };
 }
 
 type SheetsPermission = Awaited<ReturnType<typeof checkSheetsPermission>>;
@@ -709,7 +762,7 @@ async function executeRawGoogleCall(
     if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, cls.spreadsheetId, cls.isMutating));
 
     const url = `https://sheets.googleapis.com/${cleanPath.replace(/^sheets\//, '')}`;
-    const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
+    const result = await withSheetsGrace(perm, () => googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail));
     if (!result.ok) return sheetsErrorResult(result, cls.spreadsheetId);
     return jsonResult(result.data);
   }
@@ -949,7 +1002,7 @@ const handler = createMcpHandler(
         const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, spreadsheetId, false);
         if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, false));
 
-        const result = await sheetsFetch(resolved.token, `${spreadsheetId}`, 'GET', undefined, resolved.targetEmail);
+        const result = await withSheetsGrace(perm, () => sheetsFetch(resolved.token, `${spreadsheetId}`, 'GET', undefined, resolved.targetEmail));
         if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
@@ -974,7 +1027,7 @@ const handler = createMcpHandler(
         if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, spreadsheetId, false));
 
         const encodedRange = encodeURIComponent(range);
-        const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`, 'GET', undefined, resolved.targetEmail);
+        const result = await withSheetsGrace(perm, () => sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}`, 'GET', undefined, resolved.targetEmail));
         if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
@@ -1001,7 +1054,7 @@ const handler = createMcpHandler(
 
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values, range });
-        const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}?valueInputOption=USER_ENTERED`, 'PUT', body, resolved.targetEmail);
+        const result = await withSheetsGrace(perm, () => sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}?valueInputOption=USER_ENTERED`, 'PUT', body, resolved.targetEmail));
         if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
@@ -1028,7 +1081,7 @@ const handler = createMcpHandler(
 
         const encodedRange = encodeURIComponent(range);
         const body = JSON.stringify({ values });
-        const result = await sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body, resolved.targetEmail);
+        const result = await withSheetsGrace(perm, () => sheetsFetch(resolved.token, `${spreadsheetId}/values/${encodedRange}:append?valueInputOption=USER_ENTERED`, 'POST', body, resolved.targetEmail));
         if (!result.ok) return sheetsErrorResult(result, spreadsheetId);
         return jsonResult(result.data);
       }
@@ -1242,7 +1295,7 @@ async function verifyClerkJwtDirect(token: string) {
   }
 }
 
-const verifyMcpAuth = async (_req: Request, bearerToken?: string) => {
+const verifyMcpAuth = async (req: Request, bearerToken?: string) => {
   let authInfo: ReturnType<typeof verifyClerkToken> | Awaited<ReturnType<typeof verifyClerkJwtDirect>> | undefined;
 
   // Strategy 1: Try Clerk's built-in auth() + verifyClerkToken
@@ -1258,6 +1311,22 @@ const verifyMcpAuth = async (_req: Request, bearerToken?: string) => {
   if (!authInfo && bearerToken) {
     console.log('[MCP] Falling back to direct JWT verification');
     authInfo = await verifyClerkJwtDirect(bearerToken);
+  }
+
+  // Install-funnel measurement (pre-Clerk visibility): an unauthenticated MCP
+  // request is the first FGAC-owned touchpoint when a client adds the
+  // connector — the 401 issued below is what sends it into OAuth discovery.
+  // Anonymous by design (distinct_id is already excluded from user metrics);
+  // this is a rate metric, not an identity metric. reason='no_token' on POST
+  // approximates fresh install attempts; 'invalid_token' is mostly token
+  // expiry/refresh noise from established clients.
+  if (!authInfo) {
+    captureServerEvent('anonymous-mcp', 'connector_install_started', {
+      touchpoint: 'mcp_401',
+      reason: bearerToken ? 'invalid_token' : 'no_token',
+      method: req.method,
+      user_agent: req.headers.get('user-agent') ?? undefined,
+    });
   }
 
   // Eagerly create/touch agent_connection on ANY authenticated request
@@ -1295,3 +1364,7 @@ const authedHandler = experimental_withMcpAuth(
 export const POST = authedHandler;
 export const GET = authedHandler;
 export const DELETE = authedHandler;
+
+// Headroom for the sheets grant-propagation grace retries (≤ ~7 s added on
+// top of normal Google latency) — never let them race the function timeout.
+export const maxDuration = 60;

--- a/src/app/api/rules/verify-sheets-access/route.ts
+++ b/src/app/api/rules/verify-sheets-access/route.ts
@@ -42,10 +42,12 @@ export async function GET(request: NextRequest) {
         captureServerEvent(clerkUserId, 'sheets_grant_recovered', { spreadsheet_id: sid });
       }
       // link_open = the approve page checking the grant before showing the
-      // flow — the top of the picker-first funnel.
-      if (context === 'link_open') {
+      // flow — the top of the picker-first funnel. post_approval = the
+      // success card confirming the grant settled before telling the user
+      // "the agent can retry now" (grant-race fix).
+      if (context === 'link_open' || context === 'post_approval') {
         captureServerEvent(clerkUserId, 'sheets_grant_verification', {
-          result: result.state, via: 'link_open', spreadsheet_id: sid,
+          result: result.state, via: context, spreadsheet_id: sid,
         });
       }
       return NextResponse.json({ spreadsheetId: sid, ...result });

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -648,6 +648,11 @@ export type MagicApprovalResult =
        * grant for the sheet yet — the approve page must route the user into
        * the Picker recovery flow instead of claiming the agent can retry. */
       needsSheetsGrant?: { spreadsheetId: string; resourceName?: string };
+      /** Set on successful sheets approvals: the primary spreadsheet a rule
+       * was created for. The approve page's success card polls the Google
+       * grant for this id before telling the user "the agent can retry now"
+       * (drive.file grants are eventually consistent — see sheetsGrantCheck). */
+      grantedSpreadsheetId?: string;
     }
   | { ok: false; reason: string };
 
@@ -782,6 +787,7 @@ export async function approveMagicLink(
       const level = readWrite ? "read & write" : "read-only";
       return {
         ok: true,
+        grantedSpreadsheetId: verified[0].id,
         description: substituted
           ? `Granted ${level} access to ${names}. That's the sheet you picked — not the ID the agent originally sent, which you don't appear to have. The agent will find the right sheet in its permissions.`
           : `Granted ${level} access to ${names}.`,
@@ -815,6 +821,9 @@ export async function approveMagicLink(
         },
       };
     }
+    captureServerEvent(dbUser.clerkUserId, "approval_link_approved", { action: p.action });
+    revalidatePath("/dashboard");
+    return { ok: true, description: describeApproval(p), grantedSpreadsheetId: p.spreadsheetId };
   } else {
     return { ok: false, reason: "This approval link is malformed." };
   }

--- a/src/app/dashboard/approve/ApprovedSettling.tsx
+++ b/src/app/dashboard/approve/ApprovedSettling.tsx
@@ -70,7 +70,7 @@ export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: st
       <div data-testid="approved-verified">
         <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ Approved &amp; verified with Google</h1>
         <p className="text-sm text-muted-foreground">
-          {message} The agent can retry its request now. You can review or
+          {message}{" "}The agent can retry its request now. You can review or
           remove this grant any time from your dashboard rules.
         </p>
       </div>
@@ -81,7 +81,7 @@ export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: st
     <div data-testid="approved-unconfirmed">
       <h1 className="mb-2 text-xl font-bold text-foreground">✓ Approved — one more step may be needed</h1>
       <p className="text-sm text-muted-foreground">
-        {message} However, Google hasn&apos;t confirmed the sheet is shared with
+        {message}{" "}However, Google hasn&apos;t confirmed the sheet is shared with
         FGAC yet. This usually settles within a minute — if the agent still
         gets an error, finish the share on the{" "}
         <Link

--- a/src/app/dashboard/approve/ApprovedSettling.tsx
+++ b/src/app/dashboard/approve/ApprovedSettling.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 15_000;
+
+type SettleState = "settling" | "verified" | "unconfirmed";
+
+/**
+ * Post-approval settling check for sheets grants (grant-race fix, 2026-08).
+ *
+ * Approval-time verification passes with the owner's token, but Google's
+ * per-file drive.file grant is eventually consistent: the agent's very next
+ * call could still 403 for ~10-60 s ("approved → one error → success" was the
+ * launch cohort's most common post-fix failure). Instead of telling the user
+ * "the agent can retry now" the instant the rule is written, this card keeps
+ * them on the page while re-verifying the grant, and only claims success once
+ * a live test read against Google passes. If Google still hasn't settled
+ * after 15 s, it says so honestly and routes to the recovery page.
+ */
+export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: string; message: string }) {
+  const [state, setState] = useState<SettleState>("settling");
+  const startedAt = useRef(Date.now());
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      try {
+        const r = await fetch(
+          `/api/rules/verify-sheets-access?sid=${encodeURIComponent(spreadsheetId)}&context=post_approval`,
+        );
+        const data = await r.json();
+        if (cancelled) return;
+        if (data.state === "ok") {
+          setState("verified");
+          return;
+        }
+      } catch { /* transient — keep polling until the timeout */ }
+      if (cancelled) return;
+      if (Date.now() - startedAt.current >= POLL_TIMEOUT_MS) {
+        setState("unconfirmed");
+        return;
+      }
+      timer = setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    void poll();
+    return () => { cancelled = true; if (timer) clearTimeout(timer); };
+  }, [spreadsheetId]);
+
+  if (state === "settling") {
+    return (
+      <div data-testid="approved-settling">
+        <h1 className="mb-2 text-xl font-bold text-foreground">✓ Approved</h1>
+        <p className="text-sm text-muted-foreground">{message}</p>
+        <p className="mt-3 flex items-center gap-2 text-sm text-muted-foreground" role="status">
+          <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-border border-t-foreground" aria-hidden="true" />
+          Confirming Google has finished sharing the sheet…
+        </p>
+      </div>
+    );
+  }
+
+  if (state === "verified") {
+    return (
+      <div data-testid="approved-verified">
+        <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ Approved &amp; verified with Google</h1>
+        <p className="text-sm text-muted-foreground">
+          {message} The agent can retry its request now. You can review or
+          remove this grant any time from your dashboard rules.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="approved-unconfirmed">
+      <h1 className="mb-2 text-xl font-bold text-foreground">✓ Approved — one more step may be needed</h1>
+      <p className="text-sm text-muted-foreground">
+        {message} However, Google hasn&apos;t confirmed the sheet is shared with
+        FGAC yet. This usually settles within a minute — if the agent still
+        gets an error, finish the share on the{" "}
+        <Link
+          href={`/dashboard/sheets-setup?sid=${encodeURIComponent(spreadsheetId)}&from=approval`}
+          className="underline hover:text-foreground"
+        >
+          sheets setup page
+        </Link>.
+      </p>
+    </div>
+  );
+}

--- a/src/app/dashboard/approve/page.tsx
+++ b/src/app/dashboard/approve/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { verifyApprovalToken, describeApproval, approvalLinkMinutes } from "@/lib/approvalLinks";
 import { approveMagicLink } from "../actions";
 import { SheetsApprovalFlow } from "./SheetsApprovalFlow";
+import { ApprovedSettling } from "./ApprovedSettling";
 
 /* ─── Magic-link approval page (connector-growth Phase C) ────────────────
    Reached from a signed, single-use link embedded in an agent's denial (or
@@ -33,11 +34,23 @@ function Card({ children }: { children: React.ReactNode }) {
 export default async function ApprovePage({
   searchParams,
 }: {
-  searchParams: Promise<{ token?: string; result?: string; message?: string }>;
+  searchParams: Promise<{ token?: string; result?: string; message?: string; sid?: string }>;
 }) {
   const params = await searchParams;
 
   if (params.result === "ok") {
+    // Sheets approvals settle asynchronously on Google's side — verify the
+    // grant is live before claiming the agent can retry (grant-race fix).
+    if (params.sid) {
+      return (
+        <Card>
+          <ApprovedSettling
+            spreadsheetId={params.sid}
+            message={params.message || "The permission has been granted."}
+          />
+        </Card>
+      );
+    }
     return (
       <Card>
         <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ Approved</h1>
@@ -107,7 +120,10 @@ export default async function ApprovePage({
         if (result.needsSheetsGrant.resourceName) q.set("name", result.needsSheetsGrant.resourceName);
         redirect(`/dashboard/sheets-setup?${q.toString()}`);
       }
-      redirect(`/dashboard/approve?result=ok&message=${encodeURIComponent(result.description)}`);
+      const settle = result.grantedSpreadsheetId
+        ? `&sid=${encodeURIComponent(result.grantedSpreadsheetId)}`
+        : "";
+      redirect(`/dashboard/approve?result=ok&message=${encodeURIComponent(result.description)}${settle}`);
     }
     redirect(`/dashboard/approve?result=error&message=${encodeURIComponent(result.reason)}`);
   }


### PR DESCRIPTION
## What

Three fixes for the residual Sheets failures observed in PostHog after PR #71, plus top-of-funnel measurement for connector installs that never reach a Clerk account.

### 1. Verify-before-confirm on the approval page
The approve page's success card for Sheets grants now polls the Google-side grant (`verify-sheets-access?context=post_approval`) and only tells the user "the agent can retry now" once a live test read passes. Timeout after 15 s falls back to an honest "one more step may be needed" card linking to the sheets-setup recovery page.

### 2. Grace-window retry on fresh 403/404 (the load-bearing fix)
Google's per-file `drive.file` grant is eventually consistent: approval-time verification passes, yet the agent's next MCP call can still 403/404 for tens of seconds (observed as approve → one error → success on three launch-cohort users). When the matching sheets rule is younger than 120 s, the MCP route now retries the Google call up to 2× with 3.5 s pauses before surfacing an error. Older rules fail fast exactly as before. `maxDuration=60` added for headroom.

### 3. Failure instrumentation
- `error_status` (HTTP status or `network`) on every failed Google call, riding into `$mcp_tool_call`
- `sheets_grant_age_seconds`, `sheets_grace_retries`, `sheets_grace_recovered` on sheets failures/retries
- `sheets_grant_verification` now also fires with `via=post_approval`

### 4. `connector_install_started` (anonymous rate metric)
Fires from the only FGAC-owned touchpoints that exist before a Clerk account: the OAuth discovery endpoints (`touchpoint=oauth_discovery`) and unauthenticated MCP requests (`touchpoint=mcp_401`, `reason=no_token|invalid_token`). Comparing daily `mcp_401{no_token,POST}` volume against `mcp_connection_created` estimates Clerk-step abandonment — previously invisible.

## Validation (local)

- `tsc --noEmit`, lint, and production build clean
- Discovery endpoints serve unchanged metadata; 401 + WWW-Authenticate handshake intact for missing and invalid tokens
- All new event shapes verified arriving in PostHog (dev environment) with correct properties
- Approve page: plain (Gmail) success card unchanged; sheets settling → verified/unconfirmed states render; recovery link works
- Dashboard + sheets-setup recovery page regression-checked in the browser

Preview validation to follow. Docs: `docs/analytics.md` updated; plan in `docs/implementation_plans/sheets-grant-race-install-funnel_v1.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)