### PR TITLE
feat(mcp): record attachment payload size on gmail_get_attachment outcomes

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -930,8 +930,15 @@ const handler = createMcpHandler(
         if (!attachmentResult.ok) return errorResult(attachmentResult.error);
 
         const attachment = attachmentResult.data as { size?: number; data?: string };
-        if (attachment.data && attachment.data.length > MAX_ATTACHMENT_CHARS) {
-          const approxKb = Math.round((attachment.data.length * 3) / 4 / 1024);
+        // Size observability: MCP clients impose their own tool-result caps
+        // (Claude Code rejects results over ~25k tokens ≈ 75k base64 chars),
+        // so a "success" here can still be discarded client-side. Recording
+        // the payload size on every outcome lets analytics separate real
+        // successes from ones that likely died in the client.
+        const attachmentChars = attachment.data?.length ?? 0;
+        const approxKb = Math.round((attachmentChars * 3) / 4 / 1024);
+        addToolCallProps({ attachment_chars: attachmentChars, attachment_kb: approxKb });
+        if (attachmentChars > MAX_ATTACHMENT_CHARS) {
           return textResult(`⚠️ Attachment is ~${approxKb} KB, which exceeds the ~150 KB limit for MCP responses. Ask the user to retrieve it directly from Gmail.`);
         }
         return jsonResult(attachment);


### PR DESCRIPTION
## Why

Investigating reported attachment failures in prod: PostHog shows 5 `gmail_get_attachment` errors in 30 days, all Gmail API rejections (fast, sub-700ms, size guard never fired) and all predating the `error_status` instrumentation that shipped Aug 18 — so future occurrences will self-label.

What analytics *cannot* see today is the silent client-side failure mode: the server allows up to 200k base64 chars (~150 KB decoded), but MCP clients impose their own tool-result caps (Claude Code rejects results over ~25k tokens ≈ 75k base64 chars). An attachment in that zone is recorded as a server-side success while the user's client discards it.

## What

Capture `attachment_chars` and `attachment_kb` as `$mcp_tool_call` props on both the success and over-limit paths of `gmail_get_attachment`, so PostHog can show how many "successes" land in the client-rejection zone and whether the 150 KB cap needs to come down.

## Validation

- `tsc --noEmit` and `eslint` clean.
- No behavior change to responses; analytics props only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)