### PR TITLE
feat: Google Docs support — per-document access control (sheets pattern)

### DIFF
--- a/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
+++ b/docs/QA_Acceptance_Test/agents/01_hosted_mcp.md
@@ -237,6 +237,20 @@ curl -s $BASE_URL/api/mcp -X POST \
   `qa-posthog-events.ts --event sheets_grant_verification` and
   `--event sheets_grant_recovered` scoped to the run window.
 
+## Capability: Docs Management (→ capabilities/19_docs_management.md)
+
+- A5–A10: `tools/call` via curl on `docs_read_document` / `docs_append_text` /
+  `docs_replace_text` / `google_api_get` (`v1/documents/<id>`) /
+  `google_api_modify` (`:batchUpdate`, and POST `v1/documents` for the
+  auto-grant), using the setup doc's exposed + external docs fixtures.
+- A11: proxy-route probes with the profile's `sk_proxy_` bearer against
+  `$BASE_URL/api/proxy/v1/documents/...` and `.../drive/v3/files/<doc id>`.
+- A1–A4, A12: browser assertions via `/browser-agent` (picker iframe caveats
+  identical to capability 09; app-API seam is `POST /api/rules/grant-docs-access`;
+  full-fidelity picks via the Playwright CDP path).
+
+---
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/agents/02_claude_code_mcp.md
+++ b/docs/QA_Acceptance_Test/agents/02_claude_code_mcp.md
@@ -184,6 +184,18 @@ tmux kill-session -t fgac-qa
 - A4 retry + A8 events: retry via this MCP connection; events via the
   capability-16 script with `--environment development`.
 
+## Capability: Docs Management (→ capabilities/19_docs_management.md)
+
+- Drive the docs tools conversationally through Claude Code MCP: ask for a
+  read of the exposed fixture doc (expect content), the external doc (expect
+  the FGAC denial + docs_expose link relayed verbatim), an append and a
+  replace under each permission level, and a raw `v1/documents` POST for the
+  auto-grant assertion (A10).
+- Dashboard/browser halves (A1–A4, A12) run via `/browser-agent` per
+  capability 09's harness note, docs variant (`grant-docs-access` seam).
+
+---
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/agents/03_claude_code_cli.md
+++ b/docs/QA_Acceptance_Test/agents/03_claude_code_cli.md
@@ -169,6 +169,17 @@ No tmux sessions to clean up. Results are saved to `test/qa-envs/cc-cli/evals/re
   `skip` here with reason "browser assertions covered by 01_hosted_mcp").
 - A4 retry: re-run the eval post-recovery → success payload in transcript.
 
+## Capability: Docs Management (→ capabilities/19_docs_management.md)
+
+- Headless `claude -p` evals invoking the docs tools through the local MCP
+  config: read exposed fixture (A7), denied external doc with docs_expose
+  link (A6), append/replace level checks (A8), block (A9), create/auto-grant
+  (A10). Proxy assertions (A11) via the scripts' curl helpers.
+- Browser halves (A1–A4, A12) are executed once per run via `/browser-agent`
+  (shared with the other environments).
+
+---
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/agents/04_openclaw.md
+++ b/docs/QA_Acceptance_Test/agents/04_openclaw.md
@@ -148,6 +148,17 @@ docker compose -f test/qa-envs/openclaw/docker-compose.yml down
 - A2–A6: browser assertions — cover via 01_hosted_mcp or `skip` with reason.
 - A4 retry: repeat the OpenClaw task after recovery → success.
 
+## Capability: Docs Management (→ capabilities/19_docs_management.md)
+
+- From the OpenClaw container, exercise docs_read_document / docs_append_text /
+  docs_replace_text and the raw documents calls against the connected FGAC MCP
+  server; assert denials carry the docs_expose/docs_write links (A6, A8) and
+  reads/writes succeed per rule level (A7, A8).
+- Browser/dashboard halves (A1–A4, A12) via `/browser-agent` outside the
+  container, as with sheets.
+
+---
+
 ## Capability: Analytics Events (→ capabilities/16_analytics_events.md)
 
 > Run LAST — it inspects the PostHog events the capabilities above generated.

--- a/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
+++ b/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
@@ -34,6 +34,10 @@
   the backstop). With the standard grant, drive.file limits results to
   picked/app-created files. The `$mcp_tool_call` event carries
   `raw_api_passthrough: true` and `raw_api_family: 'drive/v3'`.
+- **No longer passthrough**: the `documents` family graduated to enforced
+  per-document rules when Google Docs support landed — a raw
+  `v1/documents/<id>` call must be FGAC-classified (capability 19 A6), never
+  `raw_api_passthrough`. Sheets and Docs are both enforced families now.
 
 ### A4: Non-send Gmail write is denied
 - `google_api_modify` with path `gmail/v1/users/me/messages/<any-id>/modify`

--- a/docs/QA_Acceptance_Test/capabilities/15_request_access_tool.md
+++ b/docs/QA_Acceptance_Test/capabilities/15_request_access_tool.md
@@ -33,9 +33,17 @@
 - **Expected**: The request link names the spreadsheet; after approval the
   append succeeds; before approval it was denied
 
+### A7: Docs access via request_access mirrors the sheets flows
+- `request_access` with `type=docs_read` and a `documentId` (and again with
+  `type=docs_write` on a Read-only doc)
+- **Expected**: Mints a single-use `docs_expose` / `docs_write` link naming
+  the document (30-minute TTL); nothing is granted until the owner approves;
+  after approval the corresponding docs call succeeds. Omitting `documentId`
+  is refused with the requestable-permissions explanation.
+
 ### A5: Unsupported capabilities are refused without a link
 - Call `request_access` for an unsupported grant (e.g. deleting mail, or a
-  non-Gmail/Sheets Google API)
+  non-Gmail/Sheets/Docs Google API)
 - **Expected**: Refused with an explanation of what is requestable; no
   approval link is minted
 

--- a/docs/QA_Acceptance_Test/capabilities/16_analytics_events.md
+++ b/docs/QA_Acceptance_Test/capabilities/16_analytics_events.md
@@ -31,6 +31,15 @@ Run these AFTER the environment's other capabilities (they generate the tool
 calls under inspection). Use `--since` spanning the run so counts are
 attributable to it.
 
+### A8: Response-size monitoring props on every tool call
+- Inspect `$mcp_tool_call` events across services (gmail, sheets, docs tools)
+  from this run.
+- **Expected**: Every event carries `response_chars` and `response_kb`
+  (monitoring-only — plan google-docs-support v5, D7: no size caps are
+  enforced; the props exist so PostHog can measure how often responses exceed
+  MCP clients' tool-result budgets). `gmail_get_attachment` additionally keeps
+  its historical `attachment_chars`/`attachment_kb`.
+
 ### A1: Canonical tool-call events arrive with tool names
 - Run: `npx tsx scripts/qa-posthog-events.ts --event '$mcp_tool_call' --since <run window> --environment <tier>`
 - **Expected**: `row_count` ≥ the number of MCP tool calls this run made;

--- a/docs/QA_Acceptance_Test/capabilities/17_sheets_grant_recovery.md
+++ b/docs/QA_Acceptance_Test/capabilities/17_sheets_grant_recovery.md
@@ -17,6 +17,13 @@ with the embedded Sheets demo video when the grant is missing, the dashboard
 flags stranded rules, and the MCP error for a rule-covered-but-ungranted
 sheet tells the truth.
 
+> **Shared machinery note (Google Docs support)**: the components behind this
+> capability are kind-parameterized (`FileApprovalFlow`, `FileGrantRecovery`,
+> `fileAccessHandlers`) and also serve Google Docs. Sheets behavior, copy,
+> endpoints, testids (`sheets-flow-*`), and analytics event names are
+> unchanged — these assertions double as the regression suite for that
+> generalization. The docs twin of this funnel is capability 19 A12.
+
 ## Pre-requisites
 * `/qa-setup` complete; dev server running; USER_A signed in (built-in browser).
 * An MCP connection with an approved proxy key for USER_A (hosted MCP or

--- a/docs/QA_Acceptance_Test/capabilities/19_docs_management.md
+++ b/docs/QA_Acceptance_Test/capabilities/19_docs_management.md
@@ -1,0 +1,133 @@
+# Capability: Google Docs Management (Expose, Access, Tools)
+
+## Overview
+Covers the Google Docs per-file access lifecycle end to end: the dashboard UX for
+exposing a document to a profile (Google Picker `DOCUMENTS` view, sharing the
+sheets `drive.file` machinery), the curated MCP tools (`docs_read_document`,
+`docs_append_text`, `docs_replace_text`), raw-API enforcement of the `documents`
+family (which was unenforced passthrough before this feature), the proxy-route
+twin, agent-created-doc auto-grant, and the docs approval/recovery funnel.
+Everything here mirrors capability 09/17 semantics for sheets — where behavior
+intentionally differs, the assertion says so.
+
+## Pre-requisites
+* `/qa-setup` complete; dev server running; USER_A signed in on the dashboard.
+* At least one proxy key (Agent Profile) exists with a known bearer token.
+* Docs fixtures owned by USER_A (see `setup/03_rules_configuration.md`):
+  - one "exposed" Google Doc (picked in the Picker at least once), and
+  - one "external" Google Doc that has NEVER been picked (created directly at
+    docs.google.com) — the negative-control fixture. Both fixture ids are
+    recorded in the setup doc, never inline here.
+* UI assertions: built-in browser (Picker iframe caveats identical to
+  capability 09's harness note — the app-API seam here is
+  `POST /api/rules/grant-docs-access` / the `exposeDocsFromPicker` action).
+  API assertions: MCP tools with the profile's connection, or curl with the
+  profile's `sk_proxy_` bearer against `/api/proxy/v1/documents/...`.
+
+## Assertions
+
+### A1: "+ Expose a doc" on a profile opens the Google Picker with the Documents view
+- On `/dashboard`, select any profile tab and click **+ Expose a doc** in the
+  Google Docs Rules card.
+- **Expected**: The Google Picker modal opens on this page with the Documents
+  tab (not spreadsheets). No navigation, no dead-end. (If the drive.file grant
+  is missing, a redirect to Google consent is acceptable — see A2.)
+
+### A2: Consent round-trip returns kind-scoped — the docs picker reopens, not the sheets one
+- Deterministic proxy for the return leg: navigate to
+  `/dashboard?autoOpenPicker=true&pickerKind=doc&pickerContext=<profileId>`.
+- **Expected**: The URL is cleaned AND the DOCUMENTS-view picker opens. A legacy
+  URL without `pickerKind` must open the SHEETS picker (back-compat default) —
+  the two picker hook instances on the dashboard must not both fire.
+
+### A3: A doc picked from a profile is scoped to that profile, defaulting to Read Only
+- With a doc exposed from profile P's card, check the rules state (dashboard or
+  `GET /api/rules/grant-docs-access`).
+- **Expected**: The new rule has `service='docs'`, `actionType='doc_read'`, the
+  document's `targetResourceId` and `resourceName`, and is assigned to P.
+  Re-picking the same doc must not narrow existing global rules (same merge
+  semantics as sheets, capability 09 A3).
+
+### A4: Accounts-page "Add Google Doc +" creates a global docs rule
+- On `/dashboard/accounts`, click **Add Google Doc +** in the Google Docs
+  Access Rules card.
+- **Expected**: Picker opens directly (Documents view); a picked doc appears in
+  the docs table with its ID shown; the rule is global. The sheets manager
+  above it is unchanged.
+
+### A5: get_my_permissions carries the document id for docs rules
+- As an agent, call `get_my_permissions`.
+- **Expected**: Every docs rule includes `documentId` (the `targetResourceId`)
+  and `resourceName`; `defaults.docs` states documents are DENIED unless
+  exposed. A docs rule reaching an agent without its document id is a failure.
+
+### A6: Unexposed doc is denied with a docs_expose approval link
+- Call `docs_read_document` (and raw `google_api_get` with path
+  `v1/documents/<external doc id>`) for a doc with NO docs rule.
+- **Expected**: 🚫 denial naming the document id, `denial_code=docs_not_exposed`
+  on the tool-call event, and a single-use approval link whose action is
+  `docs_expose` (30-minute TTL). The `documents` family must NOT fall through
+  to raw passthrough (pre-docs behavior) — the denial is FGAC's, not Google's.
+
+### A7: Exposed doc reads succeed through every read surface
+- With the exposed fixture doc under a `doc_read` rule: call
+  `docs_read_document` (no `fields`), `docs_read_document` with
+  `fields=title`, raw `google_api_get` `v1/documents/<id>`, and proxy
+  `GET /api/proxy/v1/documents/<id>`.
+- **Expected**: All four return the raw Docs API document resource (title/body
+  JSON — no FGAC transformation); the `fields` variant returns only the masked
+  fields. Responses carry `response_chars`/`response_kb` on their tool-call
+  events (capability 16 A8).
+
+### A8: Writes require Read & Write — and use batchUpdate semantics
+- With the rule at `doc_read`: call `docs_append_text`, `docs_replace_text`,
+  and raw `google_api_modify` `v1/documents/<id>:batchUpdate`.
+- **Expected**: All denied with `denial_code=docs_read_only` and a
+  `docs_write` approval link (write-level, never a read-only under-grant —
+  same matrix as sheets). After flipping the rule to `doc_read_write`:
+  `docs_append_text` appends text at the end of the document (existing content
+  untouched), `docs_replace_text` replaces occurrences, raw batchUpdate
+  succeeds, and the changes are visible in a follow-up `docs_read_document`.
+
+### A9: doc_block denies everything and never mints a link
+- Set the rule to `doc_block` (Blocked in either dashboard select).
+- **Expected**: Reads AND writes are denied with
+  `denial_code=docs_blocked`; the denial carries NO approval link (weakening a
+  deliberate block stays a dashboard act). The underlying Google grant is kept
+  (flipping back to Read Only restores access without re-picking).
+
+### A10: Agent-created docs are auto-granted to the creating key
+- Call raw `google_api_modify` POST `v1/documents` with body `{"title": "..."}`.
+- **Expected**: 200 with a new `documentId`; a `doc_read_write` rule scoped to
+  the calling key appears (ruleName `Agent-created: <title>`); an immediate
+  `docs_read_document` on the new id succeeds with no approval;
+  `agent_doc_created` fires with `auto_granted=true`.
+
+### A11: Proxy route enforces docs rules like MCP does
+- With the profile's `sk_proxy_` bearer: `GET /api/proxy/v1/documents/<exposed id>`
+  (expect 200), `GET` on the never-picked external doc id (expect 403 naming
+  the document), `POST /api/proxy/v1/documents/<exposed id>:batchUpdate` under
+  `doc_read` (expect 403 read-only), and a Drive-path probe
+  `GET /api/proxy/drive/v3/files/<exposed doc id>` (expect the docs rule to
+  authorize it — the Drive per-file guard honors docs rules, not just sheets).
+
+### A12: Docs grant recovery mirrors the sheets funnel
+- Create a docs rule for a real-but-never-picked doc id via the app-API seam
+  (`POST /api/rules/grant-docs-access`), then:
+  1. dashboard docs manager shows the "⚠ Needs Google access — finish setup"
+     chip linking to `/dashboard/docs-setup?did=<id>`;
+  2. the docs-setup page offers the pick-first recovery (no sheets demo video
+     is embedded for docs — intentional until a docs video exists);
+  3. an MCP docs call in this stranded state returns the honest post-policy
+     error pointing at `/dashboard/docs-setup?did=<id>` (never a bare
+     "check the ID");
+  4. a magic-link approval for this doc lands in the pick-first state
+     (`docs-flow-pick-first` testid), and `verify-docs-access?did=<id>`
+     reports `missing` → after a Picker pick, `ok` with the title
+     (full-fidelity pick via the Playwright CDP path, as in capability 09).
+
+## Analytics hooks
+`docs_grant_verification`, `docs_grant_recovered`, `agent_doc_created`,
+`approval_link_minted` with `action=docs_expose|docs_write`, denial codes
+`docs_not_exposed|docs_read_only|docs_blocked`, grace props `docs_grace_*`,
+and universal `response_chars`/`response_kb` (capability 16).

--- a/docs/QA_Acceptance_Test/capabilities/README.md
+++ b/docs/QA_Acceptance_Test/capabilities/README.md
@@ -31,3 +31,5 @@
 | 15 | `15_request_access_tool.md` | Conversational permission upgrades via `request_access` |
 | 16 | `16_analytics_events.md` | PostHog events arrive with canonical schema (`$mcp_tool_call` + tool names, outcomes, environment tags) |
 | 17 | `17_sheets_grant_recovery.md` | Sheets approval verifies the Google-side grant; picker + video recovery when missing; honest post-policy errors |
+| 18 | `18_google_reconnect.md` | Broken/expired Google grants route into the Reconnect Google flow |
+| 19 | `19_docs_management.md` | Per-document read/write/block rules, docs MCP tools, raw `documents` enforcement, docs grant recovery |

--- a/docs/QA_Acceptance_Test/setup/03_rules_configuration.md
+++ b/docs/QA_Acceptance_Test/setup/03_rules_configuration.md
@@ -119,3 +119,27 @@ All rules are managed from the **"Access Rules"** section at the bottom of the d
 - [ ] Global read blacklist rule visible with "Global (all keys)" scope
 - [ ] Delete whitelist rule visible
 - [ ] Screenshot saved as `qa_proof_setup_rules.png`
+
+---
+
+## Per-File Fixtures (Sheets & Docs)
+
+Capabilities 09/17 (sheets) and 19 (docs) need per-file fixtures owned by
+USER_A. Record the actual ids in the local, gitignored QA state
+(`test/qa-envs/*/state.json` or the run notes) — **never in these public
+docs**:
+
+- **Exposed spreadsheet**: a sheet picked at least once through the FGAC
+  Google Picker (the standing QA fixture sheet qualifies).
+- **Exposed document**: a Google Doc picked at least once through the FGAC
+  Picker (Documents view). Create one at docs.google.com as USER_A if none
+  exists, give it a title and a line of content, then pick it via
+  `/dashboard/accounts` → "Add Google Doc +".
+- **External (never-picked) document**: a Google Doc created directly at
+  docs.google.com and NEVER picked — the negative-control fixture for
+  capability 19 A6/A11/A12. If a run consumes it (by picking it), create a
+  fresh one; note Google's Picker/Drive search can lag minutes behind on
+  brand-new files, so create fixtures ahead of the run.
+- A fresh Neon branch resets FGAC rules but NOT Google-side drive.file
+  grants — "exposed" fixtures stay granted across branches; the external doc
+  must simply never be picked.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -38,6 +38,8 @@ keep internal/QA traffic out of the numbers.
 | `read_restriction_enforced` | server (`/api/mcp`) | `via` (tool name), `restriction` |
 | `sheets_grant_verification` | server (approve-page load via `/api/rules/verify-sheets-access`, and approval in `actions.ts`) | `result` (`ok`/`missing`/`unknown`), `via` (`link_open`/`magic_link`/`post_approval`), `spreadsheet_id` |
 | `sheets_grant_recovered` | server (`/api/rules/verify-sheets-access`) | `spreadsheet_id` |
+| `docs_grant_verification` / `docs_grant_recovered` | server (`/api/rules/verify-docs-access`, approval in `actions.ts`) | docs twins of the sheets grant-funnel events, with `document_id` |
+| `agent_doc_created` | server (`/api/mcp`, raw `POST v1/documents`) | `document_id`, `auto_granted` (docs twin of `agent_sheet_created`) |
 | `connector_install_started` | server (`.well-known` OAuth discovery routes, `/api/mcp` auth layer) | `touchpoint` (`oauth_discovery`/`mcp_401`), `endpoint`, `reason` (`no_token`/`invalid_token`), `method`, `user_agent` |
 
 The two `sheets_grant_*` events instrument the **picker-first sheets
@@ -74,7 +76,22 @@ Sheets failures whose matching FGAC rule is fresh also carry
 `sheets_grant_age_seconds`, and when the post-approval grace retry engaged,
 `sheets_grace_retries` + `sheets_grace_recovered` — `recovered=true` volume is
 the direct measure of how often the drive.file propagation race would have
-surfaced an error to an agent.
+surfaced an error to an agent. Google Docs calls carry the same trio under
+`docs_grant_age_seconds` / `docs_grace_retries` / `docs_grace_recovered`.
+
+**Response-size monitoring (google-docs-support plan v5, D7 — monitoring
+only, no caps):** every `$mcp_tool_call` event carries `response_chars` and
+`response_kb`, the serialized size of the tool result FGAC returned. MCP
+clients impose their own tool-result budgets (Claude Code rejects results
+over ~25k tokens), so a server-side "success" can be silently discarded
+client-side. The confirmation question these props exist to answer: what
+fraction of successful reads exceed ~25k tokens' worth of chars for
+`client_name`-identified Claude Code connections, and do those calls
+correlate with abandoned tool sequences? If material, per-kind caps with
+recovery guidance get built (Phase 6 of the plan) with thresholds calibrated
+from this distribution. `gmail_get_attachment` keeps its historical
+`attachment_chars`/`attachment_kb` alongside the generic props; its
+pre-existing 200k-char cap is unchanged.
 
 **`connector_install_started` is a rate metric, not an identity metric.** It
 fires anonymously (distinct_id `anonymous-mcp`) from the only FGAC-owned

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -39,6 +39,7 @@ keep internal/QA traffic out of the numbers.
 | `sheets_grant_verification` | server (approve-page load via `/api/rules/verify-sheets-access`, and approval in `actions.ts`) | `result` (`ok`/`missing`/`unknown`), `via` (`link_open`/`magic_link`/`post_approval`), `spreadsheet_id` |
 | `sheets_grant_recovered` | server (`/api/rules/verify-sheets-access`) | `spreadsheet_id` |
 | `docs_grant_verification` / `docs_grant_recovered` | server (`/api/rules/verify-docs-access`, approval in `actions.ts`) | docs twins of the sheets grant-funnel events, with `document_id` |
+| `google_token_fetch_failed` | server (MCP `getGoogleToken`, proxy `fetchClerkGoogleToken`, `getOwnerGoogleToken`) | `reason` (`refresh_failed` = Clerk 422 cannot-refresh, `clerk_error`), `via` (`mcp`/`proxy`/`grant_check`), `account_delegated`. The `$mcp_tool_call` event also carries `google_token_error` on affected calls. Added 2026-08-20 after the dev-instance refresh-token loss was found; this is the signal for whether production users hit it too |
 | `agent_doc_created` | server (`/api/mcp`, raw `POST v1/documents`) | `document_id`, `auto_granted` (docs twin of `agent_sheet_created`) |
 | `connector_install_started` | server (`.well-known` OAuth discovery routes, `/api/mcp` auth layer) | `touchpoint` (`oauth_discovery`/`mcp_401`), `endpoint`, `reason` (`no_token`/`invalid_token`), `method`, `user_agent` |
 

--- a/docs/architecture_and_strategy.md
+++ b/docs/architecture_and_strategy.md
@@ -94,15 +94,16 @@ Each proxy key can access multiple email accounts (via `key_email_access`):
 | CLI | `npx fgac auth login` (separate npm package) | Power users, headless flows |
 | Direct API | `Bearer sk_proxy_...` to `gmail.fgac.ai` | Custom integrations |
 
-### Google Sheets Per-File Access Control (`drive.file`)
-In addition to Gmail, FGAC natively supports Google Sheets using Google's **Per-File Access Scope (`https://www.googleapis.com/auth/drive.file`)**.
+### Google Sheets & Docs Per-File Access Control (`drive.file`)
+In addition to Gmail, FGAC natively supports Google Sheets and Google Docs using Google's **Per-File Access Scope (`https://www.googleapis.com/auth/drive.file`)**.
 
-#### Key Architecture Principles for Sheets:
-1. **Zero CASA Audit Overhead**: Utilizing `drive.file` scope avoids restricted scope audits, requiring only standard Google verification (3-7 days, $0 cost).
-2. **Google Picker Integration**: Users intentionally select specific spreadsheets via the native Google Picker UI. Google's servers bind file permissions directly to the app's scope grant on Google's authorization servers.
-3. **FGAC Per-File Rules**: For each exposed spreadsheet, users can configure per-file permissions in the dashboard:
-   - **`sheet_read` (Read Only)**: Agents can fetch structure and read range data (`GET`), but mutating operations (`POST`, `PUT`, `PATCH`, `DELETE`) return `403 Forbidden`.
-   - **`sheet_read_write` (Read & Write)**: Agents can read cell ranges, update cell values, and append rows.
-   - **`sheet_block` (Blocked)**: Explicitly denies all agent operations for that file ID.
-4. **MCP Tools**: Exposes `sheets_get_spreadsheet`, `sheets_read_range`, `sheets_update_range`, and `sheets_append_rows` tools for MCP clients.
+#### Key Architecture Principles for Per-File Access:
+1. **Zero CASA Audit Overhead**: Utilizing `drive.file` scope avoids restricted scope audits, requiring only standard Google verification (3-7 days, $0 cost). Adding Docs required **no new OAuth scope** — the same per-file grants serve both file types.
+2. **Google Picker Integration**: Users intentionally select specific spreadsheets/documents via the native Google Picker UI (`SPREADSHEETS` or `DOCUMENTS` view). Google's servers bind file permissions directly to the app's scope grant on Google's authorization servers.
+3. **FGAC Per-File Rules**: For each exposed file, users configure per-file permissions in the dashboard (`sheet_*` action types for spreadsheets, `doc_*` for documents):
+   - **`sheet_read` / `doc_read` (Read Only)**: Agents can read (`GET`), but mutating operations return `403 Forbidden`.
+   - **`sheet_read_write` / `doc_read_write` (Read & Write)**: Agents can read and write. Note: the Docs API's only write endpoint is `batchUpdate`, so Read & Write on a document permits full-document editing — the dashboard copy states this plainly.
+   - **`sheet_block` / `doc_block` (Blocked)**: Explicitly denies all agent operations for that file ID while keeping the underlying Google grant.
+4. **MCP Tools**: Sheets — `sheets_get_spreadsheet`, `sheets_read_range`, `sheets_update_range`, `sheets_append_rows`. Docs — `docs_read_document` (returns the raw Docs API resource; optional `fields` mask for large documents), `docs_append_text` (non-destructive), `docs_replace_text`. Agent-created files (raw `POST v4/spreadsheets` / `POST v1/documents`) are auto-granted read & write to the creating key.
+5. **Kind descriptor**: everything per-file (rules, Picker exposure, grant verification, recovery pages, approval links) keys off `src/lib/driveFileKinds.ts`. Adding the next file type (Slides is stubbed) means a descriptor entry + tool definitions + QA docs — shared code must not grow `if (kind === ...)` branches.
 

--- a/docs/connector_submission/listing_copy.md
+++ b/docs/connector_submission/listing_copy.md
@@ -34,6 +34,16 @@ we get surfaced.
 >
 > More Google Workspace Connections Coming Soon!
 
+> **PENDING UPDATE (Google Docs support, 2026-08-20)**: the connector now
+> also serves Google Docs (per-document read/append/replace behind the same
+> per-file rules — tools `docs_read_document`, `docs_append_text`,
+> `docs_replace_text`). The DECIDED tagline/description above predate this
+> and need the owner's sign-off before resubmission. Proposed tagline
+> (≤55 chars): `Gmail, Google Sheets & Docs — on your terms` (43).
+> Proposed description addition: "…and let it update Google Sheets and
+> Google Docs for you! … precise access to the specific sheets, docs and
+> senders you want."
+
 (Earlier keyword-first draft kept below for reference — its bullet points
 remain useful raw material if the description is ever expanded; the
 use-cases step still carries the remaining search-phrase clusters.)

--- a/docs/connector_submission/mcp-registry-server.json
+++ b/docs/connector_submission/mcp-registry-server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "ai.fgac/fgac",
-  "description": "Connect one or many Gmail accounts and editable Google Sheets to AI agents, behind deny-by-default permission rules: read mail across delegated inboxes, send to whitelisted recipients, and update exposed spreadsheets.",
-  "version": "1.2.0",
+  "description": "Connect one or many Gmail accounts, editable Google Sheets, and Google Docs to AI agents, behind deny-by-default permission rules: read mail across delegated inboxes, send to whitelisted recipients, and update exposed spreadsheets and documents.",
+  "version": "1.3.0",
   "websiteUrl": "https://fgac.ai",
   "remotes": [
     {

--- a/docs/implementation_plans/google-docs-support-plan-b36c1c_v1.md
+++ b/docs/implementation_plans/google-docs-support-plan-b36c1c_v1.md
@@ -1,0 +1,234 @@
+# Google Docs Support — Implementation Plan (v1)
+
+**Branch**: `claude/google-docs-support-plan-b36c1c`
+**Status**: Draft for review — no implementation started.
+**Pattern source**: the Google Sheets integration (see
+`feature-google-drive-sheets-fgac_v6.md` and the code it produced).
+
+## 1. How Sheets works today (the pattern we're following)
+
+The Sheets integration has five load-bearing properties, all of which carry
+over to Docs unchanged:
+
+1. **No service-wide OAuth scope.** FGAC never requests a Sheets scope; API
+   access rides on per-file `drive.file` grants that Google registers only
+   when the user picks the file in the Google Picker with our `appId`
+   ([useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts),
+   [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts)). This is what
+   keeps the CASA/verification surface small.
+2. **Deny-by-default per-file rules.** `access_rules` rows with
+   `service='sheets'`, `actionType ∈ {sheet_read, sheet_read_write,
+   sheet_block}`, `targetResourceId=<spreadsheetId>`. No rule → denied.
+3. **Two-halves enforcement.** FGAC's rule check
+   (`checkSheetsPermission` in [route.ts](../../src/app/api/mcp/route.ts))
+   is separate from the Google-side grant; a 403/404 *after* FGAC allows the
+   call routes the user to `/dashboard/sheets-setup` (grant recovery), with
+   grace retries for freshly created rules (`withSheetsGrace`).
+4. **Denial → approval funnel.** Every denial mints a single-use magic link
+   (`sheets_expose` / `sheets_write` in
+   [approvalLinks.ts](../../src/lib/approvalLinks.ts)); the approve page runs
+   picker-first (`SheetsApprovalFlow`) so a rule is never created for a sheet
+   Google can't reach.
+5. **Curated tools + raw passthrough, same policy.** Four `sheets_*` MCP
+   tools plus `google_api_get/modify`, all funneling through one
+   classification (`classifyGoogleApiCall` in
+   [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts)) and one
+   permission check. Agent-created spreadsheets are auto-granted to the
+   creating key (`sheets_create` posture, 2026-08-19).
+
+## 2. Key facts about the Google Docs API
+
+- Endpoint family: `https://docs.googleapis.com/v1/documents/{documentId}`.
+- **`drive.file` is a supported scope** for `documents.get`,
+  `documents.create`, and `documents.batchUpdate` — the per-file Picker
+  grant mechanism works identically. (Phase 0 verifies this empirically
+  before we build on it.)
+- Picker view: `google.picker.ViewId.DOCUMENTS` (we use `SPREADSHEETS`
+  today).
+- API shape differs from Sheets in one way that matters for policy:
+  **there are no ranges.** `documents.get` returns the whole document;
+  `documents.batchUpdate` is the *only* write endpoint and can insert,
+  replace, style, and **delete** content. So "Read & Write" on a doc means
+  full-document edit — the plan surfaces that honestly in tool annotations
+  and rule UI copy, and offers a non-destructive append tool for the common
+  agent case.
+
+## 3. Design decisions (please review)
+
+### D1 — Reuse the `drive.file` + Picker mechanism; no new OAuth scope
+Same consent, same appId, same grant-recovery machinery. No Google
+re-verification impact. (Alternative — request `documents` scope — rejected:
+it breaks the entire FGAC premise and the CASA posture.)
+
+### D2 — Generalize the shared plumbing instead of copy-pasting it
+The Picker hook, grant check, setup/recovery page, and approval flow are
+~95% file-type-agnostic. Rather than duplicating five files with `s/sheet/doc/`,
+parameterize them by a small descriptor:
+
+```ts
+// src/lib/driveFileKinds.ts (new)
+export type DriveFileKind = 'sheet' | 'doc';
+export const DRIVE_FILE_KINDS: Record<DriveFileKind, {
+  service: 'sheets' | 'docs';            // access_rules.service
+  pickerViewId: 'SPREADSHEETS' | 'DOCUMENTS';
+  verifyUrl: (id: string) => string;      // grant-check probe endpoint
+  setupPath: string;                      // /dashboard/sheets-setup | docs-setup
+  noun: string;                           // "spreadsheet" | "document"
+}>;
+```
+
+Existing `sheets-*` route paths, action names, and analytics event props
+**stay unchanged** (no churn for existing users/links); the docs variants
+are new parameterizations of the same components. If we ever add Slides,
+it's a descriptor entry, not a third copy.
+
+*Alternative*: straight duplication (faster to review, ~5 new files with
+diverged twins). I recommend generalization — the sheets grant-recovery
+code has absorbed multiple field-tested fixes (grace retries, consent
+round-trip params, dead-button errors) and a fork would rot.
+
+### D3 — Rule model: `service='docs'`, no schema migration
+`access_rules.service` and `actionType` are plain `text` columns. New values:
+`doc_read`, `doc_read_write`, `doc_block`; `targetResourceId=<documentId>`.
+Zero DDL — comment updates in [schema.ts](../../src/db/schema.ts) only.
+
+### D4 — Curated MCP tool set (3 new tools)
+
+| Tool | Maps to | Annotations |
+|---|---|---|
+| `docs_read_document` | `documents.get`, returns title + extracted plain text (+ optional raw structure flag) | readOnly |
+| `docs_append_text` | `batchUpdate` / `insertText` at `endOfSegmentLocation` | write, `destructive: false` (mirrors `sheets_append_rows`) |
+| `docs_replace_text` | `batchUpdate` / `replaceAllText` | write, `destructive: true` |
+
+Everything else (styling, deleting ranges, tables) goes through
+`google_api_modify` under the same per-doc rule. `documents.create` via raw
+POST is auto-granted to the calling key, mirroring the `sheets_create`
+posture. All defs must pass `scripts/mcp-tool-lint.ts` invariants.
+
+*Open question for Ken*: is 3 the right curated set, or do we want a 4th
+(`docs_batch_update` as a structured wrapper)? My take: no — raw passthrough
+already covers it and a curated wrapper adds no policy value.
+
+### D5 — Raw-API behavior change (call out explicitly)
+Today `docs/v1/documents/...` through `google_api_get/modify` falls into the
+**passthrough** branch (unknown family, backstopped only by the OAuth
+scope — and in practice 403s because nothing grants docs files). This plan
+moves the `documents` family into an **enforced** class: per-doc FGAC rule
+required, denials mint approval links. Strictly a tightening; no working
+flow regresses.
+
+### D6 — Docs get the same approval-funnel treatment as Sheets
+New approval actions `docs_expose` / `docs_write` (30-min TTL like sheets —
+generalize the `startsWith('sheets')` TTL check to a kind lookup),
+picker-first approve flow, `/dashboard/docs-setup` grant recovery, and
+`request_access` grows `docs_read` / `docs_write` request types.
+
+## 4. Work plan
+
+### Phase 0 — Spike: prove Docs API + Picker per-file grant (½ day)
+Manual/browser, QA accounts, no code merged:
+1. Picker with `ViewId.DOCUMENTS` + our appId → pick a doc as USER_A.
+2. `GET docs.googleapis.com/v1/documents/{id}` with the Clerk-vaulted token
+   → expect 200 title/body.
+3. `batchUpdate` insertText → expect 200.
+4. Negative: same calls on an unpicked doc → 403/404 (confirms the grant is
+   per-file, not ambient).
+Record results in `docs/spike_results/`. **Gate: everything after this
+phase assumes the spike passed.**
+
+### Phase 1 — Policy core (pure, unit-testable)
+- `src/lib/driveFileKinds.ts` (new) — descriptor from D2.
+- [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts):
+  `classifyGoogleApiCall` gains `documents` branch → `{kind:'docs',
+  documentId, isMutating}` + `{kind:'docs_create'}`; `extractDocsDocumentId`;
+  generalize `sheetsApprovalAction` → `fileApprovalAction(kind, …)`.
+- [approvalLinks.ts](../../src/lib/approvalLinks.ts): add `docs_expose` /
+  `docs_write` actions + TTL + validation list.
+- Extend `scripts/test-google-api-policy.ts` and
+  `scripts/test-approval-links.ts` with docs cases.
+
+### Phase 2 — Enforcement + MCP tools
+- [route.ts](../../src/app/api/mcp/route.ts): generalize
+  `checkSheetsPermission` / `withSheetsGrace` / `sheetsErrorResult` into
+  kind-parameterized versions (sheets behavior byte-identical); register the
+  3 `docs_*` tools; extend `request_access` enum + `get_my_permissions`
+  posture text; handle `docs` / `docs_create` classes with auto-grant.
+- [toolDefs.ts](../../src/app/api/mcp/toolDefs.ts): 3 new defs; update
+  `google_api_get/modify` + `request_access` descriptions to name the Docs
+  API; run `mcp-tool-lint`.
+- [proxy route](../../src/app/api/proxy/%5B...path%5D/route.ts): service
+  detection (`documents` → `docs`) + same rule enforcement as sheets there.
+- Analytics: `denial_code`s `docs_not_exposed|docs_blocked|docs_read_only`,
+  grace props `docs_grace_*`, keep `raw_api_family` stamping.
+
+### Phase 3 — Grant flow + approval funnel (dashboard)
+- [useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts): accept a
+  `DriveFileKind` (view id + title); consent round-trip params carry the
+  kind so the auto-reopen lands on the right view.
+- [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts) →
+  `driveFileGrantCheck.ts` probing the kind's verify endpoint (docs:
+  `documents.get?fields=title`); keep a `verifySheetsGrant` re-export.
+- `/dashboard/docs-setup` (new page) + generalize `SheetsGrantRecovery` into
+  the shared component both pages render.
+- [approve page](../../src/app/dashboard/approve/page.tsx) +
+  `SheetsApprovalFlow` → kind-parameterized `FileApprovalFlow`; docs
+  approvals verify-then-grant with the same settling/grace UX.
+- API routes: `grant-docs-access` / `verify-docs-access` (thin wrappers over
+  shared handlers with `grant-sheets-access` / `verify-sheets-access`).
+- [actions.ts](../../src/app/dashboard/actions.ts): docs rule CRUD +
+  `exposeDocsFromPicker` mirroring the sheets server actions;
+  `DOC_ACTION_TYPES` validation.
+
+### Phase 4 — Dashboard management UI
+- Generalize [ExposedSheetsManager.tsx](../../src/app/dashboard/ExposedSheetsManager.tsx)
+  (or add a sibling driven by the same shared list component): expose/manage
+  docs per profile, read vs read-write toggle, block, "needs Google access"
+  chip wired to `/dashboard/docs-setup`.
+- [EditRuleButton.tsx](../../src/app/dashboard/EditRuleButton.tsx) /
+  `RuleControls` / `AgentProfilesView`: render `service='docs'` rules;
+  write-access copy states plainly that Read & Write = full-document edit
+  (D4 caveat).
+- [defaultProfile.ts](../../src/db/defaultProfile.ts): comment update only —
+  docs are deny-by-default with no rules, same as sheets.
+
+### Phase 5 — Docs, QA, lint
+- New QA capability `docs/QA_Acceptance_Test/capabilities/19_docs_management.md`
+  modeled on `09_sheets_management.md` (same picker-iframe harness notes;
+  the app-API seam for post-pick assertions is `grant-docs-access`).
+- Touch-ups: `10_raw_google_api.md` (documents family now enforced),
+  `15_request_access_tool.md` (new request types), `17_sheets_grant_recovery.md`
+  (shared component note), setup docs fixture: one QA Google Doc owned by
+  USER_A.
+- Agent runbooks in `docs/QA_Acceptance_Test/agents/` gain the docs
+  capability; `npx tsx scripts/qa-coverage-check.ts` stays the arbiter.
+- Repo docs: `user_guide.md`, `architecture_and_strategy.md` (data model),
+  `connector_submission/listing_copy.md` + `mcp-registry-server.json` (tool
+  list changed — connector directory listing must be resubmitted/updated).
+
+### Phase 6 — Optional / follow-up (not in first PR)
+- [partner manifest](../../src/lib/partner/manifest.ts): `'docs'` service +
+  consent-screen line ("Access documents you explicitly share").
+- Marketing: `use-cases/google-docs-agent` page, landing-page mention,
+  `src/app/docs/page.tsx` API docs.
+- Combined picker view (sheets + docs in one dialog) for the dashboard's
+  generic "expose files" entry point.
+
+## 5. Testing & rollout
+
+- Unit: policy classification + approval-link suites (Phase 1 scripts).
+- Local QA: full docs capability run + targeted re-run of sheets
+  capabilities **09, 10, 14, 15, 17** — the generalization refactor touches
+  their code paths, so sheets regressions are the main risk.
+- `/deploy-pr-preview` → preview-branch QA per standard workflow; user runs
+  `/deploy-prod`.
+- No DB migration, no new env vars, no new OAuth scope → no infra steps.
+  Connector-directory listing update is the one external follow-up.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Docs API + Picker `drive.file` grant doesn't behave like Sheets in some corner (e.g. grant propagation lag differs) | Phase 0 spike gates everything; grace-retry machinery already handles propagation lag |
+| Generalization refactor regresses battle-hardened sheets flows | Sheets behavior kept byte-identical (routes, action names, analytics props unchanged); targeted sheets QA re-run in Phase 5 |
+| "Read & Write" on a doc is broader than users expect (batchUpdate can delete) | Explicit UI copy + `destructive: true` on replace/raw tools; append tool offered as the safe default |
+| Tool-count growth pushes connector-directory re-review | `mcp-tool-lint` invariants enforced; listing update planned as explicit follow-up |

--- a/docs/implementation_plans/google-docs-support-plan-b36c1c_v2.md
+++ b/docs/implementation_plans/google-docs-support-plan-b36c1c_v2.md
@@ -1,0 +1,263 @@
+# Google Docs Support — Implementation Plan (v2)
+
+**Branch**: `claude/google-docs-support-plan-b36c1c`
+**Status**: Draft for review — no implementation started.
+**Pattern source**: the Google Sheets integration (see
+`feature-google-drive-sheets-fgac_v6.md` and the code it produced).
+
+**Changes from v1** (Ken's review, 2026-08-19):
+- **D2 resolved — generalize.** Presentations (Google Slides) are likely
+  next, so the shared plumbing is designed for three kinds from day one,
+  with `slide` stubbed in the descriptor type now.
+- **D4 revised — the read tool returns the raw `documents.get` API response
+  verbatim** instead of extracted plain text. Markdown conversion was
+  considered and rejected for now: fidelity gets tricky with embedded
+  objects (tables, images, inline drawings). An optional `fields` mask keeps
+  large responses trimmable.
+
+## 1. How Sheets works today (the pattern we're following)
+
+The Sheets integration has five load-bearing properties, all of which carry
+over to Docs unchanged:
+
+1. **No service-wide OAuth scope.** FGAC never requests a Sheets scope; API
+   access rides on per-file `drive.file` grants that Google registers only
+   when the user picks the file in the Google Picker with our `appId`
+   ([useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts),
+   [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts)). This is what
+   keeps the CASA/verification surface small.
+2. **Deny-by-default per-file rules.** `access_rules` rows with
+   `service='sheets'`, `actionType ∈ {sheet_read, sheet_read_write,
+   sheet_block}`, `targetResourceId=<spreadsheetId>`. No rule → denied.
+3. **Two-halves enforcement.** FGAC's rule check
+   (`checkSheetsPermission` in [route.ts](../../src/app/api/mcp/route.ts))
+   is separate from the Google-side grant; a 403/404 *after* FGAC allows the
+   call routes the user to `/dashboard/sheets-setup` (grant recovery), with
+   grace retries for freshly created rules (`withSheetsGrace`).
+4. **Denial → approval funnel.** Every denial mints a single-use magic link
+   (`sheets_expose` / `sheets_write` in
+   [approvalLinks.ts](../../src/lib/approvalLinks.ts)); the approve page runs
+   picker-first (`SheetsApprovalFlow`) so a rule is never created for a sheet
+   Google can't reach.
+5. **Curated tools + raw passthrough, same policy.** Four `sheets_*` MCP
+   tools plus `google_api_get/modify`, all funneling through one
+   classification (`classifyGoogleApiCall` in
+   [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts)) and one
+   permission check. Agent-created spreadsheets are auto-granted to the
+   creating key (`sheets_create` posture, 2026-08-19).
+
+## 2. Key facts about the Google Docs API
+
+- Endpoint family: `https://docs.googleapis.com/v1/documents/{documentId}`.
+- **`drive.file` is a supported scope** for `documents.get`,
+  `documents.create`, and `documents.batchUpdate` — the per-file Picker
+  grant mechanism works identically. (Phase 0 verifies this empirically
+  before we build on it.)
+- Picker view: `google.picker.ViewId.DOCUMENTS` (we use `SPREADSHEETS`
+  today; Slides later will use `PRESENTATIONS`).
+- API shape differs from Sheets in one way that matters for policy:
+  **there are no ranges.** `documents.get` returns the whole document;
+  `documents.batchUpdate` is the *only* write endpoint and can insert,
+  replace, style, and **delete** content. So "Read & Write" on a doc means
+  full-document edit — the plan surfaces that honestly in tool annotations
+  and rule UI copy, and offers a non-destructive append tool for the common
+  agent case.
+
+## 3. Design decisions
+
+### D1 — Reuse the `drive.file` + Picker mechanism; no new OAuth scope
+Same consent, same appId, same grant-recovery machinery. No Google
+re-verification impact. (Alternative — request `documents` scope — rejected:
+it breaks the entire FGAC premise and the CASA posture.)
+
+### D2 — Generalize the shared plumbing (DECIDED — presentations coming next)
+The Picker hook, grant check, setup/recovery page, and approval flow are
+~95% file-type-agnostic. Parameterize them by a small descriptor rather than
+copy-pasting; **Google Slides is expected soon and must be a descriptor
+entry, not a third fork**:
+
+```ts
+// src/lib/driveFileKinds.ts (new)
+export type DriveFileKind = 'sheet' | 'doc' | 'slide'; // 'slide' stubbed now, wired when Slides ships
+export const DRIVE_FILE_KINDS: Record<DriveFileKind, {
+  service: 'sheets' | 'docs' | 'slides'; // access_rules.service
+  pickerViewId: 'SPREADSHEETS' | 'DOCUMENTS' | 'PRESENTATIONS';
+  verifyUrl: (id: string) => string;      // grant-check probe endpoint
+  setupPath: string;                      // /dashboard/sheets-setup | docs-setup | slides-setup
+  noun: string;                           // "spreadsheet" | "document" | "presentation"
+}>;
+```
+
+Implementation note for the refactor: every place Phase 2–4 generalizes
+(`checkSheetsPermission`, `withSheetsGrace`, grant recovery, approval flow,
+rule CRUD, exposed-files manager) must key off the descriptor — zero
+remaining `if (kind === 'doc')` branches in shared code. The acceptance test
+for the abstraction is: **adding Slides later touches `driveFileKinds.ts`,
+tool defs/registrations, and QA docs — nothing else.**
+
+Existing `sheets-*` route paths, action names, and analytics event props
+**stay unchanged** (no churn for existing users/links); the docs variants
+are new parameterizations of the same components.
+
+### D3 — Rule model: `service='docs'`, no schema migration
+`access_rules.service` and `actionType` are plain `text` columns. New values:
+`doc_read`, `doc_read_write`, `doc_block`; `targetResourceId=<documentId>`.
+Zero DDL — comment updates in [schema.ts](../../src/db/schema.ts) only.
+
+### D4 — Curated MCP tool set (3 new tools); read returns the raw API response
+
+| Tool | Maps to | Returns | Annotations |
+|---|---|---|---|
+| `docs_read_document` | `documents.get` | **The raw Docs API JSON response, verbatim.** Optional `fields` parameter passes Google's standard field mask through, so agents can trim large documents (e.g. `title,body.content`) | readOnly |
+| `docs_append_text` | `batchUpdate` / `insertText` at `endOfSegmentLocation` | Raw batchUpdate response | write, `destructive: false` (mirrors `sheets_append_rows`) |
+| `docs_replace_text` | `batchUpdate` / `replaceAllText` | Raw batchUpdate response | write, `destructive: true` |
+
+**No content transformation on read** (decided in review): FGAC passes
+through what `documents.get` returns, exactly as the `sheets_*` tools pass
+through Sheets API responses. Markdown conversion was considered and
+**rejected for the first release** — embedded objects (tables, inline
+images, drawings, footnotes, suggestions) make a faithful conversion a
+project of its own, and a lossy one would silently hide content from
+agents, which is worse than verbose JSON. Modern agents parse the Docs JSON
+structure fine. If token bloat shows up in practice, a `format: 'markdown'`
+option can be added later as a follow-up without breaking anything; the
+tool description will note that `fields` is the size-control lever for now.
+
+Everything else (styling, deleting ranges, tables) goes through
+`google_api_modify` under the same per-doc rule. `documents.create` via raw
+POST is auto-granted to the calling key, mirroring the `sheets_create`
+posture. All defs must pass `scripts/mcp-tool-lint.ts` invariants.
+
+### D5 — Raw-API behavior change (call out explicitly)
+Today `docs/v1/documents/...` through `google_api_get/modify` falls into the
+**passthrough** branch (unknown family, backstopped only by the OAuth
+scope — and in practice 403s because nothing grants docs files). This plan
+moves the `documents` family into an **enforced** class: per-doc FGAC rule
+required, denials mint approval links. Strictly a tightening; no working
+flow regresses.
+
+### D6 — Docs get the same approval-funnel treatment as Sheets
+New approval actions `docs_expose` / `docs_write` (30-min TTL like sheets —
+generalize the `startsWith('sheets')` TTL check to a kind lookup),
+picker-first approve flow, `/dashboard/docs-setup` grant recovery, and
+`request_access` grows `docs_read` / `docs_write` request types.
+
+## 4. Work plan
+
+### Phase 0 — Spike: prove Docs API + Picker per-file grant (½ day)
+Manual/browser, QA accounts, no code merged:
+1. Picker with `ViewId.DOCUMENTS` + our appId → pick a doc as USER_A.
+2. `GET docs.googleapis.com/v1/documents/{id}` with the Clerk-vaulted token
+   → expect 200 title/body; also confirm the `fields` mask works under
+   `drive.file` (it backs `docs_read_document`'s trim parameter and the
+   grant-check probe).
+3. `batchUpdate` insertText → expect 200.
+4. Negative: same calls on an unpicked doc → 403/404 (confirms the grant is
+   per-file, not ambient).
+Record results in `docs/spike_results/`. **Gate: everything after this
+phase assumes the spike passed.**
+
+### Phase 1 — Policy core (pure, unit-testable)
+- `src/lib/driveFileKinds.ts` (new) — descriptor from D2, with `slide`
+  stubbed in the type.
+- [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts):
+  `classifyGoogleApiCall` gains `documents` branch → `{kind:'docs',
+  documentId, isMutating}` + `{kind:'docs_create'}`; `extractDocsDocumentId`;
+  generalize `sheetsApprovalAction` → `fileApprovalAction(kind, …)`.
+- [approvalLinks.ts](../../src/lib/approvalLinks.ts): add `docs_expose` /
+  `docs_write` actions + TTL + validation list.
+- Extend `scripts/test-google-api-policy.ts` and
+  `scripts/test-approval-links.ts` with docs cases.
+
+### Phase 2 — Enforcement + MCP tools
+- [route.ts](../../src/app/api/mcp/route.ts): generalize
+  `checkSheetsPermission` / `withSheetsGrace` / `sheetsErrorResult` into
+  kind-parameterized versions (sheets behavior byte-identical); register the
+  3 `docs_*` tools (read passes the raw `documents.get` response through,
+  with optional `fields` mask — D4); extend `request_access` enum +
+  `get_my_permissions` posture text; handle `docs` / `docs_create` classes
+  with auto-grant.
+- [toolDefs.ts](../../src/app/api/mcp/toolDefs.ts): 3 new defs; update
+  `google_api_get/modify` + `request_access` descriptions to name the Docs
+  API; run `mcp-tool-lint`.
+- [proxy route](../../src/app/api/proxy/%5B...path%5D/route.ts): service
+  detection (`documents` → `docs`) + same rule enforcement as sheets there.
+- Analytics: `denial_code`s `docs_not_exposed|docs_blocked|docs_read_only`,
+  grace props `docs_grace_*`, keep `raw_api_family` stamping.
+
+### Phase 3 — Grant flow + approval funnel (dashboard)
+- [useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts): accept a
+  `DriveFileKind` (view id + title); consent round-trip params carry the
+  kind so the auto-reopen lands on the right view.
+- [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts) →
+  `driveFileGrantCheck.ts` probing the kind's verify endpoint (docs:
+  `documents.get?fields=title`); keep a `verifySheetsGrant` re-export.
+- `/dashboard/docs-setup` (new page) + generalize `SheetsGrantRecovery` into
+  the shared component both pages render.
+- [approve page](../../src/app/dashboard/approve/page.tsx) +
+  `SheetsApprovalFlow` → kind-parameterized `FileApprovalFlow`; docs
+  approvals verify-then-grant with the same settling/grace UX.
+- API routes: `grant-docs-access` / `verify-docs-access` (thin wrappers over
+  shared handlers with `grant-sheets-access` / `verify-sheets-access`).
+- [actions.ts](../../src/app/dashboard/actions.ts): docs rule CRUD +
+  `exposeDocsFromPicker` mirroring the sheets server actions;
+  `DOC_ACTION_TYPES` validation.
+
+### Phase 4 — Dashboard management UI
+- Generalize [ExposedSheetsManager.tsx](../../src/app/dashboard/ExposedSheetsManager.tsx)
+  (or add a sibling driven by the same shared list component): expose/manage
+  docs per profile, read vs read-write toggle, block, "needs Google access"
+  chip wired to `/dashboard/docs-setup`.
+- [EditRuleButton.tsx](../../src/app/dashboard/EditRuleButton.tsx) /
+  `RuleControls` / `AgentProfilesView`: render `service='docs'` rules;
+  write-access copy states plainly that Read & Write = full-document edit
+  (§2 caveat).
+- [defaultProfile.ts](../../src/db/defaultProfile.ts): comment update only —
+  docs are deny-by-default with no rules, same as sheets.
+
+### Phase 5 — Docs, QA, lint
+- New QA capability `docs/QA_Acceptance_Test/capabilities/19_docs_management.md`
+  modeled on `09_sheets_management.md` (same picker-iframe harness notes;
+  the app-API seam for post-pick assertions is `grant-docs-access`).
+- Touch-ups: `10_raw_google_api.md` (documents family now enforced),
+  `15_request_access_tool.md` (new request types), `17_sheets_grant_recovery.md`
+  (shared component note), setup docs fixture: one QA Google Doc owned by
+  USER_A.
+- Agent runbooks in `docs/QA_Acceptance_Test/agents/` gain the docs
+  capability; `npx tsx scripts/qa-coverage-check.ts` stays the arbiter.
+- Repo docs: `user_guide.md`, `architecture_and_strategy.md` (data model),
+  `connector_submission/listing_copy.md` + `mcp-registry-server.json` (tool
+  list changed — connector directory listing must be resubmitted/updated).
+
+### Phase 6 — Optional / follow-up (not in first PR)
+- **Google Slides** (likely next): descriptor entry + `slides_*` tool defs +
+  QA capability — the D2 abstraction's acceptance test.
+- [partner manifest](../../src/lib/partner/manifest.ts): `'docs'` service +
+  consent-screen line ("Access documents you explicitly share").
+- Marketing: `use-cases/google-docs-agent` page, landing-page mention,
+  `src/app/docs/page.tsx` API docs.
+- Combined picker view (sheets + docs in one dialog) for the dashboard's
+  generic "expose files" entry point.
+- `docs_read_document` `format: 'markdown'` option, only if raw-JSON token
+  bloat proves to be a real agent pain point (see D4).
+
+## 5. Testing & rollout
+
+- Unit: policy classification + approval-link suites (Phase 1 scripts).
+- Local QA: full docs capability run + targeted re-run of sheets
+  capabilities **09, 10, 14, 15, 17** — the generalization refactor touches
+  their code paths, so sheets regressions are the main risk.
+- `/deploy-pr-preview` → preview-branch QA per standard workflow; user runs
+  `/deploy-prod`.
+- No DB migration, no new env vars, no new OAuth scope → no infra steps.
+  Connector-directory listing update is the one external follow-up.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Docs API + Picker `drive.file` grant doesn't behave like Sheets in some corner (e.g. grant propagation lag differs) | Phase 0 spike gates everything; grace-retry machinery already handles propagation lag |
+| Generalization refactor regresses battle-hardened sheets flows | Sheets behavior kept byte-identical (routes, action names, analytics props unchanged); targeted sheets QA re-run in Phase 5 |
+| "Read & Write" on a doc is broader than users expect (batchUpdate can delete) | Explicit UI copy + `destructive: true` on replace/raw tools; append tool offered as the safe default |
+| Raw `documents.get` JSON is verbose for large docs (agent token cost) | `fields` mask parameter on `docs_read_document`; markdown format deferred as a measured follow-up, not a blocker |
+| Tool-count growth pushes connector-directory re-review | `mcp-tool-lint` invariants enforced; listing update planned as explicit follow-up |

--- a/docs/implementation_plans/google-docs-support-plan-b36c1c_v3.md
+++ b/docs/implementation_plans/google-docs-support-plan-b36c1c_v3.md
@@ -1,0 +1,353 @@
+# Google Docs Support — Implementation Plan (v3)
+
+**Branch**: `claude/google-docs-support-plan-b36c1c`
+**Status**: Draft for review — no implementation started.
+**Pattern source**: the Google Sheets integration (see
+`feature-google-drive-sheets-fgac_v6.md` and the code it produced).
+
+**Changes from v2** (Ken's review, 2026-08-19):
+- **New D7 — response-size guardrail + observability on docs reads**,
+  following the `gmail_get_attachment` pattern from
+  `claude/fgac-mcp-attachment-debug-3f9974` (commit `5aa23bd`): stamp
+  payload-size props on every read outcome, and refuse to return a payload
+  that would exceed the MCP client's tool-result cap — with an actionable
+  recovery message. For docs the recovery is agent-self-serviceable (`fields`
+  mask), unlike attachments where the message punts to the user.
+
+**Changes from v1** (Ken's review, 2026-08-19):
+- **D2 resolved — generalize.** Presentations (Google Slides) are likely
+  next, so the shared plumbing is designed for three kinds from day one,
+  with `slide` stubbed in the descriptor type now.
+- **D4 revised — the read tool returns the raw `documents.get` API response
+  verbatim** instead of extracted plain text. Markdown conversion was
+  considered and rejected for now: fidelity gets tricky with embedded
+  objects (tables, images, inline drawings). An optional `fields` mask keeps
+  large responses trimmable.
+
+## 1. How Sheets works today (the pattern we're following)
+
+The Sheets integration has five load-bearing properties, all of which carry
+over to Docs unchanged:
+
+1. **No service-wide OAuth scope.** FGAC never requests a Sheets scope; API
+   access rides on per-file `drive.file` grants that Google registers only
+   when the user picks the file in the Google Picker with our `appId`
+   ([useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts),
+   [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts)). This is what
+   keeps the CASA/verification surface small.
+2. **Deny-by-default per-file rules.** `access_rules` rows with
+   `service='sheets'`, `actionType ∈ {sheet_read, sheet_read_write,
+   sheet_block}`, `targetResourceId=<spreadsheetId>`. No rule → denied.
+3. **Two-halves enforcement.** FGAC's rule check
+   (`checkSheetsPermission` in [route.ts](../../src/app/api/mcp/route.ts))
+   is separate from the Google-side grant; a 403/404 *after* FGAC allows the
+   call routes the user to `/dashboard/sheets-setup` (grant recovery), with
+   grace retries for freshly created rules (`withSheetsGrace`).
+4. **Denial → approval funnel.** Every denial mints a single-use magic link
+   (`sheets_expose` / `sheets_write` in
+   [approvalLinks.ts](../../src/lib/approvalLinks.ts)); the approve page runs
+   picker-first (`SheetsApprovalFlow`) so a rule is never created for a sheet
+   Google can't reach.
+5. **Curated tools + raw passthrough, same policy.** Four `sheets_*` MCP
+   tools plus `google_api_get/modify`, all funneling through one
+   classification (`classifyGoogleApiCall` in
+   [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts)) and one
+   permission check. Agent-created spreadsheets are auto-granted to the
+   creating key (`sheets_create` posture, 2026-08-19).
+
+A sixth pattern arrived with the attachment work and is adopted here (D7):
+
+6. **Payload-size observability + cap.** `gmail_get_attachment` records
+   `attachment_chars` / `attachment_kb` on every outcome via
+   `addToolCallProps`, and refuses payloads over `MAX_ATTACHMENT_CHARS`
+   (200k base64url chars ≈ 150 KB) with a `⚠️` message instead — because MCP
+   clients impose their own tool-result caps (Claude Code rejects results
+   over ~25k tokens), so a server-side "success" can still be silently
+   discarded client-side after we report it as delivered.
+
+## 2. Key facts about the Google Docs API
+
+- Endpoint family: `https://docs.googleapis.com/v1/documents/{documentId}`.
+- **`drive.file` is a supported scope** for `documents.get`,
+  `documents.create`, and `documents.batchUpdate` — the per-file Picker
+  grant mechanism works identically. (Phase 0 verifies this empirically
+  before we build on it.)
+- Picker view: `google.picker.ViewId.DOCUMENTS` (we use `SPREADSHEETS`
+  today; Slides later will use `PRESENTATIONS`).
+- API shape differs from Sheets in one way that matters for policy:
+  **there are no ranges.** `documents.get` returns the whole document;
+  `documents.batchUpdate` is the *only* write endpoint and can insert,
+  replace, style, and **delete** content. So "Read & Write" on a doc means
+  full-document edit — the plan surfaces that honestly in tool annotations
+  and rule UI copy, and offers a non-destructive append tool for the common
+  agent case.
+- Because reads are whole-document and the response is verbose structural
+  JSON, **docs reads are the most cap-prone payload FGAC will serve** —
+  hence D7.
+
+## 3. Design decisions
+
+### D1 — Reuse the `drive.file` + Picker mechanism; no new OAuth scope
+Same consent, same appId, same grant-recovery machinery. No Google
+re-verification impact. (Alternative — request `documents` scope — rejected:
+it breaks the entire FGAC premise and the CASA posture.)
+
+### D2 — Generalize the shared plumbing (DECIDED — presentations coming next)
+The Picker hook, grant check, setup/recovery page, and approval flow are
+~95% file-type-agnostic. Parameterize them by a small descriptor rather than
+copy-pasting; **Google Slides is expected soon and must be a descriptor
+entry, not a third fork**:
+
+```ts
+// src/lib/driveFileKinds.ts (new)
+export type DriveFileKind = 'sheet' | 'doc' | 'slide'; // 'slide' stubbed now, wired when Slides ships
+export const DRIVE_FILE_KINDS: Record<DriveFileKind, {
+  service: 'sheets' | 'docs' | 'slides'; // access_rules.service
+  pickerViewId: 'SPREADSHEETS' | 'DOCUMENTS' | 'PRESENTATIONS';
+  verifyUrl: (id: string) => string;      // grant-check probe endpoint
+  setupPath: string;                      // /dashboard/sheets-setup | docs-setup | slides-setup
+  noun: string;                           // "spreadsheet" | "document" | "presentation"
+}>;
+```
+
+Implementation note for the refactor: every place Phase 2–4 generalizes
+(`checkSheetsPermission`, `withSheetsGrace`, grant recovery, approval flow,
+rule CRUD, exposed-files manager) must key off the descriptor — zero
+remaining `if (kind === 'doc')` branches in shared code. The acceptance test
+for the abstraction is: **adding Slides later touches `driveFileKinds.ts`,
+tool defs/registrations, and QA docs — nothing else.**
+
+Existing `sheets-*` route paths, action names, and analytics event props
+**stay unchanged** (no churn for existing users/links); the docs variants
+are new parameterizations of the same components.
+
+### D3 — Rule model: `service='docs'`, no schema migration
+`access_rules.service` and `actionType` are plain `text` columns. New values:
+`doc_read`, `doc_read_write`, `doc_block`; `targetResourceId=<documentId>`.
+Zero DDL — comment updates in [schema.ts](../../src/db/schema.ts) only.
+
+### D4 — Curated MCP tool set (3 new tools); read returns the raw API response
+
+| Tool | Maps to | Returns | Annotations |
+|---|---|---|---|
+| `docs_read_document` | `documents.get` | **The raw Docs API JSON response, verbatim.** Optional `fields` parameter passes Google's standard field mask through, so agents can trim large documents (e.g. `title,body.content`) | readOnly |
+| `docs_append_text` | `batchUpdate` / `insertText` at `endOfSegmentLocation` | Raw batchUpdate response | write, `destructive: false` (mirrors `sheets_append_rows`) |
+| `docs_replace_text` | `batchUpdate` / `replaceAllText` | Raw batchUpdate response | write, `destructive: true` |
+
+**No content transformation on read** (decided in review): FGAC passes
+through what `documents.get` returns, exactly as the `sheets_*` tools pass
+through Sheets API responses. Markdown conversion was considered and
+**rejected for the first release** — embedded objects (tables, inline
+images, drawings, footnotes, suggestions) make a faithful conversion a
+project of its own, and a lossy one would silently hide content from
+agents, which is worse than verbose JSON. Modern agents parse the Docs JSON
+structure fine. If token bloat shows up in practice, a `format: 'markdown'`
+option can be added later as a follow-up without breaking anything; the
+tool description will note that `fields` is the size-control lever for now
+(and D7's over-cap message teaches it at exactly the moment it's needed).
+
+Everything else (styling, deleting ranges, tables) goes through
+`google_api_modify` under the same per-doc rule. `documents.create` via raw
+POST is auto-granted to the calling key, mirroring the `sheets_create`
+posture. All defs must pass `scripts/mcp-tool-lint.ts` invariants.
+
+### D5 — Raw-API behavior change (call out explicitly)
+Today `docs/v1/documents/...` through `google_api_get/modify` falls into the
+**passthrough** branch (unknown family, backstopped only by the OAuth
+scope — and in practice 403s because nothing grants docs files). This plan
+moves the `documents` family into an **enforced** class: per-doc FGAC rule
+required, denials mint approval links. Strictly a tightening; no working
+flow regresses.
+
+### D6 — Docs get the same approval-funnel treatment as Sheets
+New approval actions `docs_expose` / `docs_write` (30-min TTL like sheets —
+generalize the `startsWith('sheets')` TTL check to a kind lookup),
+picker-first approve flow, `/dashboard/docs-setup` grant recovery, and
+`request_access` grows `docs_read` / `docs_write` request types.
+
+### D7 — Response-size guardrail + observability (attachment pattern)
+Mirrors `gmail_get_attachment` (commit `5aa23bd`), applied to every docs
+read path — `docs_read_document` AND `google_api_get` calls classified as
+`docs` reads:
+
+1. **Observability on every outcome.** After a successful Google fetch,
+   stamp the serialized response size onto the tool-call analytics event:
+   `addToolCallProps({ doc_response_chars, doc_response_kb })` — on both the
+   returned and over-cap paths, exactly like `attachment_chars` /
+   `attachment_kb`. PostHog can then chart how many docs reads land in the
+   client-rejection zone and whether the cap is calibrated right.
+2. **Hard cap with an actionable message.** New constant
+   `MAX_DOC_RESPONSE_CHARS = 100_000` (JSON chars ≈ 25k tokens — Claude
+   Code's tool-result rejection threshold; calibrate against the attachment
+   precedent, where 200k base64url chars maps to the same token budget at
+   base64's denser chars-per-token). Over the cap, do NOT return the doomed
+   payload — return:
+   > ⚠️ This document's API response is ~{kb} KB, which exceeds the size
+   > MCP clients accept for a tool result. Retry with the `fields`
+   > parameter to trim the response — e.g. `title,body.content` for
+   > content only, or narrower masks for specific elements. The user does
+   > not need to do anything.
+3. **Key difference from attachments, stated in code comments:** an
+   attachment is opaque binary — nothing to trim, so its over-cap message
+   punts to the user ("retrieve it directly from Gmail"). A docs read has a
+   server-side trim lever the *agent* can pull (`fields`), so the over-cap
+   message is self-service and the failure mode is recoverable within the
+   same conversation. Stamp `doc_over_cap: true` on that path so recovery
+   rates are measurable (did the agent retry with `fields` and succeed?).
+4. **Build it generic.** Implement as a small shared helper
+   (`guardResponseSize(kind, json)` alongside the D2 descriptor — cap +
+   props prefix + recovery hint per kind) so Slides adopts it by descriptor
+   entry, and so `sheets_read_range` / raw sheets reads (which can also blow
+   the cap on huge ranges, and today have no size observability at all) can
+   adopt it as a cheap follow-up. Wiring sheets reads into the helper is
+   **Phase 6** — it changes behavior on a battle-tested path and deserves
+   its own PostHog look first.
+
+Writes are exempt: batchUpdate responses are small; the guard applies to
+read-shaped responses only.
+
+## 4. Work plan
+
+### Phase 0 — Spike: prove Docs API + Picker per-file grant (½ day)
+Manual/browser, QA accounts, no code merged:
+1. Picker with `ViewId.DOCUMENTS` + our appId → pick a doc as USER_A.
+2. `GET docs.googleapis.com/v1/documents/{id}` with the Clerk-vaulted token
+   → expect 200 title/body; also confirm the `fields` mask works under
+   `drive.file` (it backs `docs_read_document`'s trim parameter, the
+   grant-check probe, AND D7's over-cap recovery advice).
+3. `batchUpdate` insertText → expect 200.
+4. Negative: same calls on an unpicked doc → 403/404 (confirms the grant is
+   per-file, not ambient).
+5. Size datapoint: fetch a real-world large doc (QA fixture below) and
+   record raw response size vs `fields`-masked size, to sanity-check the
+   `MAX_DOC_RESPONSE_CHARS` starting value.
+Record results in `docs/spike_results/`. **Gate: everything after this
+phase assumes the spike passed.**
+
+### Phase 1 — Policy core (pure, unit-testable)
+- `src/lib/driveFileKinds.ts` (new) — descriptor from D2, with `slide`
+  stubbed in the type; includes the D7 per-kind size-guard config (cap,
+  props prefix, recovery hint).
+- [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts):
+  `classifyGoogleApiCall` gains `documents` branch → `{kind:'docs',
+  documentId, isMutating}` + `{kind:'docs_create'}`; `extractDocsDocumentId`;
+  generalize `sheetsApprovalAction` → `fileApprovalAction(kind, …)`.
+- `guardResponseSize` helper (pure — unit-testable alongside the policy
+  suite): size measurement, cap check, over-cap message rendering.
+- [approvalLinks.ts](../../src/lib/approvalLinks.ts): add `docs_expose` /
+  `docs_write` actions + TTL + validation list.
+- Extend `scripts/test-google-api-policy.ts` and
+  `scripts/test-approval-links.ts` with docs cases, including
+  guard-over/under-cap cases.
+
+### Phase 2 — Enforcement + MCP tools
+- [route.ts](../../src/app/api/mcp/route.ts): generalize
+  `checkSheetsPermission` / `withSheetsGrace` / `sheetsErrorResult` into
+  kind-parameterized versions (sheets behavior byte-identical); register the
+  3 `docs_*` tools (read passes the raw `documents.get` response through,
+  with optional `fields` mask — D4 — behind the D7 size guard); extend
+  `request_access` enum + `get_my_permissions` posture text; handle `docs` /
+  `docs_create` classes with auto-grant; route raw `docs`-classified GET
+  responses through the same size guard.
+- [toolDefs.ts](../../src/app/api/mcp/toolDefs.ts): 3 new defs
+  (`docs_read_document`'s description names `fields` as the size lever);
+  update `google_api_get/modify` + `request_access` descriptions to name the
+  Docs API; run `mcp-tool-lint`.
+- [proxy route](../../src/app/api/proxy/%5B...path%5D/route.ts): service
+  detection (`documents` → `docs`) + same rule enforcement as sheets there.
+  (Size guard is MCP-only: the proxy serves plain HTTP clients with no
+  tool-result cap.)
+- Analytics: `denial_code`s `docs_not_exposed|docs_blocked|docs_read_only`,
+  grace props `docs_grace_*`, size props `doc_response_chars` /
+  `doc_response_kb` / `doc_over_cap` (D7), keep `raw_api_family` stamping.
+
+### Phase 3 — Grant flow + approval funnel (dashboard)
+- [useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts): accept a
+  `DriveFileKind` (view id + title); consent round-trip params carry the
+  kind so the auto-reopen lands on the right view.
+- [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts) →
+  `driveFileGrantCheck.ts` probing the kind's verify endpoint (docs:
+  `documents.get?fields=title`); keep a `verifySheetsGrant` re-export.
+- `/dashboard/docs-setup` (new page) + generalize `SheetsGrantRecovery` into
+  the shared component both pages render.
+- [approve page](../../src/app/dashboard/approve/page.tsx) +
+  `SheetsApprovalFlow` → kind-parameterized `FileApprovalFlow`; docs
+  approvals verify-then-grant with the same settling/grace UX.
+- API routes: `grant-docs-access` / `verify-docs-access` (thin wrappers over
+  shared handlers with `grant-sheets-access` / `verify-sheets-access`).
+- [actions.ts](../../src/app/dashboard/actions.ts): docs rule CRUD +
+  `exposeDocsFromPicker` mirroring the sheets server actions;
+  `DOC_ACTION_TYPES` validation.
+
+### Phase 4 — Dashboard management UI
+- Generalize [ExposedSheetsManager.tsx](../../src/app/dashboard/ExposedSheetsManager.tsx)
+  (or add a sibling driven by the same shared list component): expose/manage
+  docs per profile, read vs read-write toggle, block, "needs Google access"
+  chip wired to `/dashboard/docs-setup`.
+- [EditRuleButton.tsx](../../src/app/dashboard/EditRuleButton.tsx) /
+  `RuleControls` / `AgentProfilesView`: render `service='docs'` rules;
+  write-access copy states plainly that Read & Write = full-document edit
+  (§2 caveat).
+- [defaultProfile.ts](../../src/db/defaultProfile.ts): comment update only —
+  docs are deny-by-default with no rules, same as sheets.
+
+### Phase 5 — Docs, QA, lint
+- New QA capability `docs/QA_Acceptance_Test/capabilities/19_docs_management.md`
+  modeled on `09_sheets_management.md` (same picker-iframe harness notes;
+  the app-API seam for post-pick assertions is `grant-docs-access`).
+  Includes a size-guard assertion: reading the oversized QA fixture doc
+  without `fields` returns the ⚠️ guidance (not a payload), and the same
+  read WITH a `fields` mask succeeds — proving the recovery path the
+  message promises.
+- QA fixtures: one normal QA Google Doc owned by USER_A + one deliberately
+  large one (bulk-paste content until the raw response clears the cap —
+  one-time manual setup, documented in `/qa-setup` docs).
+- Touch-ups: `10_raw_google_api.md` (documents family now enforced + size
+  guard on raw docs reads), `15_request_access_tool.md` (new request types),
+  `17_sheets_grant_recovery.md` (shared component note),
+  `16_analytics_events.md` (doc_response_* / doc_over_cap props).
+- Agent runbooks in `docs/QA_Acceptance_Test/agents/` gain the docs
+  capability; `npx tsx scripts/qa-coverage-check.ts` stays the arbiter.
+- Repo docs: `user_guide.md`, `architecture_and_strategy.md` (data model),
+  `connector_submission/listing_copy.md` + `mcp-registry-server.json` (tool
+  list changed — connector directory listing must be resubmitted/updated).
+
+### Phase 6 — Optional / follow-up (not in first PR)
+- **Google Slides** (likely next): descriptor entry + `slides_*` tool defs +
+  QA capability — the D2 abstraction's acceptance test.
+- **Sheets size observability**: wire `sheets_read_range` / raw sheets reads
+  into the D7 `guardResponseSize` helper (props first, cap after a PostHog
+  look — it's a behavior change on a battle-tested path).
+- [partner manifest](../../src/lib/partner/manifest.ts): `'docs'` service +
+  consent-screen line ("Access documents you explicitly share").
+- Marketing: `use-cases/google-docs-agent` page, landing-page mention,
+  `src/app/docs/page.tsx` API docs.
+- Combined picker view (sheets + docs in one dialog) for the dashboard's
+  generic "expose files" entry point.
+- `docs_read_document` `format: 'markdown'` option, only if raw-JSON token
+  bloat proves to be a real agent pain point (see D4) — the D7 props are
+  exactly the data that decides this.
+
+## 5. Testing & rollout
+
+- Unit: policy classification + approval-link + size-guard suites (Phase 1
+  scripts).
+- Local QA: full docs capability run (incl. over-cap fixture assertion) +
+  targeted re-run of sheets capabilities **09, 10, 14, 15, 17** — the
+  generalization refactor touches their code paths, so sheets regressions
+  are the main risk.
+- `/deploy-pr-preview` → preview-branch QA per standard workflow; user runs
+  `/deploy-prod`.
+- No DB migration, no new env vars, no new OAuth scope → no infra steps.
+  Connector-directory listing update is the one external follow-up.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Docs API + Picker `drive.file` grant doesn't behave like Sheets in some corner (e.g. grant propagation lag differs) | Phase 0 spike gates everything; grace-retry machinery already handles propagation lag |
+| Generalization refactor regresses battle-hardened sheets flows | Sheets behavior kept byte-identical (routes, action names, analytics props unchanged); targeted sheets QA re-run in Phase 5 |
+| "Read & Write" on a doc is broader than users expect (batchUpdate can delete) | Explicit UI copy + `destructive: true` on replace/raw tools; append tool offered as the safe default |
+| Raw `documents.get` JSON exceeds MCP clients' tool-result caps and gets silently discarded after we report success | D7: size props on every read outcome + hard cap returning `fields`-mask recovery guidance instead of a doomed payload; over-cap rate visible in PostHog from day one |
+| `MAX_DOC_RESPONSE_CHARS` miscalibrated (too tight = needless friction; too loose = silent client drops continue) | Phase 0 records real response sizes; `doc_response_chars` distribution + `doc_over_cap` recovery rate in PostHog make recalibration a one-constant change |
+| Tool-count growth pushes connector-directory re-review | `mcp-tool-lint` invariants enforced; listing update planned as explicit follow-up |

--- a/docs/implementation_plans/google-docs-support-plan-b36c1c_v4.md
+++ b/docs/implementation_plans/google-docs-support-plan-b36c1c_v4.md
@@ -1,0 +1,374 @@
+# Google Docs Support — Implementation Plan (v4)
+
+**Branch**: `claude/google-docs-support-plan-b36c1c`
+**Status**: Draft for review — no implementation started.
+**Pattern source**: the Google Sheets integration (see
+`feature-google-drive-sheets-fgac_v6.md` and the code it produced).
+
+**Changes from v3** (Ken's review, 2026-08-19):
+- **D7 generalized from "docs reads" to "every tool response".** Size
+  observability moves to the shared MCP result-serialization layer
+  ([route.ts:198](../../src/app/api/mcp/route.ts) `textResult` — the choke
+  point every tool result already funnels through), so EVERY tool call gets
+  `response_chars` / `response_kb` stamped, not just docs. Cap *enforcement*
+  stays per-kind via a small registry: attachments (existing) and docs reads
+  (new) get caps on day one; sheets/gmail get observability now and caps
+  only after PostHog shows their real size distribution — capping a
+  battle-tested path without data is how regressions happen.
+
+**Changes from v2** (Ken's review, 2026-08-19):
+- **New D7 — response-size guardrail + observability**, following the
+  `gmail_get_attachment` pattern from `claude/fgac-mcp-attachment-debug-3f9974`
+  (commit `5aa23bd`): payload-size props on every outcome, and no returning
+  payloads that exceed the MCP client's tool-result cap — with an actionable
+  recovery message. For docs the recovery is agent-self-serviceable
+  (`fields` mask), unlike attachments where the message punts to the user.
+
+**Changes from v1** (Ken's review, 2026-08-19):
+- **D2 resolved — generalize.** Presentations (Google Slides) are likely
+  next, so the shared plumbing is designed for three kinds from day one,
+  with `slide` stubbed in the descriptor type now.
+- **D4 revised — the read tool returns the raw `documents.get` API response
+  verbatim** instead of extracted plain text. Markdown conversion was
+  considered and rejected for now: fidelity gets tricky with embedded
+  objects (tables, images, inline drawings). An optional `fields` mask keeps
+  large responses trimmable.
+
+## 1. How Sheets works today (the pattern we're following)
+
+The Sheets integration has five load-bearing properties, all of which carry
+over to Docs unchanged:
+
+1. **No service-wide OAuth scope.** FGAC never requests a Sheets scope; API
+   access rides on per-file `drive.file` grants that Google registers only
+   when the user picks the file in the Google Picker with our `appId`
+   ([useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts),
+   [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts)). This is what
+   keeps the CASA/verification surface small.
+2. **Deny-by-default per-file rules.** `access_rules` rows with
+   `service='sheets'`, `actionType ∈ {sheet_read, sheet_read_write,
+   sheet_block}`, `targetResourceId=<spreadsheetId>`. No rule → denied.
+3. **Two-halves enforcement.** FGAC's rule check
+   (`checkSheetsPermission` in [route.ts](../../src/app/api/mcp/route.ts))
+   is separate from the Google-side grant; a 403/404 *after* FGAC allows the
+   call routes the user to `/dashboard/sheets-setup` (grant recovery), with
+   grace retries for freshly created rules (`withSheetsGrace`).
+4. **Denial → approval funnel.** Every denial mints a single-use magic link
+   (`sheets_expose` / `sheets_write` in
+   [approvalLinks.ts](../../src/lib/approvalLinks.ts)); the approve page runs
+   picker-first (`SheetsApprovalFlow`) so a rule is never created for a sheet
+   Google can't reach.
+5. **Curated tools + raw passthrough, same policy.** Four `sheets_*` MCP
+   tools plus `google_api_get/modify`, all funneling through one
+   classification (`classifyGoogleApiCall` in
+   [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts)) and one
+   permission check. Agent-created spreadsheets are auto-granted to the
+   creating key (`sheets_create` posture, 2026-08-19).
+
+A sixth pattern arrived with the attachment work and is adopted and
+generalized here (D7):
+
+6. **Payload-size observability + cap.** `gmail_get_attachment` records
+   `attachment_chars` / `attachment_kb` on every outcome via
+   `addToolCallProps`, and refuses payloads over `MAX_ATTACHMENT_CHARS`
+   (200k base64url chars ≈ 150 KB) with a `⚠️` message instead — because MCP
+   clients impose their own tool-result caps (Claude Code rejects results
+   over ~25k tokens), so a server-side "success" can still be silently
+   discarded client-side after we report it as delivered.
+
+## 2. Key facts about the Google Docs API
+
+- Endpoint family: `https://docs.googleapis.com/v1/documents/{documentId}`.
+- **`drive.file` is a supported scope** for `documents.get`,
+  `documents.create`, and `documents.batchUpdate` — the per-file Picker
+  grant mechanism works identically. (Phase 0 verifies this empirically
+  before we build on it.)
+- Picker view: `google.picker.ViewId.DOCUMENTS` (we use `SPREADSHEETS`
+  today; Slides later will use `PRESENTATIONS`).
+- API shape differs from Sheets in one way that matters for policy:
+  **there are no ranges.** `documents.get` returns the whole document;
+  `documents.batchUpdate` is the *only* write endpoint and can insert,
+  replace, style, and **delete** content. So "Read & Write" on a doc means
+  full-document edit — the plan surfaces that honestly in tool annotations
+  and rule UI copy, and offers a non-destructive append tool for the common
+  agent case.
+- Because reads are whole-document and the response is verbose structural
+  JSON, **docs reads are the most cap-prone payload FGAC will serve** —
+  they are D7's first enforced kind.
+
+## 3. Design decisions
+
+### D1 — Reuse the `drive.file` + Picker mechanism; no new OAuth scope
+Same consent, same appId, same grant-recovery machinery. No Google
+re-verification impact. (Alternative — request `documents` scope — rejected:
+it breaks the entire FGAC premise and the CASA posture.)
+
+### D2 — Generalize the shared plumbing (DECIDED — presentations coming next)
+The Picker hook, grant check, setup/recovery page, and approval flow are
+~95% file-type-agnostic. Parameterize them by a small descriptor rather than
+copy-pasting; **Google Slides is expected soon and must be a descriptor
+entry, not a third fork**:
+
+```ts
+// src/lib/driveFileKinds.ts (new)
+export type DriveFileKind = 'sheet' | 'doc' | 'slide'; // 'slide' stubbed now, wired when Slides ships
+export const DRIVE_FILE_KINDS: Record<DriveFileKind, {
+  service: 'sheets' | 'docs' | 'slides'; // access_rules.service
+  pickerViewId: 'SPREADSHEETS' | 'DOCUMENTS' | 'PRESENTATIONS';
+  verifyUrl: (id: string) => string;      // grant-check probe endpoint
+  setupPath: string;                      // /dashboard/sheets-setup | docs-setup | slides-setup
+  noun: string;                           // "spreadsheet" | "document" | "presentation"
+}>;
+```
+
+Implementation note for the refactor: every place Phase 2–4 generalizes
+(`checkSheetsPermission`, `withSheetsGrace`, grant recovery, approval flow,
+rule CRUD, exposed-files manager) must key off the descriptor — zero
+remaining `if (kind === 'doc')` branches in shared code. The acceptance test
+for the abstraction is: **adding Slides later touches `driveFileKinds.ts`,
+tool defs/registrations, and QA docs — nothing else.**
+
+Existing `sheets-*` route paths, action names, and analytics event props
+**stay unchanged** (no churn for existing users/links); the docs variants
+are new parameterizations of the same components.
+
+### D3 — Rule model: `service='docs'`, no schema migration
+`access_rules.service` and `actionType` are plain `text` columns. New values:
+`doc_read`, `doc_read_write`, `doc_block`; `targetResourceId=<documentId>`.
+Zero DDL — comment updates in [schema.ts](../../src/db/schema.ts) only.
+
+### D4 — Curated MCP tool set (3 new tools); read returns the raw API response
+
+| Tool | Maps to | Returns | Annotations |
+|---|---|---|---|
+| `docs_read_document` | `documents.get` | **The raw Docs API JSON response, verbatim.** Optional `fields` parameter passes Google's standard field mask through, so agents can trim large documents (e.g. `title,body.content`) | readOnly |
+| `docs_append_text` | `batchUpdate` / `insertText` at `endOfSegmentLocation` | Raw batchUpdate response | write, `destructive: false` (mirrors `sheets_append_rows`) |
+| `docs_replace_text` | `batchUpdate` / `replaceAllText` | Raw batchUpdate response | write, `destructive: true` |
+
+**No content transformation on read** (decided in review): FGAC passes
+through what `documents.get` returns, exactly as the `sheets_*` tools pass
+through Sheets API responses. Markdown conversion was considered and
+**rejected for the first release** — embedded objects (tables, inline
+images, drawings, footnotes, suggestions) make a faithful conversion a
+project of its own, and a lossy one would silently hide content from
+agents, which is worse than verbose JSON. Modern agents parse the Docs JSON
+structure fine. If token bloat shows up in practice, a `format: 'markdown'`
+option can be added later as a follow-up without breaking anything; the
+tool description will note that `fields` is the size-control lever for now
+(and D7's over-cap message teaches it at exactly the moment it's needed).
+
+Everything else (styling, deleting ranges, tables) goes through
+`google_api_modify` under the same per-doc rule. `documents.create` via raw
+POST is auto-granted to the calling key, mirroring the `sheets_create`
+posture. All defs must pass `scripts/mcp-tool-lint.ts` invariants.
+
+### D5 — Raw-API behavior change (call out explicitly)
+Today `docs/v1/documents/...` through `google_api_get/modify` falls into the
+**passthrough** branch (unknown family, backstopped only by the OAuth
+scope — and in practice 403s because nothing grants docs files). This plan
+moves the `documents` family into an **enforced** class: per-doc FGAC rule
+required, denials mint approval links. Strictly a tightening; no working
+flow regresses.
+
+### D6 — Docs get the same approval-funnel treatment as Sheets
+New approval actions `docs_expose` / `docs_write` (30-min TTL like sheets —
+generalize the `startsWith('sheets')` TTL check to a kind lookup),
+picker-first approve flow, `/dashboard/docs-setup` grant recovery, and
+`request_access` grows `docs_read` / `docs_write` request types.
+
+### D7 — Universal response-size observability; per-kind caps
+Generalizes the `gmail_get_attachment` pattern (commit `5aa23bd`) from one
+tool to the whole tool surface. Two layers with different blast radii:
+
+**Layer 1 — observability on EVERY tool response (universal, day one).**
+All tool results already funnel through one choke point —
+`textResult` / `jsonResult` at [route.ts:198](../../src/app/api/mcp/route.ts).
+Measure there: stamp `response_chars` and `response_kb` onto the tool-call
+analytics event for **every** tool, every outcome (success, denial, error).
+Zero behavior change — pure measurement. This is what lets PostHog answer,
+for any tool and any client: how often do we report success on a payload
+the client then silently discards? The existing `attachment_chars` /
+`attachment_kb` props stay for dashboard continuity; the generic props are
+additive.
+
+The client-side budget varies by agent (Claude Code rejects tool results
+over ~25k tokens; other MCP clients differ, and `user_agent` /
+`client_name` already land on the event), so Layer 1 deliberately records
+raw size and leaves "too large for whom?" as an analytics-time question —
+per-client thresholds can be applied in PostHog without shipping code.
+
+**Layer 2 — enforcement: per-kind caps with recovery guidance.**
+A small registry (colocated with the D2 descriptor) declares, per response
+kind: the cap in chars, and the recovery hint. Over the cap, the tool does
+NOT return the doomed payload — it returns a `⚠️` message sized to the
+payload with the kind's recovery action, and stamps `response_over_cap:
+true`. Day-one entries:
+
+| Kind | Cap | Recovery hint | Status |
+|---|---|---|---|
+| Gmail attachment | 200k b64 chars (existing `MAX_ATTACHMENT_CHARS`) | "Ask the user to retrieve it from Gmail" (opaque binary — no trim lever) | already live; migrates into the registry unchanged |
+| Docs read (curated + raw) | `100_000` JSON chars ≈ 25k tokens, calibrated by Phase 0 measurements | "Retry with the `fields` parameter (e.g. `title,body.content`) — the user does not need to do anything" (agent-self-serviceable) | **new, this PR** |
+| Sheets reads, Gmail reads/lists | — | candidate hints: narrower range / fewer results / `fields` | **observability only** — caps proposed as a follow-up once Layer 1 shows their real size distribution (capping a battle-tested path without data is how regressions happen) |
+
+Writes are exempt everywhere: mutation responses are small; the guard
+applies to read-shaped responses only. The proxy route is also exempt — it
+serves plain HTTP clients that have no tool-result cap.
+
+Implementation: `guardResponseSize(kind, payload)` pure helper (Phase 1,
+unit-tested) + the `textResult`-layer measurement (Phase 2). Slides adopts
+both by registry entry when it ships.
+
+## 4. Work plan
+
+### Phase 0 — Spike: prove Docs API + Picker per-file grant (½ day)
+Manual/browser, QA accounts, no code merged:
+1. Picker with `ViewId.DOCUMENTS` + our appId → pick a doc as USER_A.
+2. `GET docs.googleapis.com/v1/documents/{id}` with the Clerk-vaulted token
+   → expect 200 title/body; also confirm the `fields` mask works under
+   `drive.file` (it backs `docs_read_document`'s trim parameter, the
+   grant-check probe, AND D7's over-cap recovery advice).
+3. `batchUpdate` insertText → expect 200.
+4. Negative: same calls on an unpicked doc → 403/404 (confirms the grant is
+   per-file, not ambient).
+5. Size datapoint: fetch a real-world large doc (QA fixture below) and
+   record raw response size vs `fields`-masked size, to sanity-check the
+   docs cap's starting value.
+Record results in `docs/spike_results/`. **Gate: everything after this
+phase assumes the spike passed.**
+
+### Phase 1 — Policy core (pure, unit-testable)
+- `src/lib/driveFileKinds.ts` (new) — descriptor from D2, with `slide`
+  stubbed in the type.
+- `guardResponseSize` helper + per-kind cap registry (D7 Layer 2) — pure,
+  unit-testable: size measurement, cap lookup, over-cap message rendering.
+  `MAX_ATTACHMENT_CHARS` migrates into the registry unchanged.
+- [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts):
+  `classifyGoogleApiCall` gains `documents` branch → `{kind:'docs',
+  documentId, isMutating}` + `{kind:'docs_create'}`; `extractDocsDocumentId`;
+  generalize `sheetsApprovalAction` → `fileApprovalAction(kind, …)`.
+- [approvalLinks.ts](../../src/lib/approvalLinks.ts): add `docs_expose` /
+  `docs_write` actions + TTL + validation list.
+- Extend `scripts/test-google-api-policy.ts` and
+  `scripts/test-approval-links.ts` with docs cases, including
+  guard-over/under-cap cases (docs and attachment kinds).
+
+### Phase 2 — Enforcement + MCP tools
+- [route.ts](../../src/app/api/mcp/route.ts):
+  - **D7 Layer 1**: `textResult`/`jsonResult` (route.ts:198) stamp
+    `response_chars` / `response_kb` via `addToolCallProps` on every tool
+    result. `gmail_get_attachment` keeps its `attachment_*` props and moves
+    its cap check onto the shared guard.
+  - Generalize `checkSheetsPermission` / `withSheetsGrace` /
+    `sheetsErrorResult` into kind-parameterized versions (sheets behavior
+    byte-identical).
+  - Register the 3 `docs_*` tools (read passes the raw `documents.get`
+    response through, with optional `fields` mask — D4 — behind the D7
+    guard); raw `docs`-classified GETs go through the same guard.
+  - Extend `request_access` enum + `get_my_permissions` posture text; handle
+    `docs` / `docs_create` classes with auto-grant.
+- [toolDefs.ts](../../src/app/api/mcp/toolDefs.ts): 3 new defs
+  (`docs_read_document`'s description names `fields` as the size lever);
+  update `google_api_get/modify` + `request_access` descriptions to name the
+  Docs API; run `mcp-tool-lint`.
+- [proxy route](../../src/app/api/proxy/%5B...path%5D/route.ts): service
+  detection (`documents` → `docs`) + same rule enforcement as sheets there.
+  (No size guard — plain HTTP clients have no tool-result cap.)
+- Analytics: `denial_code`s `docs_not_exposed|docs_blocked|docs_read_only`,
+  grace props `docs_grace_*`, universal `response_chars` / `response_kb` /
+  `response_over_cap` (D7), keep `raw_api_family` stamping.
+
+### Phase 3 — Grant flow + approval funnel (dashboard)
+- [useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts): accept a
+  `DriveFileKind` (view id + title); consent round-trip params carry the
+  kind so the auto-reopen lands on the right view.
+- [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts) →
+  `driveFileGrantCheck.ts` probing the kind's verify endpoint (docs:
+  `documents.get?fields=title`); keep a `verifySheetsGrant` re-export.
+- `/dashboard/docs-setup` (new page) + generalize `SheetsGrantRecovery` into
+  the shared component both pages render.
+- [approve page](../../src/app/dashboard/approve/page.tsx) +
+  `SheetsApprovalFlow` → kind-parameterized `FileApprovalFlow`; docs
+  approvals verify-then-grant with the same settling/grace UX.
+- API routes: `grant-docs-access` / `verify-docs-access` (thin wrappers over
+  shared handlers with `grant-sheets-access` / `verify-sheets-access`).
+- [actions.ts](../../src/app/dashboard/actions.ts): docs rule CRUD +
+  `exposeDocsFromPicker` mirroring the sheets server actions;
+  `DOC_ACTION_TYPES` validation.
+
+### Phase 4 — Dashboard management UI
+- Generalize [ExposedSheetsManager.tsx](../../src/app/dashboard/ExposedSheetsManager.tsx)
+  (or add a sibling driven by the same shared list component): expose/manage
+  docs per profile, read vs read-write toggle, block, "needs Google access"
+  chip wired to `/dashboard/docs-setup`.
+- [EditRuleButton.tsx](../../src/app/dashboard/EditRuleButton.tsx) /
+  `RuleControls` / `AgentProfilesView`: render `service='docs'` rules;
+  write-access copy states plainly that Read & Write = full-document edit
+  (§2 caveat).
+- [defaultProfile.ts](../../src/db/defaultProfile.ts): comment update only —
+  docs are deny-by-default with no rules, same as sheets.
+
+### Phase 5 — Docs, QA, lint
+- New QA capability `docs/QA_Acceptance_Test/capabilities/19_docs_management.md`
+  modeled on `09_sheets_management.md` (same picker-iframe harness notes;
+  the app-API seam for post-pick assertions is `grant-docs-access`).
+  Includes a size-guard assertion: reading the oversized QA fixture doc
+  without `fields` returns the ⚠️ guidance (not a payload), and the same
+  read WITH a `fields` mask succeeds — proving the recovery path the
+  message promises.
+- QA fixtures: one normal QA Google Doc owned by USER_A + one deliberately
+  large one (bulk-paste content until the raw response clears the cap —
+  one-time manual setup, documented in `/qa-setup` docs).
+- Touch-ups: `10_raw_google_api.md` (documents family now enforced + size
+  guard on raw docs reads), `15_request_access_tool.md` (new request types),
+  `17_sheets_grant_recovery.md` (shared component note),
+  `16_analytics_events.md` (universal `response_chars` / `response_kb` /
+  `response_over_cap` props — assert they appear on gmail and sheets tool
+  calls too, since Layer 1 is universal).
+- Agent runbooks in `docs/QA_Acceptance_Test/agents/` gain the docs
+  capability; `npx tsx scripts/qa-coverage-check.ts` stays the arbiter.
+- Repo docs: `user_guide.md`, `architecture_and_strategy.md` (data model),
+  `analytics.md` (new universal size props), `connector_submission/listing_copy.md`
+  + `mcp-registry-server.json` (tool list changed — connector directory
+  listing must be resubmitted/updated).
+
+### Phase 6 — Optional / follow-up (not in first PR)
+- **Google Slides** (likely next): descriptor entry + `slides_*` tool defs +
+  QA capability — the D2 abstraction's acceptance test.
+- **Caps for sheets/gmail reads** (D7 Layer 2 extension): once Layer 1's
+  `response_chars` distribution shows where sheets/gmail reads actually
+  land, add registry entries with the right hints (narrower range, fewer
+  results, `fields`). Data-first, because these paths are battle-tested.
+- [partner manifest](../../src/lib/partner/manifest.ts): `'docs'` service +
+  consent-screen line ("Access documents you explicitly share").
+- Marketing: `use-cases/google-docs-agent` page, landing-page mention,
+  `src/app/docs/page.tsx` API docs.
+- Combined picker view (sheets + docs in one dialog) for the dashboard's
+  generic "expose files" entry point.
+- `docs_read_document` `format: 'markdown'` option, only if raw-JSON token
+  bloat proves to be a real agent pain point (see D4) — the D7 props are
+  exactly the data that decides this.
+
+## 5. Testing & rollout
+
+- Unit: policy classification + approval-link + size-guard suites (Phase 1
+  scripts).
+- Local QA: full docs capability run (incl. over-cap fixture assertion) +
+  targeted re-run of sheets capabilities **09, 10, 14, 15, 17** and
+  **16 (analytics)** — the generalization refactor and the universal size
+  props touch their code paths.
+- `/deploy-pr-preview` → preview-branch QA per standard workflow; user runs
+  `/deploy-prod`.
+- No DB migration, no new env vars, no new OAuth scope → no infra steps.
+  Connector-directory listing update is the one external follow-up.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Docs API + Picker `drive.file` grant doesn't behave like Sheets in some corner (e.g. grant propagation lag differs) | Phase 0 spike gates everything; grace-retry machinery already handles propagation lag |
+| Generalization refactor regresses battle-hardened sheets flows | Sheets behavior kept byte-identical (routes, action names, analytics props unchanged); targeted sheets QA re-run in Phase 5 |
+| "Read & Write" on a doc is broader than users expect (batchUpdate can delete) | Explicit UI copy + `destructive: true` on replace/raw tools; append tool offered as the safe default |
+| Raw `documents.get` JSON exceeds MCP clients' tool-result caps and gets silently discarded after we report success | D7: universal size props on every response + docs cap returning `fields`-mask recovery guidance instead of a doomed payload; over-cap rate visible in PostHog from day one |
+| Docs cap miscalibrated (too tight = needless friction; too loose = silent client drops continue), and client budgets differ per agent | Phase 0 records real response sizes; universal `response_chars` + `client_name` on events make per-client threshold analysis a PostHog query and recalibration a one-constant change |
+| Universal measurement layer accidentally alters result shape or breaks a tool | Layer 1 is measurement-only inside `textResult` — no payload change; QA capability 16 asserts props exist AND existing capabilities re-run green |
+| Tool-count growth pushes connector-directory re-review | `mcp-tool-lint` invariants enforced; listing update planned as explicit follow-up |

--- a/docs/implementation_plans/google-docs-support-plan-b36c1c_v5.md
+++ b/docs/implementation_plans/google-docs-support-plan-b36c1c_v5.md
@@ -1,0 +1,369 @@
+# Google Docs Support — Implementation Plan (v5)
+
+**Branch**: `claude/google-docs-support-plan-b36c1c`
+**Status**: Draft for review — no implementation started.
+**Pattern source**: the Google Sheets integration (see
+`feature-google-drive-sheets-fgac_v6.md` and the code it produced).
+
+**Changes from v4** (Ken's review, 2026-08-19):
+- **D7 is now monitoring-only.** No new caps are enforced anywhere — not
+  even on docs reads — until PostHog data confirms response size is
+  actually the failure mode. Universal `response_chars` / `response_kb`
+  measurement ships in this PR; the cap registry, the docs over-cap
+  message, and all enforcement move to Phase 6, gated on that data. The
+  one exception is the existing `gmail_get_attachment` cap
+  (`MAX_ATTACHMENT_CHARS`), which is already live in production and stays
+  exactly as it is — untouched.
+
+**Changes from v3** (Ken's review, 2026-08-19):
+- **D7 generalized from "docs reads" to "every tool response".** Size
+  observability moves to the shared MCP result-serialization layer
+  ([route.ts:198](../../src/app/api/mcp/route.ts) `textResult` — the choke
+  point every tool result already funnels through), so EVERY tool call gets
+  size props stamped, not just docs.
+
+**Changes from v2** (Ken's review, 2026-08-19):
+- **New D7 — response-size observability**, following the
+  `gmail_get_attachment` pattern from `claude/fgac-mcp-attachment-debug-3f9974`
+  (commit `5aa23bd`): payload-size props on every outcome, so PostHog can
+  see server-side "successes" that exceed the MCP client's tool-result cap
+  and get silently discarded client-side.
+
+**Changes from v1** (Ken's review, 2026-08-19):
+- **D2 resolved — generalize.** Presentations (Google Slides) are likely
+  next, so the shared plumbing is designed for three kinds from day one,
+  with `slide` stubbed in the descriptor type now.
+- **D4 revised — the read tool returns the raw `documents.get` API response
+  verbatim** instead of extracted plain text. Markdown conversion was
+  considered and rejected for now: fidelity gets tricky with embedded
+  objects (tables, images, inline drawings). An optional `fields` mask keeps
+  large responses trimmable.
+
+## 1. How Sheets works today (the pattern we're following)
+
+The Sheets integration has five load-bearing properties, all of which carry
+over to Docs unchanged:
+
+1. **No service-wide OAuth scope.** FGAC never requests a Sheets scope; API
+   access rides on per-file `drive.file` grants that Google registers only
+   when the user picks the file in the Google Picker with our `appId`
+   ([useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts),
+   [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts)). This is what
+   keeps the CASA/verification surface small.
+2. **Deny-by-default per-file rules.** `access_rules` rows with
+   `service='sheets'`, `actionType ∈ {sheet_read, sheet_read_write,
+   sheet_block}`, `targetResourceId=<spreadsheetId>`. No rule → denied.
+3. **Two-halves enforcement.** FGAC's rule check
+   (`checkSheetsPermission` in [route.ts](../../src/app/api/mcp/route.ts))
+   is separate from the Google-side grant; a 403/404 *after* FGAC allows the
+   call routes the user to `/dashboard/sheets-setup` (grant recovery), with
+   grace retries for freshly created rules (`withSheetsGrace`).
+4. **Denial → approval funnel.** Every denial mints a single-use magic link
+   (`sheets_expose` / `sheets_write` in
+   [approvalLinks.ts](../../src/lib/approvalLinks.ts)); the approve page runs
+   picker-first (`SheetsApprovalFlow`) so a rule is never created for a sheet
+   Google can't reach.
+5. **Curated tools + raw passthrough, same policy.** Four `sheets_*` MCP
+   tools plus `google_api_get/modify`, all funneling through one
+   classification (`classifyGoogleApiCall` in
+   [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts)) and one
+   permission check. Agent-created spreadsheets are auto-granted to the
+   creating key (`sheets_create` posture, 2026-08-19).
+
+A sixth pattern arrived with the attachment work; this plan adopts its
+**observability half** universally (D7):
+
+6. **Payload-size observability.** `gmail_get_attachment` records
+   `attachment_chars` / `attachment_kb` on every outcome via
+   `addToolCallProps` — because MCP clients impose their own tool-result
+   caps (Claude Code rejects results over ~25k tokens), so a server-side
+   "success" can still be silently discarded client-side after we report it
+   as delivered. Analytics can't see that failure mode without the size on
+   the event. (That tool also enforces `MAX_ATTACHMENT_CHARS`; the cap half
+   of the pattern is deliberately NOT extended anywhere new in this plan —
+   see D7.)
+
+## 2. Key facts about the Google Docs API
+
+- Endpoint family: `https://docs.googleapis.com/v1/documents/{documentId}`.
+- **`drive.file` is a supported scope** for `documents.get`,
+  `documents.create`, and `documents.batchUpdate` — the per-file Picker
+  grant mechanism works identically. (Phase 0 verifies this empirically
+  before we build on it.)
+- Picker view: `google.picker.ViewId.DOCUMENTS` (we use `SPREADSHEETS`
+  today; Slides later will use `PRESENTATIONS`).
+- API shape differs from Sheets in one way that matters for policy:
+  **there are no ranges.** `documents.get` returns the whole document;
+  `documents.batchUpdate` is the *only* write endpoint and can insert,
+  replace, style, and **delete** content. So "Read & Write" on a doc means
+  full-document edit — the plan surfaces that honestly in tool annotations
+  and rule UI copy, and offers a non-destructive append tool for the common
+  agent case.
+- Because reads are whole-document and the response is verbose structural
+  JSON, **docs reads are the most cap-prone payload FGAC will serve** —
+  which is why D7's monitoring lands in the same PR, so the size question
+  has data from day one.
+
+## 3. Design decisions
+
+### D1 — Reuse the `drive.file` + Picker mechanism; no new OAuth scope
+Same consent, same appId, same grant-recovery machinery. No Google
+re-verification impact. (Alternative — request `documents` scope — rejected:
+it breaks the entire FGAC premise and the CASA posture.)
+
+### D2 — Generalize the shared plumbing (DECIDED — presentations coming next)
+The Picker hook, grant check, setup/recovery page, and approval flow are
+~95% file-type-agnostic. Parameterize them by a small descriptor rather than
+copy-pasting; **Google Slides is expected soon and must be a descriptor
+entry, not a third fork**:
+
+```ts
+// src/lib/driveFileKinds.ts (new)
+export type DriveFileKind = 'sheet' | 'doc' | 'slide'; // 'slide' stubbed now, wired when Slides ships
+export const DRIVE_FILE_KINDS: Record<DriveFileKind, {
+  service: 'sheets' | 'docs' | 'slides'; // access_rules.service
+  pickerViewId: 'SPREADSHEETS' | 'DOCUMENTS' | 'PRESENTATIONS';
+  verifyUrl: (id: string) => string;      // grant-check probe endpoint
+  setupPath: string;                      // /dashboard/sheets-setup | docs-setup | slides-setup
+  noun: string;                           // "spreadsheet" | "document" | "presentation"
+}>;
+```
+
+Implementation note for the refactor: every place Phase 2–4 generalizes
+(`checkSheetsPermission`, `withSheetsGrace`, grant recovery, approval flow,
+rule CRUD, exposed-files manager) must key off the descriptor — zero
+remaining `if (kind === 'doc')` branches in shared code. The acceptance test
+for the abstraction is: **adding Slides later touches `driveFileKinds.ts`,
+tool defs/registrations, and QA docs — nothing else.**
+
+Existing `sheets-*` route paths, action names, and analytics event props
+**stay unchanged** (no churn for existing users/links); the docs variants
+are new parameterizations of the same components.
+
+### D3 — Rule model: `service='docs'`, no schema migration
+`access_rules.service` and `actionType` are plain `text` columns. New values:
+`doc_read`, `doc_read_write`, `doc_block`; `targetResourceId=<documentId>`.
+Zero DDL — comment updates in [schema.ts](../../src/db/schema.ts) only.
+
+### D4 — Curated MCP tool set (3 new tools); read returns the raw API response
+
+| Tool | Maps to | Returns | Annotations |
+|---|---|---|---|
+| `docs_read_document` | `documents.get` | **The raw Docs API JSON response, verbatim.** Optional `fields` parameter passes Google's standard field mask through, so agents can trim large documents (e.g. `title,body.content`) | readOnly |
+| `docs_append_text` | `batchUpdate` / `insertText` at `endOfSegmentLocation` | Raw batchUpdate response | write, `destructive: false` (mirrors `sheets_append_rows`) |
+| `docs_replace_text` | `batchUpdate` / `replaceAllText` | Raw batchUpdate response | write, `destructive: true` |
+
+**No content transformation on read** (decided in review): FGAC passes
+through what `documents.get` returns, exactly as the `sheets_*` tools pass
+through Sheets API responses. Markdown conversion was considered and
+**rejected for the first release** — embedded objects (tables, inline
+images, drawings, footnotes, suggestions) make a faithful conversion a
+project of its own, and a lossy one would silently hide content from
+agents, which is worse than verbose JSON. Modern agents parse the Docs JSON
+structure fine. If token bloat shows up in practice, a `format: 'markdown'`
+option can be added later as a follow-up without breaking anything; the
+tool description names `fields` as the size-control lever so agents reach
+for it unprompted.
+
+Everything else (styling, deleting ranges, tables) goes through
+`google_api_modify` under the same per-doc rule. `documents.create` via raw
+POST is auto-granted to the calling key, mirroring the `sheets_create`
+posture. All defs must pass `scripts/mcp-tool-lint.ts` invariants.
+
+### D5 — Raw-API behavior change (call out explicitly)
+Today `docs/v1/documents/...` through `google_api_get/modify` falls into the
+**passthrough** branch (unknown family, backstopped only by the OAuth
+scope — and in practice 403s because nothing grants docs files). This plan
+moves the `documents` family into an **enforced** class: per-doc FGAC rule
+required, denials mint approval links. Strictly a tightening; no working
+flow regresses.
+
+### D6 — Docs get the same approval-funnel treatment as Sheets
+New approval actions `docs_expose` / `docs_write` (30-min TTL like sheets —
+generalize the `startsWith('sheets')` TTL check to a kind lookup),
+picker-first approve flow, `/dashboard/docs-setup` grant recovery, and
+`request_access` grows `docs_read` / `docs_write` request types.
+
+### D7 — Universal response-size MONITORING; no new caps (DECIDED)
+Generalizes the observability half of the `gmail_get_attachment` pattern
+(commit `5aa23bd`) from one tool to the whole tool surface. **Enforcement is
+explicitly out of scope for this PR** — no payload is refused for size
+anywhere new until the data confirms response size is actually the failure
+mode agents are hitting.
+
+**What ships now — measurement at the choke point.** All tool results
+already funnel through `textResult` / `jsonResult` at
+[route.ts:198](../../src/app/api/mcp/route.ts). Measure there: stamp
+`response_chars` and `response_kb` onto the tool-call analytics event for
+**every** tool, every outcome (success, denial, error). Zero behavior
+change — the payload is returned exactly as before, whatever its size.
+The existing `attachment_chars` / `attachment_kb` props stay for dashboard
+continuity; the generic props are additive.
+
+The client-side budget varies by agent (Claude Code rejects tool results
+over ~25k tokens; other MCP clients differ, and `client_name` /
+`user_agent` already land on the event), so the monitoring deliberately
+records raw size and leaves "too large for whom?" as an analytics-time
+question — per-client thresholds are PostHog queries, not shipped code.
+
+**What does NOT ship — caps.** The v4 draft added a docs-read cap with a
+`fields`-mask recovery message. Cut (Ken, 2026-08-19): we don't yet know
+that size is the problem, and a cap on an unconfirmed theory adds friction
+and a new failure mode for nothing. The one existing cap —
+`gmail_get_attachment`'s `MAX_ATTACHMENT_CHARS` — is live production
+behavior and **stays exactly as it is**; this plan neither extends nor
+refactors it.
+
+**The confirmation question the monitoring must answer** (PostHog, after
+release): what fraction of successful docs/sheets/gmail reads exceed ~25k
+tokens' worth of chars for clients identified as Claude Code, and do those
+calls correlate with abandoned tool sequences (the client-side silent-drop
+signature — server says success, agent behaves as if it got nothing)? If
+that fraction is material, Phase 6 revives the v4 cap design (per-kind
+registry + recovery hints, docs first since `fields` makes its recovery
+agent-self-serviceable) as its own reviewed change.
+
+## 4. Work plan
+
+### Phase 0 — Spike: prove Docs API + Picker per-file grant (½ day)
+Manual/browser, QA accounts, no code merged:
+1. Picker with `ViewId.DOCUMENTS` + our appId → pick a doc as USER_A.
+2. `GET docs.googleapis.com/v1/documents/{id}` with the Clerk-vaulted token
+   → expect 200 title/body; also confirm the `fields` mask works under
+   `drive.file` (it backs `docs_read_document`'s trim parameter and the
+   grant-check probe).
+3. `batchUpdate` insertText → expect 200.
+4. Negative: same calls on an unpicked doc → 403/404 (confirms the grant is
+   per-file, not ambient).
+5. Size datapoint: fetch a realistically large doc and record raw response
+   size vs `fields`-masked size — baseline data for the D7 confirmation
+   question and for calibrating a future cap if one proves warranted.
+Record results in `docs/spike_results/`. **Gate: everything after this
+phase assumes the spike passed.**
+
+### Phase 1 — Policy core (pure, unit-testable)
+- `src/lib/driveFileKinds.ts` (new) — descriptor from D2, with `slide`
+  stubbed in the type.
+- [googleApiPolicy.ts](../../src/app/api/mcp/googleApiPolicy.ts):
+  `classifyGoogleApiCall` gains `documents` branch → `{kind:'docs',
+  documentId, isMutating}` + `{kind:'docs_create'}`; `extractDocsDocumentId`;
+  generalize `sheetsApprovalAction` → `fileApprovalAction(kind, …)`.
+- [approvalLinks.ts](../../src/lib/approvalLinks.ts): add `docs_expose` /
+  `docs_write` actions + TTL + validation list.
+- Extend `scripts/test-google-api-policy.ts` and
+  `scripts/test-approval-links.ts` with docs cases.
+
+### Phase 2 — Enforcement + MCP tools
+- [route.ts](../../src/app/api/mcp/route.ts):
+  - **D7 monitoring**: `textResult`/`jsonResult` (route.ts:198) stamp
+    `response_chars` / `response_kb` via `addToolCallProps` on every tool
+    result. Measurement-only — no size-based behavior anywhere new;
+    `gmail_get_attachment`'s existing cap and props are untouched.
+  - Generalize `checkSheetsPermission` / `withSheetsGrace` /
+    `sheetsErrorResult` into kind-parameterized versions (sheets behavior
+    byte-identical).
+  - Register the 3 `docs_*` tools (read passes the raw `documents.get`
+    response through, with optional `fields` mask — D4).
+  - Extend `request_access` enum + `get_my_permissions` posture text; handle
+    `docs` / `docs_create` classes with auto-grant.
+- [toolDefs.ts](../../src/app/api/mcp/toolDefs.ts): 3 new defs
+  (`docs_read_document`'s description names `fields` as the size lever);
+  update `google_api_get/modify` + `request_access` descriptions to name the
+  Docs API; run `mcp-tool-lint`.
+- [proxy route](../../src/app/api/proxy/%5B...path%5D/route.ts): service
+  detection (`documents` → `docs`) + same rule enforcement as sheets there.
+- Analytics: `denial_code`s `docs_not_exposed|docs_blocked|docs_read_only`,
+  grace props `docs_grace_*`, universal `response_chars` / `response_kb`
+  (D7), keep `raw_api_family` stamping.
+
+### Phase 3 — Grant flow + approval funnel (dashboard)
+- [useGooglePicker.ts](../../src/app/dashboard/useGooglePicker.ts): accept a
+  `DriveFileKind` (view id + title); consent round-trip params carry the
+  kind so the auto-reopen lands on the right view.
+- [sheetsGrantCheck.ts](../../src/lib/sheetsGrantCheck.ts) →
+  `driveFileGrantCheck.ts` probing the kind's verify endpoint (docs:
+  `documents.get?fields=title`); keep a `verifySheetsGrant` re-export.
+- `/dashboard/docs-setup` (new page) + generalize `SheetsGrantRecovery` into
+  the shared component both pages render.
+- [approve page](../../src/app/dashboard/approve/page.tsx) +
+  `SheetsApprovalFlow` → kind-parameterized `FileApprovalFlow`; docs
+  approvals verify-then-grant with the same settling/grace UX.
+- API routes: `grant-docs-access` / `verify-docs-access` (thin wrappers over
+  shared handlers with `grant-sheets-access` / `verify-sheets-access`).
+- [actions.ts](../../src/app/dashboard/actions.ts): docs rule CRUD +
+  `exposeDocsFromPicker` mirroring the sheets server actions;
+  `DOC_ACTION_TYPES` validation.
+
+### Phase 4 — Dashboard management UI
+- Generalize [ExposedSheetsManager.tsx](../../src/app/dashboard/ExposedSheetsManager.tsx)
+  (or add a sibling driven by the same shared list component): expose/manage
+  docs per profile, read vs read-write toggle, block, "needs Google access"
+  chip wired to `/dashboard/docs-setup`.
+- [EditRuleButton.tsx](../../src/app/dashboard/EditRuleButton.tsx) /
+  `RuleControls` / `AgentProfilesView`: render `service='docs'` rules;
+  write-access copy states plainly that Read & Write = full-document edit
+  (§2 caveat).
+- [defaultProfile.ts](../../src/db/defaultProfile.ts): comment update only —
+  docs are deny-by-default with no rules, same as sheets.
+
+### Phase 5 — Docs, QA, lint
+- New QA capability `docs/QA_Acceptance_Test/capabilities/19_docs_management.md`
+  modeled on `09_sheets_management.md` (same picker-iframe harness notes;
+  the app-API seam for post-pick assertions is `grant-docs-access`).
+- QA fixture: one QA Google Doc owned by USER_A (documented in `/qa-setup`
+  docs).
+- Touch-ups: `10_raw_google_api.md` (documents family now enforced),
+  `15_request_access_tool.md` (new request types),
+  `17_sheets_grant_recovery.md` (shared component note),
+  `16_analytics_events.md` (universal `response_chars` / `response_kb`
+  props — assert they appear on gmail, sheets, AND docs tool calls, since
+  the monitoring is universal).
+- Agent runbooks in `docs/QA_Acceptance_Test/agents/` gain the docs
+  capability; `npx tsx scripts/qa-coverage-check.ts` stays the arbiter.
+- Repo docs: `user_guide.md`, `architecture_and_strategy.md` (data model),
+  `analytics.md` (new universal size props + the D7 confirmation question
+  they exist to answer), `connector_submission/listing_copy.md`
+  + `mcp-registry-server.json` (tool list changed — connector directory
+  listing must be resubmitted/updated).
+
+### Phase 6 — Optional / follow-up (not in first PR)
+- **Google Slides** (likely next): descriptor entry + `slides_*` tool defs +
+  QA capability — the D2 abstraction's acceptance test.
+- **Size-cap enforcement — only if monitoring confirms the problem**: if
+  the D7 confirmation question comes back material, revive the v4 design
+  (per-kind cap registry + recovery hints; docs first, since its `fields`
+  recovery is agent-self-serviceable) as its own reviewed change, with caps
+  calibrated from the observed `response_chars` distribution rather than
+  guessed.
+- [partner manifest](../../src/lib/partner/manifest.ts): `'docs'` service +
+  consent-screen line ("Access documents you explicitly share").
+- Marketing: `use-cases/google-docs-agent` page, landing-page mention,
+  `src/app/docs/page.tsx` API docs.
+- Combined picker view (sheets + docs in one dialog) for the dashboard's
+  generic "expose files" entry point.
+- `docs_read_document` `format: 'markdown'` option, only if raw-JSON token
+  bloat proves to be a real agent pain point (see D4) — the D7 props are
+  exactly the data that decides this.
+
+## 5. Testing & rollout
+
+- Unit: policy classification + approval-link suites (Phase 1 scripts).
+- Local QA: full docs capability run + targeted re-run of sheets
+  capabilities **09, 10, 14, 15, 17** and **16 (analytics)** — the
+  generalization refactor and the universal size props touch their code
+  paths.
+- `/deploy-pr-preview` → preview-branch QA per standard workflow; user runs
+  `/deploy-prod`.
+- No DB migration, no new env vars, no new OAuth scope → no infra steps.
+  Connector-directory listing update is the one external follow-up.
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Docs API + Picker `drive.file` grant doesn't behave like Sheets in some corner (e.g. grant propagation lag differs) | Phase 0 spike gates everything; grace-retry machinery already handles propagation lag |
+| Generalization refactor regresses battle-hardened sheets flows | Sheets behavior kept byte-identical (routes, action names, analytics props unchanged); targeted sheets QA re-run in Phase 5 |
+| "Read & Write" on a doc is broader than users expect (batchUpdate can delete) | Explicit UI copy + `destructive: true` on replace/raw tools; append tool offered as the safe default |
+| Raw `documents.get` JSON exceeds MCP clients' tool-result caps and gets silently discarded after we report success | Accepted for launch (monitoring-only, by decision): universal `response_chars` + `client_name` on every event make the failure mode measurable from day one; `fields` mask in the tool description is the agent-side mitigation; enforcement follows as Phase 6 only if the data confirms it |
+| Universal measurement layer accidentally alters result shape or breaks a tool | Measurement-only inside `textResult` — no payload change; QA capability 16 asserts props exist AND existing capabilities re-run green |
+| Tool-count growth pushes connector-directory re-review | `mcp-tool-lint` invariants enforced; listing update planned as explicit follow-up |

--- a/docs/spike_results/google-docs-drive-file-spike.md
+++ b/docs/spike_results/google-docs-drive-file-spike.md
@@ -1,0 +1,53 @@
+# Spike: Google Docs API on drive.file per-file grants
+
+**Date**: 2026-08-20 · **Plan**: google-docs-support-plan-b36c1c_v5, Phase 0
+**Environment**: dev Clerk instance, USER_A, Cloud project 627660126377
+
+## Part 1 — API mechanics on the drive.file token: PASS
+
+| Probe | Result |
+|---|---|
+| `POST v1/documents` (create) | 200 — documentId returned; **required enabling the Google Docs API on project 627660126377 first** (was disabled; enabled 2026-08-20 via gcloud, now alongside Sheets + Drive APIs) |
+| `GET v1/documents/{id}?fields=title` | 200 — field mask works under drive.file |
+| `POST …:batchUpdate` insertText at `endOfSegmentLocation` | 200 — write confirmed in readback |
+| `GET v1/documents/{id}` (full) | 200 — raw resource; 5,610 chars for a one-line doc vs 669 chars with `fields=title,body.content` (D7 size baseline) |
+| `GET` bogus id | 404 |
+| `GET` real doc owned by USER_A, never picked | **404 — grant is per-file, not ambient** (the core FGAC premise holds for Docs) |
+
+## Part 2 — Picker grant registration: mechanism verified by proxy, full-fidelity pick deferred to QA
+
+- Picker opens with `ViewId.DOCUMENTS` + our appId on the app origin; the
+  Documents tab renders and lists files.
+- Control probe with `ViewId.DOCS` (all types) listed the account's full
+  Drive — shared Colabs, Forms, and sheets that are definitely NOT
+  app-granted — proving the picker lists ungranted files (listing is
+  user-session-scoped, not token-scoped).
+- The account owns no *old* Google Docs; docs created during the spike
+  (via docs.new and `document/u/0/create?title=…`) had not entered Drive's
+  search/listing index within the session (~45 min observed lag on this
+  account), so the pick-of-an-ungranted-doc could not be completed live.
+- Risk assessment: grant registration by Picker pick is Drive-level and
+  file-type-agnostic (drive.file covers "files the user picked with the
+  app"); the identical flow with this appId registers sheet grants in
+  production daily. Residual docs-specific risk is minimal.
+- **Follow-through**: capability 19 A12 executes the full-fidelity docs pick
+  (Playwright CDP path) once the fixture doc (`FGAC External Pick Test`,
+  created this session) is indexed. QA setup doc now instructs creating
+  per-file fixtures ahead of runs because of this lag.
+
+## Incidental findings
+
+1. **Google Docs API was disabled** on the OAuth client's Cloud project —
+   enabled during the spike. Launch checklist: verify the PRODUCTION Clerk
+   instance's OAuth client project also has docs.googleapis.com enabled
+   before/at deploy.
+2. **USER_A's dev-instance Google grant had no refresh token** (access token
+   expired hourly; Clerk 422 "Cannot refresh OAuth access token"). Cause:
+   Clerk's reauthorize leg reached Google with `prompt=select_account`, which
+   re-uses the grant without reissuing a refresh token. Repaired by forcing
+   `prompt=consent` on the authorization URL (full consent screen → refresh
+   token reissued). If USER_A's token dies again mid-QA, re-run the
+   reconnect with a forced consent prompt.
+3. Brand-new Google Docs (even titled, with the editor open) can take a long
+   time to appear in Picker/Drive listings — QA fixtures must be created
+   ahead of the runs that pick them.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -132,6 +132,8 @@ Access rules let you control what your agent can do. Create them in the **"Acces
 | **Send Whitelist** | Only allows sending to addresses matching a regex pattern | `.*@yourcompany\.com` limits sending to company emails |
 | **Label Blacklist** | Blocks agent from reading emails that have specific Gmail labels | `Highly-Confidential` blocks reading tagged emails |
 | **Label Whitelist** | Only allows reading emails that have specific Gmail labels | `AI-Allowed` restricts reading to tagged emails only |
+| **Sheets access** | Per-spreadsheet Read Only / Read & Write / Blocked, granted by picking the sheet in the Google Picker | Expose one budget spreadsheet, keep the rest of Drive invisible |
+| **Docs access** | Per-document Read Only / Read & Write / Blocked, granted by picking the doc in the Google Picker. Read & Write on a doc permits full-document editing (the Docs API has no finer write granularity) | Let an agent append meeting notes to one running doc |
 
 ### Built-In Safeguards
 
@@ -207,8 +209,8 @@ Owner (user_a@example.com)              Delegate (user_b@example.com)
    - The delegated email (indigo **"Delegated"** badge)
 4. **Your Default Profile picks up the delegated mailbox automatically** — agents
    connected on the Default Profile can read it immediately, with the same
-   read-only default posture as your own mailbox (no sending, no Sheets, until
-   you add rules).
+   read-only default posture as your own mailbox (no sending, no Sheets or
+   Docs, until you add rules).
 5. For a **custom** API key/profile, mailbox access stays opt-in: check both
    emails under **"Email Access"** when creating the key.
 6. Either way, one key serves both inboxes — no separate key per mailbox.

--- a/scripts/test-approval-links.ts
+++ b/scripts/test-approval-links.ts
@@ -58,6 +58,20 @@ async function main() {
   check('sheets payload carries resourceName', sheetOk.ok && sheetOk.payload.resourceName === 'Budget');
   if (sheetOk.ok) check('sheets description prefers name', describeApproval(sheetOk.payload).includes('Budget'));
 
+  // Docs actions mirror sheets: documentId payload, resourceName, 30-min TTL.
+  const docToken = await mintApprovalToken('u', 'k', { action: 'docs_write', documentId: 'doc-9', resourceName: 'Q3 Notes' });
+  const docOk = await verifyApprovalToken(docToken);
+  check('docs payload carries documentId', docOk.ok && docOk.payload.documentId === 'doc-9');
+  check('docs payload carries resourceName', docOk.ok && docOk.payload.resourceName === 'Q3 Notes');
+  if (docOk.ok) {
+    check('docs description prefers name', describeApproval(docOk.payload).includes('Q3 Notes'));
+    check('docs description says read & write', describeApproval(docOk.payload).includes('read & write'));
+  }
+  const docExpose = await verifyApprovalToken(await mintApprovalToken('u', 'k', { action: 'docs_expose', documentId: 'doc-1' }));
+  check('docs_expose roundtrip verifies', docExpose.ok && docExpose.payload.action === 'docs_expose');
+  const expiredDoc = await verifyApprovalToken(await mintApprovalToken('u', 'k', { action: 'docs_expose', documentId: 'doc-1' }, -10));
+  check('expired docs token rejected', !expiredDoc.ok && expiredDoc.reason === 'expired');
+
   // send_all: the "email anyone" escape hatch offered alongside per-recipient
   // approval in send denials.
   const allToken = await mintApprovalToken('user-1', 'key-1', { action: 'send_all' });

--- a/scripts/test-google-api-policy.ts
+++ b/scripts/test-google-api-policy.ts
@@ -3,7 +3,8 @@
  * (src/app/api/mcp/googleApiPolicy.ts). Run: npx tsx scripts/test-google-api-policy.ts
  */
 import {
-  classifyGoogleApiCall, extractSendRecipients, collectLabelIds, sheetsApprovalAction,
+  classifyGoogleApiCall, extractSendRecipients, collectLabelIds,
+  sheetsApprovalAction, docsApprovalAction, extractDocsDocumentId,
 } from '../src/app/api/mcp/googleApiPolicy';
 
 let failures = 0;
@@ -57,6 +58,29 @@ expect('sheets no-id GET → passthrough (Google rejects it, not us)',
 expect('batch endpoint → denied',
   classifyGoogleApiCall('batch/gmail/v1', 'POST'),
   (c: { kind: string }) => c.kind === 'denied');
+expect('docs GET document → docs read',
+  classifyGoogleApiCall('v1/documents/1AbCdoc', 'GET'),
+  (c: { kind: string; documentId?: string; isMutating?: boolean }) =>
+    c.kind === 'docs' && c.documentId === '1AbCdoc' && c.isMutating === false);
+expect('docs GET with docs/ prefix → docs read',
+  classifyGoogleApiCall('docs/v1/documents/1AbCdoc?fields=title', 'GET'),
+  (c: { kind: string; documentId?: string }) => c.kind === 'docs' && c.documentId === '1AbCdoc');
+expect('docs batchUpdate POST → docs write (verb suffix not part of id)',
+  classifyGoogleApiCall('v1/documents/1AbCdoc:batchUpdate', 'POST'),
+  (c: { kind: string; documentId?: string; isMutating?: boolean }) =>
+    c.kind === 'docs' && c.documentId === '1AbCdoc' && c.isMutating === true);
+expect('docs create (no id) POST → docs_create (auto-granted, mirrors sheets_create)',
+  classifyGoogleApiCall('v1/documents', 'POST'),
+  (c: { kind: string }) => c.kind === 'docs_create');
+expect('docs no-id GET → passthrough (Google rejects it, not us)',
+  classifyGoogleApiCall('v1/documents', 'GET'),
+  (c: { kind: string; family?: string }) => c.kind === 'passthrough' && c.family === 'documents');
+
+console.log('extractDocsDocumentId:');
+expect('plain path', extractDocsDocumentId('v1/documents/1AbC_x-9'), (id: string | null) => id === '1AbC_x-9');
+expect('batchUpdate verb excluded', extractDocsDocumentId('v1/documents/1AbC:batchUpdate'), (id: string | null) => id === '1AbC');
+expect('no id → null', extractDocsDocumentId('v1/documents'), (id: string | null) => id === null);
+
 expect('unknown API (drive) → passthrough with family (classify, not block)',
   classifyGoogleApiCall('drive/v3/files', 'GET'),
   (c: { kind: string; family?: string }) => c.kind === 'passthrough' && c.family === 'drive/v3');
@@ -112,6 +136,24 @@ expect('blocked mints nothing (write)',
 expect('spreadsheetId carried through',
   sheetsApprovalAction('not_exposed', 'ss-42', true),
   (a: { spreadsheetId?: string } | null) => a?.spreadsheetId === 'ss-42');
+
+console.log('docsApprovalAction (same matrix as sheets):');
+expect('read on unexposed -> docs_expose',
+  docsApprovalAction('not_exposed', 'doc1', false),
+  (a: { action: string } | null) => a?.action === 'docs_expose');
+expect('WRITE on unexposed -> docs_write',
+  docsApprovalAction('not_exposed', 'doc1', true),
+  (a: { action: string } | null) => a?.action === 'docs_write');
+expect('write on read-only -> docs_write',
+  docsApprovalAction('read_only', 'doc1', true),
+  (a: { action: string } | null) => a?.action === 'docs_write');
+expect('blocked mints nothing (read)',
+  docsApprovalAction('blocked', 'doc1', false), (a: unknown) => a === null);
+expect('blocked mints nothing (write)',
+  docsApprovalAction('blocked', 'doc1', true), (a: unknown) => a === null);
+expect('documentId carried through',
+  docsApprovalAction('not_exposed', 'doc-42', true),
+  (a: { documentId?: string } | null) => a?.documentId === 'doc-42');
 
 if (failures > 0) {
   console.error(`\n${failures} test(s) FAILED`);

--- a/src/app/api/mcp/googleApiPolicy.ts
+++ b/src/app/api/mcp/googleApiPolicy.ts
@@ -12,6 +12,8 @@
 export type RawCallClass =
   | { kind: 'sheets'; spreadsheetId: string; isMutating: boolean }
   | { kind: 'sheets_create' }
+  | { kind: 'docs'; documentId: string; isMutating: boolean }
+  | { kind: 'docs_create' }
   | { kind: 'gmail_read' }
   | { kind: 'gmail_send' }
   | { kind: 'passthrough'; family: string; isMutating: boolean }
@@ -24,6 +26,11 @@ export type DenialCode =
 
 export function extractSheetsSpreadsheetId(path: string): string | null {
   const match = path.match(/(?:v4\/spreadsheets|sheets\/v4\/spreadsheets|spreadsheets)\/([^/?:#]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export function extractDocsDocumentId(path: string): string | null {
+  const match = path.match(/(?:v1\/documents|docs\/v1\/documents|documents)\/([^/?:#]+)/);
   return match ? decodeURIComponent(match[1]) : null;
 }
 
@@ -57,6 +64,19 @@ export function classifyGoogleApiCall(rawPath: string, method: string): RawCallC
       return { kind: 'passthrough', family: 'spreadsheets', isMutating };
     }
     return { kind: 'sheets', spreadsheetId, isMutating };
+  }
+
+  if (segments.includes('documents')) {
+    const documentId = extractDocsDocumentId(path);
+    if (!documentId) {
+      // POST v1/documents = create. Same posture as sheets_create: the Docs
+      // policy keeps agents out of the user's EXISTING documents, not out of
+      // making new ones — the route handler auto-grants the created id to
+      // the calling key. Anything else id-less is nonsense Google rejects.
+      if (isMutating) return { kind: 'docs_create' };
+      return { kind: 'passthrough', family: 'documents', isMutating };
+    }
+    return { kind: 'docs', documentId, isMutating };
   }
 
   if (segments[0] === 'gmail') {
@@ -134,24 +154,41 @@ export function collectLabelIds(value: unknown, depth = 0): string[] {
   return out;
 }
 
-// ─── Sheets denial → approval action (magic links) ──────────────────────────
+// ─── Per-file denial → approval action (magic links) ────────────────────────
 
-export type SheetsDenialKind = 'not_exposed' | 'blocked' | 'read_only';
+export type FileDenialKind = 'not_exposed' | 'blocked' | 'read_only';
+export type SheetsDenialKind = FileDenialKind;
 
 /**
- * Which grant a denied Sheets operation should request. The action must match
- * the access level the DENIED OPERATION requires — a write denied on an
- * unexposed sheet must request write access; minting a read-only exposure
+ * Which grant a denied per-file operation should request. The action must
+ * match the access level the DENIED OPERATION requires — a write denied on an
+ * unexposed file must request write access; minting a read-only exposure
  * there sends the user through an approval that cannot satisfy the retry
  * (tester finding, 2026-08-15). Explicit blocks never mint an action:
  * weakening a deliberate block stays a dashboard act.
  */
+function fileApprovalLevel(denial: FileDenialKind, isMutating: boolean): 'expose' | 'write' | null {
+  if (denial === 'blocked') return null;
+  if (denial === 'read_only') return 'write';
+  return isMutating ? 'write' : 'expose';
+}
+
 export function sheetsApprovalAction(
   denial: SheetsDenialKind,
   spreadsheetId: string,
   isMutating: boolean,
 ): { action: 'sheets_expose' | 'sheets_write'; spreadsheetId: string } | null {
-  if (denial === 'blocked') return null;
-  if (denial === 'read_only') return { action: 'sheets_write', spreadsheetId };
-  return { action: isMutating ? 'sheets_write' : 'sheets_expose', spreadsheetId };
+  const level = fileApprovalLevel(denial, isMutating);
+  if (!level) return null;
+  return { action: level === 'write' ? 'sheets_write' : 'sheets_expose', spreadsheetId };
+}
+
+export function docsApprovalAction(
+  denial: FileDenialKind,
+  documentId: string,
+  isMutating: boolean,
+): { action: 'docs_expose' | 'docs_write'; documentId: string } | null {
+  const level = fileApprovalLevel(denial, isMutating);
+  if (!level) return null;
+  return { action: level === 'write' ? 'docs_write' : 'docs_expose', documentId };
 }

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -265,8 +265,27 @@ async function getGoogleToken(targetEmail: string, keyOwner: { id: string; email
   }
 
   const client = await clerkClient();
-  const tokenResponse = await client.users.getUserOauthAccessToken(tokenOwnerClerkId, 'oauth_google');
-  return tokenResponse.data?.[0]?.token || null;
+  try {
+    const tokenResponse = await client.users.getUserOauthAccessToken(tokenOwnerClerkId, 'oauth_google');
+    const token = tokenResponse.data?.[0]?.token || null;
+    if (!token) addToolCallProps({ google_token_error: 'no_token' });
+    return token;
+  } catch (err) {
+    // Observability for the "Clerk cannot refresh the Google token" failure
+    // mode (Clerk 422: grant stored without a refresh token — seen on the
+    // dev instance 2026-08-20, cause unconfirmed in prod). Without this,
+    // these failures are indistinguishable from generic errors in analytics.
+    const message = err instanceof Error ? err.message : String(err);
+    const reason = /refresh/i.test(message) ? 'refresh_failed' : 'clerk_error';
+    addToolCallProps({ google_token_error: reason });
+    captureServerEvent(keyOwner.clerkUserId, 'google_token_fetch_failed', {
+      reason,
+      via: 'mcp',
+      account_delegated: targetEmail.toLowerCase() !== keyOwner.email.toLowerCase(),
+    });
+    console.error(`[MCP] Google token fetch failed (${reason}) for target mailbox:`, message);
+    return null;
+  }
 }
 
 // loadApplicableRules / checkReadRestrictions moved to src/lib/gmailRules.ts —

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -457,10 +457,13 @@ function fileGrantErrorResult(kind: DriveFileKind, result: { error: string; stat
   if (result.status === 403 || result.status === 404) {
     const d = DRIVE_FILE_KINDS[kind];
     const short = kind === 'sheet' ? 'sheet' : d.noun;
+    // Only the sheets setup page embeds a demo video today — the error must
+    // not promise docs users a video that isn't there (QA 19 A12 finding).
+    const setupBlurb = kind === 'sheet' ? ' (includes a short how-to video)' : '';
     return errorResult(
       `❌ FGAC allows this ${d.noun}, but Google hasn't shared the ${short} itself with FGAC yet, so Google rejected the call (${result.status}). ` +
       `This is a one-time setup step only the user can do: they must pick this ${short} in Google's file picker. ` +
-      `👉 Send the user here to finish setup (includes a short how-to video): ${DASHBOARD_URL}${d.setupPath}?${d.setupIdParam}=${encodeURIComponent(fileId)} ` +
+      `👉 Send the user here to finish setup${setupBlurb}: ${DASHBOARD_URL}${d.setupPath}?${d.setupIdParam}=${encodeURIComponent(fileId)} ` +
       `Note: a wrong ${d.noun} ID produces this same error — the setup page verifies real access before reporting success, so it resolves either case. Retry after the user confirms.`,
     );
   }

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -33,8 +33,9 @@ import { ensureDefaultProfile } from '@/db/defaultProfile';
 import { mintApprovalLink, approvalLinkMinutes, type ApprovalAction } from '@/lib/approvalLinks';
 import { TOOL_DEFS, toolAnnotations, type FgacToolDef } from './toolDefs';
 import {
-  classifyGoogleApiCall, extractSendRecipients, sheetsApprovalAction,
+  classifyGoogleApiCall, extractSendRecipients, sheetsApprovalAction, docsApprovalAction,
 } from './googleApiPolicy';
+import { DRIVE_FILE_KINDS, type DriveFileKind } from '@/lib/driveFileKinds';
 
 /** Env URL values have shipped with trailing whitespace/newlines (pasted
  * Vercel vars); a whitespace-only value must also not win the fallback chain.
@@ -444,25 +445,32 @@ async function googleFetch(
 }
 
 /**
- * Post-policy Google failure on a sheets call. A 403/404 HERE — after FGAC's
- * own permission check passed — almost always means the FGAC rule exists but
- * Google never registered a drive.file grant for the sheet (it was approved
- * via magic link but never picked in the Google Picker; a mistyped id looks
- * identical from outside). The generic "check the ID" text sent the whole
- * 2026-08 connector cohort into a retry loop; say what is actually wrong and
- * where the one-click fix lives.
+ * Post-policy Google failure on a per-file (sheets/docs) call. A 403/404
+ * HERE — after FGAC's own permission check passed — almost always means the
+ * FGAC rule exists but Google never registered a drive.file grant for the
+ * file (it was approved via magic link but never picked in the Google
+ * Picker; a mistyped id looks identical from outside). The generic "check
+ * the ID" text sent the whole 2026-08 connector cohort into a retry loop;
+ * say what is actually wrong and where the one-click fix lives.
  */
-function sheetsErrorResult(result: { error: string; status?: number }, spreadsheetId: string) {
+function fileGrantErrorResult(kind: DriveFileKind, result: { error: string; status?: number }, fileId: string) {
   if (result.status === 403 || result.status === 404) {
+    const d = DRIVE_FILE_KINDS[kind];
+    const short = kind === 'sheet' ? 'sheet' : d.noun;
     return errorResult(
-      `❌ FGAC allows this spreadsheet, but Google hasn't shared the sheet itself with FGAC yet, so Google rejected the call (${result.status}). ` +
-      `This is a one-time setup step only the user can do: they must pick this sheet in Google's file picker. ` +
-      `👉 Send the user here to finish setup (includes a short how-to video): ${DASHBOARD_URL}/dashboard/sheets-setup?sid=${encodeURIComponent(spreadsheetId)} ` +
-      `Note: a wrong spreadsheet ID produces this same error — the setup page verifies real access before reporting success, so it resolves either case. Retry after the user confirms.`,
+      `❌ FGAC allows this ${d.noun}, but Google hasn't shared the ${short} itself with FGAC yet, so Google rejected the call (${result.status}). ` +
+      `This is a one-time setup step only the user can do: they must pick this ${short} in Google's file picker. ` +
+      `👉 Send the user here to finish setup (includes a short how-to video): ${DASHBOARD_URL}${d.setupPath}?${d.setupIdParam}=${encodeURIComponent(fileId)} ` +
+      `Note: a wrong ${d.noun} ID produces this same error — the setup page verifies real access before reporting success, so it resolves either case. Retry after the user confirms.`,
     );
   }
   return errorResult(result.error);
 }
+
+const sheetsErrorResult = (result: { error: string; status?: number }, spreadsheetId: string) =>
+  fileGrantErrorResult('sheet', result, spreadsheetId);
+const docsErrorResult = (result: { error: string; status?: number }, documentId: string) =>
+  fileGrantErrorResult('doc', result, documentId);
 
 async function gmailFetch(token: string, email: string, path: string, method = 'GET', body?: string): Promise<GoogleFetchResult> {
   const userId = email === 'me' ? 'me' : encodeURIComponent(email);
@@ -473,8 +481,12 @@ async function sheetsFetch(token: string, path: string, method = 'GET', body?: s
   return googleFetch(`https://sheets.googleapis.com/v4/spreadsheets/${path}`, token, method, body, targetEmail);
 }
 
-/** How recently a matching sheets rule must have been created for a 403/404 to
- * be treated as grant propagation rather than a genuinely missing grant. */
+async function docsFetch(token: string, path: string, method = 'GET', body?: string, targetEmail = ''): Promise<GoogleFetchResult> {
+  return googleFetch(`https://docs.googleapis.com/v1/documents/${path}`, token, method, body, targetEmail);
+}
+
+/** How recently a matching per-file rule must have been created for a 403/404
+ * to be treated as grant propagation rather than a genuinely missing grant. */
 const SHEETS_GRACE_WINDOW_MS = 120_000;
 const SHEETS_GRACE_RETRIES = 2;
 const SHEETS_GRACE_DELAY_MS = 3_500;
@@ -482,19 +494,24 @@ const SHEETS_GRACE_DELAY_MS = 3_500;
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
 /**
- * sheetsFetch with a propagation grace window. Approval-time verification
- * passes with the owner's token, yet the MCP call path can still see 403/404
- * for tens of seconds while Google's per-file drive.file grant settles
- * (observed on three launch-cohort users: one error immediately after
- * approval, success seconds later). When the matching rule is younger than
- * the grace window, a 403/404 is retried with a short pause instead of being
- * surfaced — the agent sees a slower success, not an error. Rules older than
- * the window fail fast exactly as before.
+ * A per-file fetch with a propagation grace window. Approval-time
+ * verification passes with the owner's token, yet the MCP call path can
+ * still see 403/404 for tens of seconds while Google's per-file drive.file
+ * grant settles (observed on three launch-cohort users: one error
+ * immediately after approval, success seconds later). When the matching rule
+ * is younger than the grace window, a 403/404 is retried with a short pause
+ * instead of being surfaced — the agent sees a slower success, not an error.
+ * Rules older than the window fail fast exactly as before.
+ *
+ * Analytics props are prefixed by the kind's service so sheets dashboards
+ * keep their historical names (sheets_grace_*) and docs get docs_grace_*.
  */
-async function withSheetsGrace(
-  perm: SheetsPermission,
+async function withGrantGrace(
+  kind: DriveFileKind,
+  perm: FilePermission,
   doFetch: () => Promise<GoogleFetchResult>,
 ): Promise<GoogleFetchResult> {
+  const service = DRIVE_FILE_KINDS[kind].service;
   let result = await doFetch();
   const ruleAt = perm.allowed ? perm.newestRuleAt : null;
   if (!ruleAt) return result;
@@ -503,7 +520,7 @@ async function withSheetsGrace(
   const inGrace = () => Date.now() - ruleAt.getTime() < SHEETS_GRACE_WINDOW_MS;
   const retriable = () => !result.ok && (result.status === 403 || result.status === 404);
 
-  if (retriable()) addToolCallProps({ sheets_grant_age_seconds: grantAgeSeconds() });
+  if (retriable()) addToolCallProps({ [`${service}_grant_age_seconds`]: grantAgeSeconds() });
 
   let retries = 0;
   while (retriable() && inGrace() && retries < SHEETS_GRACE_RETRIES) {
@@ -512,65 +529,84 @@ async function withSheetsGrace(
     result = await doFetch();
   }
   if (retries > 0) {
-    addToolCallProps({ sheets_grace_retries: retries, sheets_grace_recovered: result.ok });
+    addToolCallProps({ [`${service}_grace_retries`]: retries, [`${service}_grace_recovered`]: result.ok });
     if (result.ok) {
       // Don't let the first attempt's transient status ride on a success event.
       addToolCallProps({ error_status: undefined });
-      console.log(`[MCP] Sheets grace retry recovered after ${retries} attempt(s) (rule age ${grantAgeSeconds()}s)`);
+      console.log(`[MCP] ${service} grace retry recovered after ${retries} attempt(s) (rule age ${grantAgeSeconds()}s)`);
     }
   }
   return result;
 }
 
-async function checkSheetsPermission(userId: string, proxyKeyId: string, spreadsheetId: string, isMutating: boolean) {
+const withSheetsGrace = (perm: FilePermission, doFetch: () => Promise<GoogleFetchResult>) =>
+  withGrantGrace('sheet', perm, doFetch);
+const withDocsGrace = (perm: FilePermission, doFetch: () => Promise<GoogleFetchResult>) =>
+  withGrantGrace('doc', perm, doFetch);
+
+async function checkFilePermission(kind: DriveFileKind, userId: string, proxyKeyId: string, fileId: string, isMutating: boolean) {
+  const d = DRIVE_FILE_KINDS[kind];
   const allRules = await db.select().from(accessRules).where(eq(accessRules.userId, userId));
   const keyAssignments = await db.select().from(keyRuleAssignments).where(eq(keyRuleAssignments.proxyKeyId, proxyKeyId));
   const assignedRuleIds = new Set(keyAssignments.map(a => a.accessRuleId));
   const allAssignments = await db.select().from(keyRuleAssignments);
   const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
 
-  const sheetsRules = allRules.filter(rule => {
-    if (rule.service !== 'sheets') return false;
+  const fileRules = allRules.filter(rule => {
+    if (rule.service !== d.service) return false;
     const isGlobal = !rulesWithAssignments.has(rule.id);
     const isAssigned = assignedRuleIds.has(rule.id);
-    const matchesId = rule.targetResourceId === spreadsheetId || rule.regexPattern === spreadsheetId;
+    const matchesId = rule.targetResourceId === fileId || rule.regexPattern === fileId;
     return (isGlobal || isAssigned) && matchesId;
   });
 
-  if (sheetsRules.length === 0) {
-    addToolCallProps({ denial_code: 'sheets_not_exposed' });
-    return { allowed: false as const, denial: 'not_exposed' as const, reason: `🚫 Access Denied: Spreadsheet '${spreadsheetId}' is not exposed in your FGAC rules.` };
+  const nounCap = d.noun.charAt(0).toUpperCase() + d.noun.slice(1);
+  if (fileRules.length === 0) {
+    addToolCallProps({ denial_code: `${d.service}_not_exposed` });
+    return { allowed: false as const, denial: 'not_exposed' as const, reason: `🚫 Access Denied: ${nounCap} '${fileId}' is not exposed in your FGAC rules.` };
   }
 
-  if (sheetsRules.some(r => r.actionType === 'sheet_block')) {
-    addToolCallProps({ denial_code: 'sheets_blocked' });
-    return { allowed: false as const, denial: 'blocked' as const, reason: `🚫 Access Denied: Access to spreadsheet '${spreadsheetId}' is explicitly blocked.` };
+  if (fileRules.some(r => r.actionType === d.actionTypes.block)) {
+    addToolCallProps({ denial_code: `${d.service}_blocked` });
+    return { allowed: false as const, denial: 'blocked' as const, reason: `🚫 Access Denied: Access to ${d.noun} '${fileId}' is explicitly blocked.` };
   }
 
   if (isMutating) {
-    const hasReadWrite = sheetsRules.some(r => r.actionType === 'sheet_read_write');
+    const hasReadWrite = fileRules.some(r => r.actionType === d.actionTypes.readWrite);
     if (!hasReadWrite) {
-      addToolCallProps({ denial_code: 'sheets_read_only' });
-      return { allowed: false as const, denial: 'read_only' as const, reason: `🚫 Access Denied: Write access to spreadsheet '${spreadsheetId}' is restricted (Read Only).` };
+      addToolCallProps({ denial_code: `${d.service}_read_only` });
+      return { allowed: false as const, denial: 'read_only' as const, reason: `🚫 Access Denied: Write access to ${d.noun} '${fileId}' is restricted (Read Only).` };
     }
   }
 
   // Newest matching rule's age drives the post-approval grace retry: a rule
   // created seconds ago means Google's drive.file grant may still be
   // propagating even though approval-time verification passed.
-  const newestRuleAt = sheetsRules.reduce<Date | null>(
+  const newestRuleAt = fileRules.reduce<Date | null>(
     (acc, r) => (!acc || r.createdAt > acc ? r.createdAt : acc), null,
   );
   return { allowed: true as const, newestRuleAt };
 }
 
-type SheetsPermission = Awaited<ReturnType<typeof checkSheetsPermission>>;
+type FilePermission = Awaited<ReturnType<typeof checkFilePermission>>;
+type SheetsPermission = FilePermission;
+
+const checkSheetsPermission = (userId: string, proxyKeyId: string, spreadsheetId: string, isMutating: boolean) =>
+  checkFilePermission('sheet', userId, proxyKeyId, spreadsheetId, isMutating);
+const checkDocsPermission = (userId: string, proxyKeyId: string, documentId: string, isMutating: boolean) =>
+  checkFilePermission('doc', userId, proxyKeyId, documentId, isMutating);
 
 /** Map a sheets denial onto an approvable action matching the access level
  * the denied operation requires (see sheetsApprovalAction in googleApiPolicy). */
 function sheetsDenialAction(perm: SheetsPermission, spreadsheetId: string, isMutating: boolean): ApprovalAction | null {
   if (perm.allowed) return null;
   return sheetsApprovalAction(perm.denial, spreadsheetId, isMutating);
+}
+
+/** Docs twin of sheetsDenialAction. */
+function docsDenialAction(perm: FilePermission, documentId: string, isMutating: boolean): ApprovalAction | null {
+  if (perm.allowed) return null;
+  return docsApprovalAction(perm.denial, documentId, isMutating);
 }
 
 // ─── Gmail Message Parsing (token-frugal responses) ─────────────────────────
@@ -714,6 +750,20 @@ function withToolAnalytics<R extends ToolAnalyticsResult>(
     );
     try {
       const result = await fn(params, extra);
+      // Response-size observability (plan google-docs-support v5, D7):
+      // MCP clients impose their own tool-result caps (Claude Code rejects
+      // results over ~25k tokens), so a server-side "success" can still be
+      // silently discarded client-side. Stamp the serialized size on EVERY
+      // tool result — monitoring only, no size-based behavior — so PostHog
+      // can chart how often responses land in the client-rejection zone.
+      const responseChars = Array.isArray((result as { content?: unknown }).content)
+        ? ((result as { content: Array<{ text?: unknown }> }).content)
+            .reduce((n, c) => n + (typeof c.text === 'string' ? c.text.length : 0), 0)
+        : 0;
+      addToolCallProps({
+        response_chars: responseChars,
+        response_kb: Math.round(responseChars / 1024),
+      });
       track(classifyToolOutcome(result));
       return result;
     } catch (err) {
@@ -787,6 +837,12 @@ async function executeRawGoogleCall(
   }
 
   const cleanPath = path.replace(/^\/+/, '');
+  // Route a raw path to the host that owns its API family. Sheets and Docs
+  // live on their own subdomains; everything else rides www.googleapis.com.
+  const rawUrl = (p: string) =>
+    p.includes('spreadsheets') ? `https://sheets.googleapis.com/${p.replace(/^sheets\//, '')}`
+    : p.includes('documents') ? `https://docs.googleapis.com/${p.replace(/^docs\//, '')}`
+    : `https://www.googleapis.com/${p}`;
 
   if (cls.kind === 'sheets_create') {
     // Agent-created sheets are allowed and auto-granted to the calling key
@@ -826,15 +882,49 @@ async function executeRawGoogleCall(
     return jsonResult(result.data);
   }
 
+  if (cls.kind === 'docs_create') {
+    // Agent-created docs are allowed and auto-granted to the calling key
+    // (read & write), mirroring sheets_create: the Docs policy protects the
+    // user's EXISTING documents, not the agent's own output. drive.file
+    // already limits the app to picked files + files it created.
+    const result = await googleFetch(rawUrl(cleanPath), resolved.token, method, serializeBody(body), resolved.targetEmail);
+    if (!result.ok) return errorResult(result.error);
+    const created = result.data as { documentId?: unknown; title?: unknown };
+    const newId = typeof created?.documentId === 'string' ? created.documentId : null;
+    if (newId) {
+      const title = typeof created?.title === 'string' ? created.title : null;
+      try {
+        const [rule] = await db.insert(accessRules).values({
+          userId: conn.user.id,
+          ruleName: `Agent-created: ${title || newId}`,
+          service: 'docs',
+          actionType: 'doc_read_write',
+          targetResourceId: newId,
+          resourceName: title,
+        }).returning();
+        await db.insert(keyRuleAssignments).values({ proxyKeyId: resolved.proxyKeyId, accessRuleId: rule.id });
+        captureServerEvent(conn.user.clerkUserId, 'agent_doc_created', {
+          document_id: newId, auto_granted: true,
+        });
+        addToolCallProps({ doc_created: true });
+      } catch (err) {
+        // The doc exists either way; a failed auto-grant just means the next
+        // access denies and mints an approval link — degraded, not broken.
+        console.error('[MCP] Failed to auto-grant agent-created doc:', err);
+        captureServerEvent(conn.user.clerkUserId, 'agent_doc_created', {
+          document_id: newId, auto_granted: false,
+        });
+      }
+    }
+    return jsonResult(result.data);
+  }
+
   if (cls.kind === 'passthrough') {
     // Classify-don't-block: unknown Google API families are forwarded with
     // the account's token (Google's scopes are the enforcement backstop) and
     // tagged so demand is visible in analytics before we build rules for it.
     addToolCallProps({ raw_api_family: cls.family, raw_api_passthrough: true });
-    const url = cleanPath.includes('spreadsheets')
-      ? `https://sheets.googleapis.com/${cleanPath.replace(/^sheets\//, '')}`
-      : `https://www.googleapis.com/${cleanPath}`;
-    const result = await googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail);
+    const result = await googleFetch(rawUrl(cleanPath), resolved.token, method, serializeBody(body), resolved.targetEmail);
     if (!result.ok) return errorResult(result.error);
     return jsonResult(result.data);
   }
@@ -843,9 +933,17 @@ async function executeRawGoogleCall(
     const perm = await checkSheetsPermission(conn.user.id, resolved.proxyKeyId, cls.spreadsheetId, cls.isMutating);
     if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, sheetsDenialAction(perm, cls.spreadsheetId, cls.isMutating));
 
-    const url = `https://sheets.googleapis.com/${cleanPath.replace(/^sheets\//, '')}`;
-    const result = await withSheetsGrace(perm, () => googleFetch(url, resolved.token, method, serializeBody(body), resolved.targetEmail));
+    const result = await withSheetsGrace(perm, () => googleFetch(rawUrl(cleanPath), resolved.token, method, serializeBody(body), resolved.targetEmail));
     if (!result.ok) return sheetsErrorResult(result, cls.spreadsheetId);
+    return jsonResult(result.data);
+  }
+
+  if (cls.kind === 'docs') {
+    const perm = await checkDocsPermission(conn.user.id, resolved.proxyKeyId, cls.documentId, cls.isMutating);
+    if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, docsDenialAction(perm, cls.documentId, cls.isMutating));
+
+    const result = await withDocsGrace(perm, () => googleFetch(rawUrl(cleanPath), resolved.token, method, serializeBody(body), resolved.targetEmail));
+    if (!result.ok) return docsErrorResult(result, cls.documentId);
     return jsonResult(result.data);
   }
 
@@ -916,6 +1014,7 @@ const handler = createMcpHandler(
           next_steps: {
             gmail: "Read a mailbox with gmail_list (pass account: '<address>' to target a specific one; defaults to the primary). Reads work out of the box.",
             sheets: 'Spreadsheet access is granted per sheet: call sheets_get_spreadsheet with a spreadsheetId, or request_access — a denial returns a one-click approval link for the user.',
+            docs: 'Google Docs access is granted per document: call docs_read_document with a documentId, or request_access — a denial returns a one-click approval link for the user.',
             sending: 'Email sending is off by default; the first gmail_send returns a one-click approval link the user can use to whitelist the recipient.',
           },
           add_more_accounts: {
@@ -1182,6 +1281,87 @@ const handler = createMcpHandler(
       }
     );
 
+    // ── docs_read_document ────────────────────────────────────────────
+    server.registerTool(
+      TOOL_DEFS.docs_read_document.name,
+      toolConfig(TOOL_DEFS.docs_read_document, {
+        documentId: z.string().describe('Google Docs document ID (e.g. 1NQiAY...)'),
+        fields: z.string().optional().describe('Optional Docs API field mask to trim the response (e.g. "title,body.content"). Use when a full read is too large.'),
+        account: z.string().optional().describe('Email account to use.'),
+      }),
+      async ({ documentId, fields, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return textResult(resolved.error);
+
+        const perm = await checkDocsPermission(conn.user.id, resolved.proxyKeyId, documentId, false);
+        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, docsDenialAction(perm, documentId, false));
+
+        const query = fields ? `?fields=${encodeURIComponent(fields)}` : '';
+        const result = await withDocsGrace(perm, () => docsFetch(resolved.token, `${encodeURIComponent(documentId)}${query}`, 'GET', undefined, resolved.targetEmail));
+        if (!result.ok) return docsErrorResult(result, documentId);
+        return jsonResult(result.data);
+      }
+    );
+
+    // ── docs_append_text ──────────────────────────────────────────────
+    server.registerTool(
+      TOOL_DEFS.docs_append_text.name,
+      toolConfig(TOOL_DEFS.docs_append_text, {
+        documentId: z.string().describe('Google Docs document ID'),
+        text: z.string().describe('Plain text to append at the end of the document'),
+        account: z.string().optional().describe('Email account to use.'),
+      }),
+      async ({ documentId, text, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return textResult(resolved.error);
+
+        const perm = await checkDocsPermission(conn.user.id, resolved.proxyKeyId, documentId, true);
+        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, docsDenialAction(perm, documentId, true));
+
+        const body = JSON.stringify({
+          requests: [{ insertText: { endOfSegmentLocation: { segmentId: '' }, text } }],
+        });
+        const result = await withDocsGrace(perm, () => docsFetch(resolved.token, `${encodeURIComponent(documentId)}:batchUpdate`, 'POST', body, resolved.targetEmail));
+        if (!result.ok) return docsErrorResult(result, documentId);
+        return jsonResult(result.data);
+      }
+    );
+
+    // ── docs_replace_text ─────────────────────────────────────────────
+    server.registerTool(
+      TOOL_DEFS.docs_replace_text.name,
+      toolConfig(TOOL_DEFS.docs_replace_text, {
+        documentId: z.string().describe('Google Docs document ID'),
+        find: z.string().describe('Text to find (every occurrence is replaced)'),
+        replace: z.string().describe('Replacement text'),
+        matchCase: z.boolean().optional().describe('Case-sensitive match (default: true)'),
+        account: z.string().optional().describe('Email account to use.'),
+      }),
+      async ({ documentId, find, replace, matchCase, account }, { authInfo }) => {
+        const conn = await requireApproval(authInfo);
+        if ('content' in conn) return conn;
+
+        const resolved = await resolveAccountAndToken(conn, account);
+        if ('error' in resolved) return textResult(resolved.error);
+
+        const perm = await checkDocsPermission(conn.user.id, resolved.proxyKeyId, documentId, true);
+        if (!perm.allowed) return policyDenialWithLink(conn, resolved.proxyKeyId, perm.reason, docsDenialAction(perm, documentId, true));
+
+        const body = JSON.stringify({
+          requests: [{ replaceAllText: { containsText: { text: find, matchCase: matchCase ?? true }, replaceText: replace } }],
+        });
+        const result = await withDocsGrace(perm, () => docsFetch(resolved.token, `${encodeURIComponent(documentId)}:batchUpdate`, 'POST', body, resolved.targetEmail));
+        if (!result.ok) return docsErrorResult(result, documentId);
+        return jsonResult(result.data);
+      }
+    );
+
     // ── google_api_get ────────────────────────────────────────────────
     server.registerTool(
       TOOL_DEFS.google_api_get.name,
@@ -1224,26 +1404,35 @@ const handler = createMcpHandler(
     server.registerTool(
       TOOL_DEFS.request_access.name,
       toolConfig(TOOL_DEFS.request_access, {
-        type: z.enum(['send', 'sheets_read', 'sheets_write']).describe('What to request: permission to send email to a recipient, or read / read-write access to a spreadsheet'),
+        type: z.enum(['send', 'sheets_read', 'sheets_write', 'docs_read', 'docs_write']).describe('What to request: permission to send email to a recipient, or read / read-write access to a spreadsheet or document'),
         recipient: z.string().optional().describe('Email address to whitelist (required for type "send")'),
         spreadsheetId: z.string().optional().describe('Google Spreadsheet ID (required for sheets types)'),
+        documentId: z.string().optional().describe('Google Docs document ID (required for docs types)'),
       }),
-      async ({ type, recipient, spreadsheetId }, { authInfo }) => {
+      async ({ type, recipient, spreadsheetId, documentId }, { authInfo }) => {
         const conn = await requireApproval(authInfo);
         if ('content' in conn) return conn;
         if (!conn.proxyKeyId) {
           return textResult('❌ No proxy key assigned to this connection.');
         }
 
+        const REQUESTABLE = 'Requestable permissions: sending to a specific recipient, or read/read-write access to a specific spreadsheet or document.';
         let action: ApprovalAction;
         if (type === 'send') {
           if (!recipient || !/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(recipient)) {
-            return textResult('🚫 A valid "recipient" email address is required to request send access. Requestable permissions: sending to a specific recipient, or read/read-write access to a specific spreadsheet.');
+            return textResult(`🚫 A valid "recipient" email address is required to request send access. ${REQUESTABLE}`);
           }
           action = { action: 'send_whitelist', recipient };
+        } else if (type === 'docs_read' || type === 'docs_write') {
+          if (!documentId) {
+            return textResult(`🚫 A "documentId" is required to request document access. ${REQUESTABLE}`);
+          }
+          action = type === 'docs_read'
+            ? { action: 'docs_expose', documentId }
+            : { action: 'docs_write', documentId };
         } else {
           if (!spreadsheetId) {
-            return textResult('🚫 A "spreadsheetId" is required to request spreadsheet access. Requestable permissions: sending to a specific recipient, or read/read-write access to a specific spreadsheet.');
+            return textResult(`🚫 A "spreadsheetId" is required to request spreadsheet access. ${REQUESTABLE}`);
           }
           action = type === 'sheets_read'
             ? { action: 'sheets_expose', spreadsheetId }
@@ -1257,7 +1446,9 @@ const handler = createMcpHandler(
           status: 'approval_required',
           summary: action.action === 'send_whitelist'
             ? `Requesting permission to send email to ${recipient}`
-            : `Requesting ${type === 'sheets_read' ? 'read-only' : 'read & write'} access to spreadsheet ${spreadsheetId}`,
+            : action.action.startsWith('docs')
+              ? `Requesting ${type === 'docs_read' ? 'read-only' : 'read & write'} access to document ${documentId}`
+              : `Requesting ${type === 'sheets_read' ? 'read-only' : 'read & write'} access to spreadsheet ${spreadsheetId}`,
           approvalUrl: url,
           note: `Nothing has been granted. Show the approval link to the user VERBATIM as a clickable URL — it is single-use, expires in ${approvalLinkMinutes(action.action)} minutes, and only they can approve it. Do not retry the original operation until they confirm; if the link expires unused, call request_access again.`,
         });
@@ -1304,6 +1495,7 @@ const handler = createMcpHandler(
             gmailRead: 'ALLOWED by default for every accessible email; read-block rules (label/content) below restrict it',
             gmailSend: 'DENIED unless a send_whitelist rule matches the recipient',
             sheets: 'DENIED unless a per-spreadsheet rule below exposes the sheet',
+            docs: 'DENIED unless a per-document rule below exposes the document',
             deletion: 'NEVER available through any tool',
           },
           rules: applicableRules.map(r => ({
@@ -1312,10 +1504,13 @@ const handler = createMcpHandler(
             pattern: r.regexPattern,
             email: r.targetEmail || 'all',
             scope: rulesWithAssignments.has(r.id) ? 'this-key' : 'global',
-            // Sheets rules are per-file: without the spreadsheet id an
-            // agent cannot locate the file it was granted access to.
+            // Per-file rules: without the file id an agent cannot locate
+            // the file it was granted access to.
             ...(r.service === 'sheets'
               ? { spreadsheetId: r.targetResourceId, resourceName: r.resourceName }
+              : {}),
+            ...(r.service === 'docs'
+              ? { documentId: r.targetResourceId, resourceName: r.resourceName }
               : {}),
           })),
         });

--- a/src/app/api/mcp/toolDefs.ts
+++ b/src/app/api/mcp/toolDefs.ts
@@ -89,17 +89,37 @@ export const TOOL_DEFS = {
     readOnly: false,
     destructive: false,
   },
+  docs_read_document: {
+    name: 'docs_read_document',
+    title: 'Read a Google Doc',
+    description: 'Read a Google Docs document exposed by the user\'s FGAC rules. Returns the raw Docs API document resource (title, body content as structured JSON). Large documents can be trimmed with the optional "fields" mask (e.g. "title,body.content") — use it if a full read is too big.',
+    readOnly: true,
+  },
+  docs_append_text: {
+    name: 'docs_append_text',
+    title: 'Append text to a Google Doc',
+    description: 'Append plain text at the end of a Google Docs document without modifying existing content. Requires a Read & Write FGAC rule for the document.',
+    readOnly: false,
+    destructive: false,
+  },
+  docs_replace_text: {
+    name: 'docs_replace_text',
+    title: 'Replace text in a Google Doc',
+    description: 'Replace every occurrence of a text string in a Google Docs document (Docs API replaceAllText). Requires a Read & Write FGAC rule for the document. Note: a Read & Write rule on a document permits full-document editing.',
+    readOnly: false,
+    destructive: true,
+  },
   google_api_get: {
     name: 'google_api_get',
     title: 'Raw Google API read',
-    description: 'Perform a read-only GET request against any endpoint of the Gmail API (https://developers.google.com/gmail/api/reference/rest) or Google Sheets API (https://developers.google.com/sheets/api/reference/rest). Access model: Gmail reads are allowed by default and filtered by the user\'s read-block rules if any; Sheets require an explicit per-spreadsheet rule; other Google APIs and batch endpoints are denied.',
+    description: 'Perform a read-only GET request against any endpoint of the Gmail API (https://developers.google.com/gmail/api/reference/rest), Google Sheets API (https://developers.google.com/sheets/api/reference/rest), or Google Docs API (https://developers.google.com/docs/api/reference/rest). Access model: Gmail reads are allowed by default and filtered by the user\'s read-block rules if any; Sheets and Docs require an explicit per-file rule; other Google APIs and batch endpoints are denied.',
     readOnly: true,
     freeformMethods: ['GET'],
   },
   google_api_modify: {
     name: 'google_api_modify',
     title: 'Raw Google API write',
-    description: 'Perform a POST, PUT, or PATCH request against supported write endpoints of the Gmail API (https://developers.google.com/gmail/api/reference/rest) or Google Sheets API (https://developers.google.com/sheets/api/reference/rest). Allowed writes: Gmail messages/send (recipients are checked against the user\'s FGAC send whitelist) and Sheets value updates/appends on spreadsheets with Read & Write rules. All other write endpoints are denied. DELETE is never available through FGAC.',
+    description: 'Perform a POST, PUT, or PATCH request against supported write endpoints of the Gmail API (https://developers.google.com/gmail/api/reference/rest), Google Sheets API (https://developers.google.com/sheets/api/reference/rest), or Google Docs API (https://developers.google.com/docs/api/reference/rest). Allowed writes: Gmail messages/send (recipients are checked against the user\'s FGAC send whitelist), Sheets value updates/appends on spreadsheets with Read & Write rules, and Docs batchUpdate on documents with Read & Write rules. All other write endpoints are denied. DELETE is never available through FGAC.',
     readOnly: false,
     destructive: true,
     openWorld: true,
@@ -108,7 +128,7 @@ export const TOOL_DEFS = {
   request_access: {
     name: 'request_access',
     title: 'Request a permission upgrade',
-    description: 'Ask the user to grant this agent a specific permission: sending email to a recipient, or read/write access to a Google Spreadsheet. Returns a single-use approval link for the user — calling this tool grants nothing by itself; the user must open the link and approve.',
+    description: 'Ask the user to grant this agent a specific permission: sending email to a recipient, or read/write access to a Google Spreadsheet or Google Docs document. Returns a single-use approval link for the user — calling this tool grants nothing by itself; the user must open the link and approve.',
     readOnly: true,
   },
   get_my_permissions: {

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -54,6 +54,7 @@ async function trackedProxyRequest(request: NextRequest, params: { path: string[
 
   const fullPath = params.path.join('/');
   const service = fullPath.includes('spreadsheets') ? 'sheets'
+    : fullPath.includes('documents') ? 'docs'
     : /^drive\/v[23]\//.test(fullPath) ? 'drive'
     : 'gmail';
   const outcome = response.status < 400 ? 'success'
@@ -88,6 +89,31 @@ function extractGmailUserId(fullPath: string): string {
 function extractSheetsSpreadsheetId(fullPath: string): string | null {
   const match = fullPath.match(/(?:v4\/spreadsheets|sheets\/v4\/spreadsheets)\/([^/?:#]+)/);
   return match ? decodeURIComponent(match[1]) : null;
+}
+
+function extractDocsDocumentId(fullPath: string): string | null {
+  const match = fullPath.match(/(?:v1\/documents|docs\/v1\/documents)\/([^/?:#]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Per-file rule check shared by the Sheets, Docs, and Drive-file guards.
+ * Returns the rules for `service` that apply to this key and match `fileId`.
+ */
+function applicableFileRules(
+  allUserRules: Array<{ id: string; service: string; actionType: string; targetResourceId: string | null; regexPattern: string | null }>,
+  rulesWithAssignments: Set<string>,
+  assignedRuleIds: Set<string>,
+  service: string,
+  fileId: string,
+) {
+  return allUserRules.filter(rule => {
+    if (rule.service !== service) return false;
+    const isGlobal = !rulesWithAssignments.has(rule.id);
+    const isAssignedToThisKey = assignedRuleIds.has(rule.id);
+    const resourceMatches = (rule.targetResourceId === fileId) || (rule.regexPattern === fileId);
+    return (isGlobal || isAssignedToThisKey) && resourceMatches;
+  });
 }
 
 async function handleProxyRequest(request: NextRequest, params: { path: string[] }, telemetry: ProxyTelemetry) {
@@ -163,26 +189,25 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
         const allAssignments = await db.select().from(keyRuleAssignments);
         const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
 
-        const applicableSheetsRules = allUserRules.filter(rule => {
-          if (rule.service !== 'sheets') return false;
-          const isGlobal = !rulesWithAssignments.has(rule.id);
-          const isAssignedToThisKey = assignedRuleIds.has(rule.id);
-          const resourceMatches = (rule.targetResourceId === fileId) || (rule.regexPattern === fileId);
-          return (isGlobal || isAssignedToThisKey) && resourceMatches;
-        });
+        // A Drive file may be exposed as a spreadsheet OR a document — either
+        // kind's rule authorizes it; a block on either denies it.
+        const fileRules = [
+          ...applicableFileRules(allUserRules, rulesWithAssignments, assignedRuleIds, 'sheets', fileId),
+          ...applicableFileRules(allUserRules, rulesWithAssignments, assignedRuleIds, 'docs', fileId),
+        ];
 
-        if (applicableSheetsRules.length === 0) {
+        if (fileRules.length === 0) {
           return NextResponse.json({
             error: `Access Denied: File '${fileId}' is not exposed in FGAC rules for this API key.`
           }, { status: 403 });
         }
-        if (applicableSheetsRules.some(r => r.actionType === 'sheet_block')) {
+        if (fileRules.some(r => r.actionType === 'sheet_block' || r.actionType === 'doc_block')) {
           return NextResponse.json({
             error: `Access Denied: Access to file '${fileId}' has been explicitly blocked.`
           }, { status: 403 });
         }
         const isMutating = request.method !== 'GET' && request.method !== 'HEAD';
-        if (isMutating && !applicableSheetsRules.some(r => r.actionType === 'sheet_read_write')) {
+        if (isMutating && !fileRules.some(r => r.actionType === 'sheet_read_write' || r.actionType === 'doc_read_write')) {
           return NextResponse.json({
             error: `Access Denied: Write operations on file '${fileId}' are restricted to Read-Only.`
           }, { status: 403 });
@@ -216,13 +241,9 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
       const allAssignments = await db.select().from(keyRuleAssignments);
       const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
 
-      const applicableSheetsRules = allUserRules.filter(rule => {
-        if (rule.service !== 'sheets') return false;
-        const isGlobal = !rulesWithAssignments.has(rule.id);
-        const isAssignedToThisKey = assignedRuleIds.has(rule.id);
-        const resourceMatches = (rule.targetResourceId === spreadsheetId) || (rule.regexPattern === spreadsheetId);
-        return (isGlobal || isAssignedToThisKey) && resourceMatches;
-      });
+      const applicableSheetsRules = applicableFileRules(
+        allUserRules, rulesWithAssignments, assignedRuleIds, 'sheets', spreadsheetId,
+      );
 
       if (applicableSheetsRules.length === 0) {
         return NextResponse.json({
@@ -263,6 +284,93 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
       // Forward to Google Sheets API
       const cleanPath = fullPath.replace(/^sheets\//, '');
       const googleUrl = `https://sheets.googleapis.com/${cleanPath}${request.nextUrl.search}`;
+      const headers = new Headers(request.headers);
+      headers.set('Authorization', `Bearer ${realGoogleToken}`);
+      headers.delete('host');
+
+      let requestBody: ArrayBuffer | undefined = undefined;
+      if (isMutatingRequest) {
+        requestBody = await request.clone().arrayBuffer();
+      }
+
+      const googleResponse = await fetch(googleUrl, {
+        method: request.method,
+        headers,
+        body: requestBody,
+      });
+
+      const returnBody = await googleResponse.text();
+      const responseHeaders = new Headers(googleResponse.headers);
+      responseHeaders.delete('content-encoding');
+
+      return new NextResponse(returnBody, {
+        status: googleResponse.status,
+        headers: responseHeaders,
+      });
+    }
+
+    // ─── GOOGLE DOCS PROXY HANDLER ───────────────────────────────────────────
+    // Mirrors the Sheets handler: per-document deny-by-default rules on the
+    // key owner's own Google token (no delegated-mailbox path).
+    if (fullPath.includes('documents')) {
+      telemetry.targetEmail = dbUser.email;
+      telemetry.accountDelegated = false;
+      const documentId = extractDocsDocumentId(fullPath);
+      if (!documentId) {
+        return NextResponse.json({ error: 'Invalid Google Docs API path' }, { status: 400 });
+      }
+
+      const allUserRules = await db
+        .select()
+        .from(accessRules)
+        .where(eq(accessRules.userId, dbUser.id));
+
+      const keyAssignments = await db
+        .select()
+        .from(keyRuleAssignments)
+        .where(eq(keyRuleAssignments.proxyKeyId, dbKey.id));
+
+      const assignedRuleIds = new Set(keyAssignments.map(a => a.accessRuleId));
+      const allAssignments = await db.select().from(keyRuleAssignments);
+      const rulesWithAssignments = new Set(allAssignments.map(a => a.accessRuleId));
+
+      const applicableDocsRules = applicableFileRules(
+        allUserRules, rulesWithAssignments, assignedRuleIds, 'docs', documentId,
+      );
+
+      if (applicableDocsRules.length === 0) {
+        return NextResponse.json({
+          error: `Access Denied: Document '${documentId}' is not exposed in FGAC rules for this API key.`
+        }, { status: 403 });
+      }
+
+      if (applicableDocsRules.some(r => r.actionType === 'doc_block')) {
+        return NextResponse.json({
+          error: `Access Denied: Access to document '${documentId}' has been explicitly blocked.`
+        }, { status: 403 });
+      }
+
+      const isMutatingRequest = request.method !== 'GET' && request.method !== 'HEAD';
+      if (isMutatingRequest) {
+        if (!applicableDocsRules.some(r => r.actionType === 'doc_read_write')) {
+          return NextResponse.json({
+            error: `Access Denied: Write operations on document '${documentId}' are restricted to Read-Only.`
+          }, { status: 403 });
+        }
+      }
+
+      const client = await clerkClient();
+      const tokenResponse = await client.users.getUserOauthAccessToken(dbUser.clerkUserId, 'oauth_google');
+      const realGoogleToken = tokenResponse.data?.[0]?.token;
+
+      if (!realGoogleToken) {
+        return NextResponse.json({
+          error: `Could not fetch Google access token for user '${dbUser.email}'. Please reconnect your Google account.`
+        }, { status: 403 });
+      }
+
+      const cleanPath = fullPath.replace(/^docs\//, '');
+      const googleUrl = `https://docs.googleapis.com/${cleanPath}${request.nextUrl.search}`;
       const headers = new Headers(request.headers);
       headers.set('Authorization', `Bearer ${realGoogleToken}`);
       headers.delete('host');

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -47,6 +47,29 @@ type ProxyTelemetry = {
  * either an FGAC denial or an upstream Google 403 — the status is recorded
  * as-is; the key/user attribution is what matters for usage analytics.
  */
+
+/**
+ * Clerk Google-token fetch with refresh-failure observability (see the MCP
+ * route's getGoogleToken): a Clerk "cannot refresh" 422 otherwise surfaces
+ * as a generic 403, indistinguishable in analytics from real permission
+ * problems. Returns null on any failure.
+ */
+async function fetchClerkGoogleToken(clerkUserIdForToken: string, reporterClerkUserId: string): Promise<string | null> {
+  const client = await clerkClient();
+  try {
+    const tokenResponse = await client.users.getUserOauthAccessToken(clerkUserIdForToken, 'oauth_google');
+    return tokenResponse.data?.[0]?.token || null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    captureServerEvent(reporterClerkUserId, 'google_token_fetch_failed', {
+      reason: /refresh/i.test(message) ? 'refresh_failed' : 'clerk_error',
+      via: 'proxy',
+    });
+    console.error('[PROXY] Google token fetch failed:', message);
+    return null;
+  }
+}
+
 async function trackedProxyRequest(request: NextRequest, params: { path: string[] }) {
   const telemetry: ProxyTelemetry = {};
   const started = Date.now();
@@ -271,9 +294,7 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
       }
 
       // Fetch Real Google Token from Clerk
-      const client = await clerkClient();
-      const tokenResponse = await client.users.getUserOauthAccessToken(dbUser.clerkUserId, 'oauth_google');
-      const realGoogleToken = tokenResponse.data?.[0]?.token;
+      const realGoogleToken = await fetchClerkGoogleToken(dbUser.clerkUserId, dbUser.clerkUserId);
 
       if (!realGoogleToken) {
         return NextResponse.json({
@@ -359,9 +380,7 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
         }
       }
 
-      const client = await clerkClient();
-      const tokenResponse = await client.users.getUserOauthAccessToken(dbUser.clerkUserId, 'oauth_google');
-      const realGoogleToken = tokenResponse.data?.[0]?.token;
+      const realGoogleToken = await fetchClerkGoogleToken(dbUser.clerkUserId, dbUser.clerkUserId);
 
       if (!realGoogleToken) {
         return NextResponse.json({
@@ -583,9 +602,7 @@ async function handleProxyRequest(request: NextRequest, params: { path: string[]
     }
 
     // ─── 8. Fetch Real Google Token from Clerk ──────────────────────────────
-    const client = await clerkClient();
-    const tokenResponse = await client.users.getUserOauthAccessToken(tokenOwnerClerkUserId, 'oauth_google');
-    const realGoogleToken = tokenResponse.data?.[0]?.token;
+    const realGoogleToken = await fetchClerkGoogleToken(tokenOwnerClerkUserId, dbUser.clerkUserId);
 
     if (!realGoogleToken) {
       return NextResponse.json({

--- a/src/app/api/rules/fileAccessHandlers.ts
+++ b/src/app/api/rules/fileAccessHandlers.ts
@@ -1,0 +1,301 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { db } from '@/db';
+import { users, accessRules, keyRuleAssignments, proxyKeys } from '@/db/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+import { verifyFileGrant, getOwnerGoogleToken, type FileGrantState } from '@/lib/driveFileGrantCheck';
+import { DRIVE_FILE_KINDS, type DriveFileKind } from '@/lib/driveFileKinds';
+import { captureServerEvent } from '@/lib/posthogServer';
+
+/**
+ * Shared implementations behind the per-kind rule routes:
+ *   /api/rules/verify-sheets-access  /api/rules/grant-sheets-access
+ *   /api/rules/verify-docs-access    /api/rules/grant-docs-access
+ * Extracted from the sheets routes when Docs support landed — sheets request
+ * and response shapes (param names, response keys, analytics event names)
+ * are unchanged; docs mirrors them with its own nouns.
+ */
+
+const kindNames = (kind: DriveFileKind) => {
+  const d = DRIVE_FILE_KINDS[kind];
+  return {
+    d,
+    idParam: d.setupIdParam,                                     // sid | did
+    idKey: kind === 'sheet' ? 'spreadsheetId' : 'documentId',    // response key
+    idProp: kind === 'sheet' ? 'spreadsheet_id' : 'document_id', // analytics prop
+    recoveredEvent: kind === 'sheet' ? 'sheets_grant_recovered' : 'docs_grant_recovered',
+    verificationEvent: kind === 'sheet' ? 'sheets_grant_verification' : 'docs_grant_verification',
+    rulesKey: kind === 'sheet' ? 'sheetsRules' : 'docsRules',
+    fallbackNoun: d.noun.charAt(0).toUpperCase() + d.noun.slice(1),
+  };
+};
+
+/**
+ * GET verify-<kind>s-access[?sid|did=<fileId>][&context=recovery]
+ *
+ * For the signed-in user, checks whether Google actually grants us access to
+ * the file(s) behind their rules (FGAC rule ≠ Google grant — see
+ * driveFileGrantCheck.ts). Without an id, verifies every rule of this kind
+ * and returns a map; with one, verifies just that file (it does not need an
+ * existing rule — the approval flow verifies before the page settles).
+ *
+ * `context=recovery` marks a re-check issued by the recovery UI right after a
+ * Picker pick; a verified `ok` in that context is the "user completed the
+ * recovery loop" signal and fires <kind>s_grant_recovered.
+ */
+export async function verifyFileAccessGET(kind: DriveFileKind, request: NextRequest) {
+  const n = kindNames(kind);
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const fileId = searchParams.get(n.idParam);
+    const context = searchParams.get('context');
+
+    const token = await getOwnerGoogleToken(clerkUserId);
+
+    if (fileId) {
+      const result: FileGrantState = token
+        ? await verifyFileGrant(kind, token, fileId)
+        : { state: 'missing' };
+      if (context === 'recovery' && result.state === 'ok') {
+        captureServerEvent(clerkUserId, n.recoveredEvent, { [n.idProp]: fileId });
+      }
+      // link_open = the approve page checking the grant before showing the
+      // flow — the top of the picker-first funnel. post_approval = the
+      // success card confirming the grant settled before telling the user
+      // "the agent can retry now" (grant-race fix).
+      if (context === 'link_open' || context === 'post_approval') {
+        captureServerEvent(clerkUserId, n.verificationEvent, {
+          result: result.state, via: context, [n.idProp]: fileId,
+        });
+      }
+      return NextResponse.json({ [n.idKey]: fileId, ...result });
+    }
+
+    const dbUser = await db.select().from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1).then(r => r[0]);
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const rules = await db.select().from(accessRules).where(
+      and(eq(accessRules.userId, dbUser.id), eq(accessRules.service, n.d.service)),
+    );
+
+    // Distinct file ids only — several rules can share one file.
+    const ids = [...new Set(rules.map(r => r.targetResourceId).filter((v): v is string => !!v))];
+    const entries = await Promise.all(ids.map(async id => {
+      const result: FileGrantState = token
+        ? await verifyFileGrant(kind, token, id)
+        : { state: 'missing' };
+      return [id, result] as const;
+    }));
+
+    return NextResponse.json({ grants: Object.fromEntries(entries) });
+  } catch (error) {
+    console.error(`Error verifying ${n.d.service} access:`, error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+/** GET grant-<kind>s-access — list this kind's rules for the current user. */
+export async function grantFileAccessGET(kind: DriveFileKind) {
+  const n = kindNames(kind);
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const dbUser = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1)
+      .then(res => res[0]);
+
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const rules = await db
+      .select()
+      .from(accessRules)
+      .where(
+        and(
+          eq(accessRules.userId, dbUser.id),
+          eq(accessRules.service, n.d.service)
+        )
+      );
+
+    const ruleAssignments = await db.select().from(keyRuleAssignments);
+    const rulesWithKeys = rules.map(rule => {
+      const assignedKeyIds = ruleAssignments
+        .filter(a => a.accessRuleId === rule.id)
+        .map(a => a.proxyKeyId);
+      return {
+        ...rule,
+        assignedKeyIds
+      };
+    });
+
+    return NextResponse.json({ [n.rulesKey]: rulesWithKeys });
+  } catch (error) {
+    console.error(`Error fetching ${n.d.service} rules:`, error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+/** POST grant-<kind>s-access — create or update one of this kind's rules. */
+export async function grantFileAccessPOST(kind: DriveFileKind, request: NextRequest) {
+  const n = kindNames(kind);
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const dbUser = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1)
+      .then(res => res[0]);
+
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { targetResourceId, resourceName, actionType, proxyKeyIds } = body;
+
+    if (!targetResourceId) {
+      return NextResponse.json({ error: `targetResourceId (${n.idKey}) is required` }, { status: 400 });
+    }
+
+    const validActionTypes = [n.d.actionTypes.read, n.d.actionTypes.readWrite, n.d.actionTypes.block];
+    const chosenActionType = validActionTypes.includes(actionType) ? actionType : n.d.actionTypes.read;
+
+    // Check if a rule for this file already exists for this user
+    const existingRule = await db
+      .select()
+      .from(accessRules)
+      .where(
+        and(
+          eq(accessRules.userId, dbUser.id),
+          eq(accessRules.service, n.d.service),
+          eq(accessRules.targetResourceId, targetResourceId)
+        )
+      )
+      .limit(1)
+      .then(res => res[0]);
+
+    let ruleId: string;
+
+    if (existingRule) {
+      ruleId = existingRule.id;
+      await db
+        .update(accessRules)
+        .set({
+          ruleName: resourceName || existingRule.ruleName,
+          resourceName: resourceName || existingRule.resourceName,
+          actionType: chosenActionType,
+          updatedAt: new Date()
+        })
+        .where(eq(accessRules.id, ruleId));
+    } else {
+      const [newRule] = await db
+        .insert(accessRules)
+        .values({
+          userId: dbUser.id,
+          ruleName: resourceName || `${n.fallbackNoun} ${targetResourceId.slice(0, 8)}...`,
+          service: n.d.service,
+          actionType: chosenActionType,
+          targetResourceId,
+          resourceName: resourceName || `${n.fallbackNoun} (${targetResourceId.slice(0, 8)})`
+        })
+        .returning();
+      ruleId = newRule.id;
+    }
+
+    // Sync Key Rule Assignments if proxyKeyIds provided
+    if (Array.isArray(proxyKeyIds)) {
+      await db.delete(keyRuleAssignments).where(eq(keyRuleAssignments.accessRuleId, ruleId));
+
+      if (proxyKeyIds.length > 0) {
+        const userKeys = await db
+          .select()
+          .from(proxyKeys)
+          .where(
+            and(
+              eq(proxyKeys.userId, dbUser.id),
+              inArray(proxyKeys.id, proxyKeyIds)
+            )
+          );
+
+        const validKeyIds = userKeys.map(k => k.id);
+        if (validKeyIds.length > 0) {
+          await db.insert(keyRuleAssignments).values(
+            validKeyIds.map(keyId => ({
+              proxyKeyId: keyId,
+              accessRuleId: ruleId
+            }))
+          );
+        }
+      }
+    }
+
+    return NextResponse.json({ success: true, ruleId });
+  } catch (error) {
+    console.error(`Error saving ${n.d.service} rule:`, error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+/** DELETE grant-<kind>s-access?ruleId=… — delete one of this kind's rules. */
+export async function grantFileAccessDELETE(kind: DriveFileKind, request: NextRequest) {
+  const n = kindNames(kind);
+  try {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const dbUser = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, clerkUserId))
+      .limit(1)
+      .then(res => res[0]);
+
+    if (!dbUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const ruleId = searchParams.get('ruleId');
+
+    if (!ruleId) {
+      return NextResponse.json({ error: 'ruleId parameter is required' }, { status: 400 });
+    }
+
+    await db
+      .delete(accessRules)
+      .where(
+        and(
+          eq(accessRules.id, ruleId),
+          eq(accessRules.userId, dbUser.id)
+        )
+      );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error(`Error deleting ${n.d.service} rule:`, error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/rules/grant-docs-access/route.ts
+++ b/src/app/api/rules/grant-docs-access/route.ts
@@ -3,15 +3,15 @@ import { grantFileAccessGET, grantFileAccessPOST, grantFileAccessDELETE } from '
 
 export const dynamic = 'force-dynamic';
 
-/** /api/rules/grant-sheets-access — see fileAccessHandlers.ts. */
+/** /api/rules/grant-docs-access — see fileAccessHandlers.ts. */
 export async function GET() {
-  return grantFileAccessGET('sheet');
+  return grantFileAccessGET('doc');
 }
 
 export async function POST(request: NextRequest) {
-  return grantFileAccessPOST('sheet', request);
+  return grantFileAccessPOST('doc', request);
 }
 
 export async function DELETE(request: NextRequest) {
-  return grantFileAccessDELETE('sheet', request);
+  return grantFileAccessDELETE('doc', request);
 }

--- a/src/app/api/rules/verify-docs-access/route.ts
+++ b/src/app/api/rules/verify-docs-access/route.ts
@@ -3,7 +3,7 @@ import { verifyFileAccessGET } from '../fileAccessHandlers';
 
 export const dynamic = 'force-dynamic';
 
-/** GET /api/rules/verify-sheets-access — see fileAccessHandlers.ts. */
+/** GET /api/rules/verify-docs-access?did=… — see fileAccessHandlers.ts. */
 export async function GET(request: NextRequest) {
-  return verifyFileAccessGET('sheet', request);
+  return verifyFileAccessGET('doc', request);
 }

--- a/src/app/dashboard/AgentProfilesView.tsx
+++ b/src/app/dashboard/AgentProfilesView.tsx
@@ -113,6 +113,30 @@ export function AgentProfilesView({
     }
   }, []);
 
+  // fileId → Google-side grant state per kind. A rule can exist without
+  // Google ever having shared the file (approved via magic link, never
+  // picked) — those rows get a "Needs Google access" chip (capability 17
+  // A6 names the profile card, not just the Accounts manager). Verification
+  // failing entirely degrades to no chips, never a broken card.
+  const [grantStates, setGrantStates] = useState<{ sheet: Record<string, { state: string }>; doc: Record<string, { state: string }> }>({ sheet: {}, doc: {} });
+  useEffect(() => {
+    let cancelled = false;
+    const load = async (path: string): Promise<Record<string, { state: string }>> => {
+      try {
+        const res = await fetch(path);
+        const data = await res.json();
+        return data.grants ?? {};
+      } catch {
+        return {};
+      }
+    };
+    Promise.all([
+      load('/api/rules/verify-sheets-access'),
+      load('/api/rules/verify-docs-access'),
+    ]).then(([sheet, doc]) => { if (!cancelled) setGrantStates({ sheet, doc }); });
+    return () => { cancelled = true; };
+  }, [rules]);
+
   useEffect(() => { fetchConnections(); }, [fetchConnections]);
 
   const active = activeProfiles.find(p => p.id === activeId) ?? null;
@@ -190,6 +214,7 @@ export function AgentProfilesView({
                 kind="sheet"
                 profileId={active.id}
                 rules={sheetRules}
+                grantStates={grantStates.sheet}
                 onExpose={() => triggerAddSheets(active.id)}
                 exposing={pickerLoading}
                 pickerError={pickerError}
@@ -199,6 +224,7 @@ export function AgentProfilesView({
                 kind="doc"
                 profileId={active.id}
                 rules={docRules}
+                grantStates={grantStates.doc}
                 onExpose={() => triggerAddDocs(active.id)}
                 exposing={docsPickerLoading}
                 pickerError={docsPickerError}
@@ -488,6 +514,7 @@ function FilesRulesCard({
   kind,
   profileId,
   rules,
+  grantStates,
   onExpose,
   pickerError,
   exposing,
@@ -495,10 +522,15 @@ function FilesRulesCard({
   kind: 'sheet' | 'doc';
   profileId: string;
   rules: Rule[];
+  /** fileId → Google-side grant state; missing entries mean "unknown" (no chip). */
+  grantStates: Record<string, { state: string }>;
   onExpose: () => void;
   pickerError: string | null;
   exposing: boolean;
 }) {
+  const setup = kind === 'sheet'
+    ? { path: '/dashboard/sheets-setup', idParam: 'sid', noun: 'sheet' }
+    : { path: '/dashboard/docs-setup', idParam: 'did', noun: 'doc' };
   // "+ Expose a …" opens the Google Picker directly — picking a file is
   // the whole flow, whether or not it was already exposed elsewhere (the
   // server action merges assignments instead of narrowing them). No detour
@@ -539,6 +571,15 @@ function FilesRulesCard({
                     {rule.resourceName || rule.ruleName}
                   </span>
                   {isGlobal(rule) && <Badge tone="neutral">Global</Badge>}
+                  {rule.targetResourceId && grantStates[rule.targetResourceId]?.state === 'missing' && (
+                    <a
+                      href={`${setup.path}?${setup.idParam}=${encodeURIComponent(rule.targetResourceId)}${rule.resourceName ? `&name=${encodeURIComponent(rule.resourceName)}` : ''}`}
+                      className="inline-flex shrink-0 items-center gap-1 rounded-full border border-warning-foreground/30 bg-warning px-2 py-0.5 text-[11px] font-semibold text-warning-foreground hover:opacity-80"
+                      title={`FGAC has this rule, but Google hasn't shared the ${setup.noun} with FGAC yet — agents get errors until you pick it in the Google Picker.`}
+                    >
+                      ⚠ Needs Google access — finish setup
+                    </a>
+                  )}
                 </div>
                 {rule.targetResourceId && (
                   <code className="mt-1 block truncate font-mono text-[11px] text-subtle">

--- a/src/app/dashboard/AgentProfilesView.tsx
+++ b/src/app/dashboard/AgentProfilesView.tsx
@@ -3,8 +3,11 @@
 import Link from 'next/link';
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Card, CardHeader, Badge, EmptyState, buttonPrimary, buttonSecondary, buttonDanger } from '@/components/ui';
-import { assignRulesToKey, unassignRuleFromKey, revokeProxyKey, setSheetRulePermission, exposeSheetsFromPicker, applyRecommendedSecurityRules, enableSendToAnyone } from './actions';
+import { assignRulesToKey, unassignRuleFromKey, revokeProxyKey, setSheetRulePermission, exposeSheetsFromPicker, exposeDocsFromPicker, applyRecommendedSecurityRules, enableSendToAnyone } from './actions';
 import { useGooglePicker, PickedSheet } from './useGooglePicker';
+
+/** access_rules.service values that are per-file grants (not Gmail rules). */
+const FILE_SERVICES = ['sheets', 'docs'];
 import { EditRuleButton } from './EditRuleButton';
 import { DeleteRuleButton } from './DeleteRuleButton';
 import { RuleControls } from './RuleControls';
@@ -115,9 +118,10 @@ export function AgentProfilesView({
   const active = activeProfiles.find(p => p.id === activeId) ?? null;
   const pending = connections.filter(c => c.status === 'pending');
 
-  // Google Picker for "+ Expose a sheet". One hook instance for the whole
-  // view: it also consumes the ?autoOpenPicker= return leg of the first-time
-  // consent redirect, with the profile id carried through as picker context.
+  // Google Pickers for "+ Expose a sheet" / "+ Expose a doc". One hook
+  // instance per kind for the whole view: each also consumes the
+  // ?autoOpenPicker= return leg of the first-time consent redirect for its
+  // own kind (pickerKind), with the profile id carried through as context.
   const handleSheetsPicked = useCallback(async (sheets: PickedSheet[], context?: string) => {
     try {
       await exposeSheetsFromPicker(sheets, context || undefined);
@@ -127,12 +131,22 @@ export function AgentProfilesView({
   }, []);
   const { triggerAddSheets, isLoading: pickerLoading, pickerError } = useGooglePicker(handleSheetsPicked);
 
-  const { sheetRules, gmailRules } = useMemo(() => {
-    if (!active) return { sheetRules: [], gmailRules: [] };
+  const handleDocsPicked = useCallback(async (docs: PickedSheet[], context?: string) => {
+    try {
+      await exposeDocsFromPicker(docs, context || undefined);
+    } catch (e) {
+      console.error('Failed to save exposed docs:', e);
+    }
+  }, []);
+  const { triggerAddSheets: triggerAddDocs, isLoading: docsPickerLoading, pickerError: docsPickerError } = useGooglePicker(handleDocsPicked, 'doc');
+
+  const { sheetRules, docRules, gmailRules } = useMemo(() => {
+    if (!active) return { sheetRules: [], docRules: [], gmailRules: [] };
     const forProfile = rules.filter(r => isGlobal(r) || r.assignedKeyIds.includes(active.id));
     return {
       sheetRules: forProfile.filter(r => r.service === 'sheets'),
-      gmailRules: forProfile.filter(r => r.service !== 'sheets'),
+      docRules: forProfile.filter(r => r.service === 'docs'),
+      gmailRules: forProfile.filter(r => !FILE_SERVICES.includes(r.service)),
     };
   }, [rules, active]);
 
@@ -172,13 +186,22 @@ export function AgentProfilesView({
 
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-6 items-start">
             <div className="space-y-6 min-w-0">
-              <SheetsRulesCard
+              <FilesRulesCard
+                kind="sheet"
                 profileId={active.id}
                 rules={sheetRules}
-                allRules={rules}
                 onExpose={() => triggerAddSheets(active.id)}
                 exposing={pickerLoading}
                 pickerError={pickerError}
+              />
+
+              <FilesRulesCard
+                kind="doc"
+                profileId={active.id}
+                rules={docRules}
+                onExpose={() => triggerAddDocs(active.id)}
+                exposing={docsPickerLoading}
+                pickerError={docsPickerError}
               />
 
               <GmailRulesCard
@@ -268,7 +291,7 @@ function RecentConnectionsBanner({ connections, rules }: { connections: Connecti
   const recent = connections.filter(
     c => c.status === 'approved' && new Date(c.createdAt).getTime() > sevenDaysAgo,
   );
-  const hasShield = rules.some(r => r.service !== 'sheets' && r.actionType === 'read_blacklist');
+  const hasShield = rules.some(r => !FILE_SERVICES.includes(r.service) && r.actionType === 'read_blacklist');
 
   if (dismissed || recent.length === 0) return null;
 
@@ -427,43 +450,69 @@ function ProfileHeader({ profile }: { profile: Profile }) {
   );
 }
 
-// ─── Google Sheets rules ────────────────────────────────────────────────────
+// ─── Per-file (Sheets / Docs) rules ─────────────────────────────────────────
 
-const SHEET_PERMISSIONS = [
-  { value: 'sheet_read', label: 'Read Only', tone: 'info' as const },
-  { value: 'sheet_read_write', label: 'Read & Write', tone: 'success' as const },
-  { value: 'sheet_block', label: 'Blocked', tone: 'error' as const },
-];
+const FILE_PERMISSIONS = {
+  sheet: [
+    { value: 'sheet_read', label: 'Read Only', tone: 'info' as const },
+    { value: 'sheet_read_write', label: 'Read & Write', tone: 'success' as const },
+    { value: 'sheet_block', label: 'Blocked', tone: 'error' as const },
+  ],
+  doc: [
+    { value: 'doc_read', label: 'Read Only', tone: 'info' as const },
+    { value: 'doc_read_write', label: 'Read & Write', tone: 'success' as const },
+    { value: 'doc_block', label: 'Blocked', tone: 'error' as const },
+  ],
+};
 
-function SheetsRulesCard({
+const FILE_CARD_COPY = {
+  sheet: {
+    tone: 'sheets' as const,
+    title: 'Google Sheets Rules',
+    subtitle: 'Spreadsheets this profile can reach',
+    expose: '+ Expose a sheet',
+    empty: <>No sheets exposed to this profile. Click &quot;+ Expose a sheet&quot; to pick
+      spreadsheets from Google Drive.</>,
+  },
+  doc: {
+    tone: 'docs' as const,
+    title: 'Google Docs Rules',
+    subtitle: 'Documents this profile can reach',
+    expose: '+ Expose a doc',
+    empty: <>No docs exposed to this profile. Click &quot;+ Expose a doc&quot; to pick
+      documents from Google Drive.</>,
+  },
+};
+
+function FilesRulesCard({
+  kind,
   profileId,
   rules,
-  allRules,
   onExpose,
   pickerError,
   exposing,
 }: {
+  kind: 'sheet' | 'doc';
   profileId: string;
   rules: Rule[];
-  allRules: Rule[];
   onExpose: () => void;
   pickerError: string | null;
   exposing: boolean;
 }) {
-  // "+ Expose a sheet" opens the Google Picker directly — picking a sheet is
+  // "+ Expose a …" opens the Google Picker directly — picking a file is
   // the whole flow, whether or not it was already exposed elsewhere (the
   // server action merges assignments instead of narrowing them). No detour
   // through the Accounts page.
-  void profileId; void allRules;
+  const copy = FILE_CARD_COPY[kind];
 
   return (
-    <Card tone="sheets">
+    <Card tone={copy.tone}>
       <CardHeader
-        title="Google Sheets Rules"
-        subtitle="Spreadsheets this profile can reach"
+        title={copy.title}
+        subtitle={copy.subtitle}
         action={
           <button className={buttonSecondary} onClick={onExpose} disabled={exposing}>
-            {exposing ? 'Opening Google Picker…' : '+ Expose a sheet'}
+            {exposing ? 'Opening Google Picker…' : copy.expose}
           </button>
         }
       />
@@ -476,8 +525,7 @@ function SheetsRulesCard({
         )}
         {rules.length === 0 ? (
           <EmptyState>
-            No sheets exposed to this profile. Click &quot;+ Expose a sheet&quot; to pick
-            spreadsheets from Google Drive.
+            {copy.empty}
           </EmptyState>
         ) : (
           rules.map(rule => (
@@ -500,7 +548,7 @@ function SheetsRulesCard({
               </div>
 
               <div className="flex shrink-0 items-center gap-3">
-                <SheetPermissionSelect rule={rule} />
+                <FilePermissionSelect kind={kind} rule={rule} />
                 {!isGlobal(rule) && <DetachRuleButton profileId={profileId} rule={rule} />}
               </div>
             </div>
@@ -513,14 +561,15 @@ function SheetsRulesCard({
 
 /**
  * Saves on change. The select is recolored to match the permission so the
- * access level of every sheet is legible at a glance without reading labels.
+ * access level of every file is legible at a glance without reading labels.
  */
-function SheetPermissionSelect({ rule }: { rule: Rule }) {
+function FilePermissionSelect({ kind, rule }: { kind: 'sheet' | 'doc'; rule: Rule }) {
   const [value, setValue] = useState(rule.actionType);
   const [busy, setBusy] = useState(false);
   const [failed, setFailed] = useState(false);
 
-  const tone = SHEET_PERMISSIONS.find(p => p.value === value)?.tone ?? 'neutral';
+  const permissions = FILE_PERMISSIONS[kind];
+  const tone = permissions.find(p => p.value === value)?.tone ?? 'neutral';
   const toneClass = {
     info: 'border-info-foreground/30 bg-info text-info-foreground',
     success: 'border-success-foreground/30 bg-success text-success-foreground',
@@ -552,7 +601,7 @@ function SheetPermissionSelect({ rule }: { rule: Rule }) {
         }}
         className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold disabled:opacity-60 ${toneClass}`}
       >
-        {SHEET_PERMISSIONS.map(p => (
+        {permissions.map(p => (
           <option key={p.value} value={p.value}>{p.label}</option>
         ))}
       </select>
@@ -591,7 +640,7 @@ function GmailRulesCard({
   // Only rules that exist but are not yet on this profile can be applied.
   // Global rules are excluded — they already apply everywhere.
   const applicable = allRules.filter(
-    r => r.service !== 'sheets' && !isGlobal(r) && !r.assignedKeyIds.includes(profileId),
+    r => !FILE_SERVICES.includes(r.service) && !isGlobal(r) && !r.assignedKeyIds.includes(profileId),
   );
 
   return (
@@ -609,7 +658,7 @@ function GmailRulesCard({
                 profileId={profileId}
                 candidates={applicable}
                 emptyMessage={
-                  allRules.some(r => r.service !== 'sheets')
+                  allRules.some(r => !FILE_SERVICES.includes(r.service))
                     ? 'Every existing Gmail rule already applies to this profile.'
                     : "You haven't created any Gmail rules yet."
                 }

--- a/src/app/dashboard/EditRuleButton.tsx
+++ b/src/app/dashboard/EditRuleButton.tsx
@@ -118,6 +118,8 @@ export function EditRuleButton({
                     setSelectedService(e.target.value);
                     if (e.target.value === 'sheets') {
                       setSelectedActionType('sheet_read');
+                    } else if (e.target.value === 'docs') {
+                      setSelectedActionType('doc_read');
                     } else {
                       setSelectedActionType('read_blacklist');
                     }
@@ -126,6 +128,7 @@ export function EditRuleButton({
                 >
                   <option value="gmail">Gmail</option>
                   <option value="sheets">Google Sheets</option>
+                  <option value="docs">Google Docs</option>
                 </select>
               </div>
 
@@ -151,6 +154,18 @@ export function EditRuleButton({
                         Blocked (Deny All)
                       </option>
                     </>
+                  ) : selectedService === 'docs' ? (
+                    <>
+                      <option value="doc_read">
+                        Read Only (GET)
+                      </option>
+                      <option value="doc_read_write">
+                        Read & Write (GET + POST/PUT)
+                      </option>
+                      <option value="doc_block">
+                        Blocked (Deny All)
+                      </option>
+                    </>
                   ) : (
                     <>
                       <option value="read_blacklist">
@@ -173,10 +188,10 @@ export function EditRuleButton({
                 </select>
               </div>
 
-              {selectedService === 'sheets' ? (
+              {selectedService === 'sheets' || selectedService === 'docs' ? (
                 <div>
                   <label className="block text-sm font-semibold text-slate-700 mb-1.5">
-                    Spreadsheet ID
+                    {selectedService === 'sheets' ? 'Spreadsheet ID' : 'Document ID'}
                   </label>
                   <input
                     type="text"
@@ -187,7 +202,7 @@ export function EditRuleButton({
                     className="w-full border border-slate-300 rounded-md px-3 py-2 text-sm font-mono text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm"
                   />
                   <p className="text-xs text-slate-500 mt-1">
-                    Document Title: {rule.resourceName || 'Google Sheet'}
+                    Document Title: {rule.resourceName || (selectedService === 'sheets' ? 'Google Sheet' : 'Google Doc')}
                   </p>
                 </div>
               ) : (

--- a/src/app/dashboard/ExposedFilesManager.tsx
+++ b/src/app/dashboard/ExposedFilesManager.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState, useEffect, useCallback } from 'react';
-import { useGooglePicker, PickedSheet } from './useGooglePicker';
+import { useGooglePicker, PickedFile } from './useGooglePicker';
+import { DRIVE_FILE_KINDS, type DriveFileKind } from '@/lib/driveFileKinds';
 
-interface SheetsRule {
+interface FileRule {
   id: string;
   ruleName: string;
   targetResourceId: string;
@@ -17,74 +18,108 @@ interface ProxyKeyInfo {
   label: string;
 }
 
-export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKeyInfo[] }) {
-  const [sheetsRules, setSheetsRules] = useState<SheetsRule[]>([]);
+const KIND_UI = {
+  sheet: {
+    title: 'Google Sheets Access Rules',
+    subject: 'Google Sheets',
+    addLabel: 'Add Google Sheet +',
+    idHeader: 'Spreadsheet ID',
+    emptyTitle: 'No Google Sheets exposed yet',
+    emptyBody: 'Click "Add Google Sheet +" to pick spreadsheets using Google Picker and define Read or Read/Write permissions.',
+    accent: 'emerald',
+    iconPath: 'M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z',
+    grantPath: '/api/rules/grant-sheets-access',
+    verifyPath: '/api/rules/verify-sheets-access',
+    rulesKey: 'sheetsRules',
+    noun: 'sheet',
+  },
+  doc: {
+    title: 'Google Docs Access Rules',
+    subject: 'Google Docs',
+    addLabel: 'Add Google Doc +',
+    idHeader: 'Document ID',
+    emptyTitle: 'No Google Docs exposed yet',
+    emptyBody: 'Click "Add Google Doc +" to pick documents using Google Picker and define Read or Read/Write permissions.',
+    accent: 'blue',
+    iconPath: 'M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z',
+    grantPath: '/api/rules/grant-docs-access',
+    verifyPath: '/api/rules/verify-docs-access',
+    rulesKey: 'docsRules',
+    noun: 'doc',
+  },
+} as const;
+
+export function ExposedFilesManager({ kind, activeKeys = [] }: { kind: 'sheet' | 'doc'; activeKeys?: ProxyKeyInfo[] }) {
+  void activeKeys;
+  const ui = KIND_UI[kind];
+  const d = DRIVE_FILE_KINDS[kind];
+  const [fileRules, setFileRules] = useState<FileRule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  // spreadsheetId → Google-side grant state ('ok' | 'missing' | 'unknown').
-  // A rule can exist without Google ever having shared the sheet (approved
+  // fileId → Google-side grant state ('ok' | 'missing' | 'unknown').
+  // A rule can exist without Google ever having shared the file (approved
   // via magic link, never picked) — those rows get a "Needs Google access"
   // chip. Verification failing entirely degrades to no chips, never a
   // broken card.
   const [grantStates, setGrantStates] = useState<Record<string, { state: string }>>({});
 
-  const fetchSheetsRules = useCallback(async () => {
+  const fetchFileRules = useCallback(async () => {
     try {
-      const res = await fetch('/api/rules/grant-sheets-access');
+      const res = await fetch(ui.grantPath);
       const data = await res.json();
-      if (data.sheetsRules) {
-        setSheetsRules(data.sheetsRules);
+      if (data[ui.rulesKey]) {
+        setFileRules(data[ui.rulesKey]);
       }
     } catch (err) {
-      console.error('Failed to load sheets rules:', err);
+      console.error(`Failed to load ${ui.noun} rules:`, err);
     } finally {
       setIsLoading(false);
     }
     try {
-      const res = await fetch('/api/rules/verify-sheets-access');
+      const res = await fetch(ui.verifyPath);
       const data = await res.json();
       setGrantStates(data.grants ?? {});
     } catch {
       setGrantStates({});
     }
-  }, []);
+  }, [ui.grantPath, ui.verifyPath, ui.rulesKey, ui.noun]);
 
   useEffect(() => {
-    fetchSheetsRules();
-  }, [fetchSheetsRules]);
+    fetchFileRules();
+  }, [fetchFileRules]);
 
-  const handleSheetsPicked = async (pickedSheets: PickedSheet[]) => {
-    setStatusMessage('Saving exposed sheets to FGAC...');
-    for (const sheet of pickedSheets) {
-      await fetch('/api/rules/grant-sheets-access', {
+  const handleFilesPicked = async (picked: PickedFile[]) => {
+    setStatusMessage(`Saving exposed ${ui.noun}s to FGAC...`);
+    for (const file of picked) {
+      await fetch(ui.grantPath, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          targetResourceId: sheet.id,
-          resourceName: sheet.name,
-          actionType: 'sheet_read', // Default to Read Only
+          targetResourceId: file.id,
+          resourceName: file.name,
+          actionType: d.actionTypes.read, // Default to Read Only
         })
       });
     }
-    await fetchSheetsRules();
-    setStatusMessage(`Successfully added ${pickedSheets.length} sheet(s)!`);
+    await fetchFileRules();
+    setStatusMessage(`Successfully added ${picked.length} ${ui.noun}(s)!`);
     setTimeout(() => setStatusMessage(null), 4000);
   };
 
-  const { triggerAddSheets, isLoading: isPickerLoading } = useGooglePicker(handleSheetsPicked);
+  const { triggerAddSheets: triggerAddFiles, isLoading: isPickerLoading } = useGooglePicker(handleFilesPicked, kind);
 
   const handlePermissionChange = async (targetResourceId: string, resourceName: string | null, newActionType: string) => {
     try {
-      await fetch('/api/rules/grant-sheets-access', {
+      await fetch(ui.grantPath, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           targetResourceId,
-          resourceName: resourceName || `Spreadsheet (${targetResourceId.slice(0, 6)})`,
+          resourceName: resourceName || `${d.noun.charAt(0).toUpperCase() + d.noun.slice(1)} (${targetResourceId.slice(0, 6)})`,
           actionType: newActionType
         })
       });
-      await fetchSheetsRules();
+      await fetchFileRules();
     } catch (err) {
       console.error('Failed to update permission:', err);
     }
@@ -92,33 +127,42 @@ export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKe
 
   const handleDeleteRule = async (ruleId: string) => {
     try {
-      await fetch(`/api/rules/grant-sheets-access?ruleId=${ruleId}`, {
+      await fetch(`${ui.grantPath}?ruleId=${ruleId}`, {
         method: 'DELETE'
       });
-      await fetchSheetsRules();
+      await fetchFileRules();
     } catch (err) {
-      console.error('Failed to remove sheet rule:', err);
+      console.error(`Failed to remove ${ui.noun} rule:`, err);
     }
   };
+
+  const accentText = ui.accent === 'emerald' ? 'text-emerald-600' : 'text-blue-600';
+  const accentButton = ui.accent === 'emerald'
+    ? 'bg-emerald-600 hover:bg-emerald-500'
+    : 'bg-blue-600 hover:bg-blue-500';
+  const accentStatus = ui.accent === 'emerald'
+    ? 'bg-emerald-50 border-emerald-200 text-emerald-800'
+    : 'bg-blue-50 border-blue-200 text-blue-800';
+  const accentDot = ui.accent === 'emerald' ? 'bg-emerald-500' : 'bg-blue-500';
 
   return (
     <div className="bg-white rounded-xl border border-slate-200 p-6 shadow-sm mb-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
         <div>
           <div className="flex items-center gap-2">
-            <svg className="w-6 h-6 text-emerald-600" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
+            <svg className={`w-6 h-6 ${accentText}`} viewBox="0 0 24 24" fill="currentColor">
+              <path d={ui.iconPath} />
             </svg>
-            <h3 className="text-lg font-bold text-slate-900">Google Sheets Access Rules</h3>
+            <h3 className="text-lg font-bold text-slate-900">{ui.title}</h3>
           </div>
           <p className="text-sm text-slate-600 mt-1">
-            Grant agents intentional access to specific Google Sheets via per-file (<code className="bg-slate-100 px-1 py-0.5 rounded text-slate-800 text-xs">drive.file</code>) permission.
+            Grant agents intentional access to specific {ui.subject} via per-file (<code className="bg-slate-100 px-1 py-0.5 rounded text-slate-800 text-xs">drive.file</code>) permission.
           </p>
         </div>
         <button
-          onClick={() => triggerAddSheets()}
+          onClick={() => triggerAddFiles()}
           disabled={isPickerLoading}
-          className="flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white font-medium text-sm px-4 py-2 rounded-lg transition-colors shadow-sm disabled:opacity-50 flex-shrink-0"
+          className={`flex items-center justify-center gap-2 ${accentButton} text-white font-medium text-sm px-4 py-2 rounded-lg transition-colors shadow-sm disabled:opacity-50 flex-shrink-0`}
         >
           {isPickerLoading ? (
             <span>Connecting...</span>
@@ -127,29 +171,29 @@ export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKe
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
               </svg>
-              <span>Add Google Sheet +</span>
+              <span>{ui.addLabel}</span>
             </>
           )}
         </button>
       </div>
 
       {statusMessage && (
-        <div className="mb-4 p-3 bg-emerald-50 border border-emerald-200 text-emerald-800 text-sm rounded-lg flex items-center gap-2">
-          <span className="inline-block w-2 h-2 rounded-full bg-emerald-500 animate-pulse" />
+        <div className={`mb-4 p-3 border text-sm rounded-lg flex items-center gap-2 ${accentStatus}`}>
+          <span className={`inline-block w-2 h-2 rounded-full animate-pulse ${accentDot}`} />
           {statusMessage}
         </div>
       )}
 
       {isLoading ? (
-        <div className="py-8 text-center text-slate-400 text-sm">Loading sheets access rules...</div>
-      ) : sheetsRules.length === 0 ? (
+        <div className="py-8 text-center text-slate-400 text-sm">Loading {ui.noun}s access rules...</div>
+      ) : fileRules.length === 0 ? (
         <div className="py-8 border-2 border-dashed border-slate-200 rounded-lg text-center p-6 bg-slate-50/50">
           <svg className="w-10 h-10 text-slate-400 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
-          <p className="text-sm font-medium text-slate-700">No Google Sheets exposed yet</p>
+          <p className="text-sm font-medium text-slate-700">{ui.emptyTitle}</p>
           <p className="text-xs text-slate-500 mt-1 mb-3">
-            Click &quot;Add Google Sheet +&quot; to pick spreadsheets using Google Picker and define Read or Read/Write permissions.
+            {ui.emptyBody}
           </p>
         </div>
       ) : (
@@ -158,24 +202,24 @@ export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKe
             <thead>
               <tr className="border-b border-slate-200 text-slate-500 font-semibold text-xs uppercase tracking-wider bg-slate-50">
                 <th className="py-3 px-4">Document Title</th>
-                <th className="py-3 px-4">Spreadsheet ID</th>
+                <th className="py-3 px-4">{ui.idHeader}</th>
                 <th className="py-3 px-4">FGAC Permission</th>
                 <th className="py-3 px-4 text-right">Action</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
-              {sheetsRules.map((rule) => (
+              {fileRules.map((rule) => (
                 <tr key={rule.id} className="hover:bg-slate-50/80 transition-colors">
                   <td className="py-3 px-4 font-medium text-slate-900 flex items-center gap-2">
-                    <svg className="w-4 h-4 text-emerald-600 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
+                    <svg className={`w-4 h-4 ${accentText} flex-shrink-0`} fill="currentColor" viewBox="0 0 24 24">
+                      <path d={ui.iconPath} />
                     </svg>
                     <span>{rule.resourceName || rule.ruleName}</span>
                     {grantStates[rule.targetResourceId]?.state === 'missing' && (
                       <a
-                        href={`/dashboard/sheets-setup?sid=${encodeURIComponent(rule.targetResourceId)}${rule.resourceName ? `&name=${encodeURIComponent(rule.resourceName)}` : ''}`}
+                        href={`${d.setupPath}?${d.setupIdParam}=${encodeURIComponent(rule.targetResourceId)}${rule.resourceName ? `&name=${encodeURIComponent(rule.resourceName)}` : ''}`}
                         className="inline-flex items-center gap-1 rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-800 hover:bg-amber-100 transition-colors flex-shrink-0"
-                        title="FGAC has this rule, but Google hasn't shared the sheet with FGAC yet — agents get errors until you pick it in the Google Picker."
+                        title={`FGAC has this rule, but Google hasn't shared the ${ui.noun} with FGAC yet — agents get errors until you pick it in the Google Picker.`}
                       >
                         ⚠ Needs Google access — finish setup
                       </a>
@@ -195,16 +239,16 @@ export function ExposedSheetsManager({ activeKeys = [] }: { activeKeys?: ProxyKe
                       value={rule.actionType}
                       onChange={(e) => handlePermissionChange(rule.targetResourceId, rule.resourceName, e.target.value)}
                       className={`text-xs font-semibold px-2.5 py-1.5 rounded-md border focus:outline-none focus:ring-2 ${
-                        rule.actionType === 'sheet_read'
+                        rule.actionType === d.actionTypes.read
                           ? 'bg-blue-50 text-blue-700 border-blue-200 focus:ring-blue-500'
-                          : rule.actionType === 'sheet_read_write'
+                          : rule.actionType === d.actionTypes.readWrite
                           ? 'bg-emerald-50 text-emerald-700 border-emerald-200 focus:ring-emerald-500'
                           : 'bg-rose-50 text-rose-700 border-rose-200 focus:ring-rose-500'
                       }`}
                     >
-                      <option value="sheet_read">Read Only (GET)</option>
-                      <option value="sheet_read_write">Read & Write (GET + POST/PUT)</option>
-                      <option value="sheet_block">Blocked (Deny All)</option>
+                      <option value={d.actionTypes.read}>Read Only (GET)</option>
+                      <option value={d.actionTypes.readWrite}>Read & Write (GET + POST/PUT)</option>
+                      <option value={d.actionTypes.block}>Blocked (Deny All)</option>
                     </select>
                   </td>
                   <td className="py-3 px-4 text-right">

--- a/src/app/dashboard/FileGrantRecovery.tsx
+++ b/src/app/dashboard/FileGrantRecovery.tsx
@@ -8,7 +8,7 @@ import { DRIVE_FILE_KINDS, type DriveFileKind } from "@/lib/driveFileKinds";
 
 const SHEETS_DEMO_EMBED = "https://share.descript.com/embed/Fv9pwXugLUa";
 
-type GrantStatus = "checking" | "needs_grant" | "verified" | "picked_other";
+type GrantStatus = "checking" | "needs_grant" | "verified" | "verified_other";
 
 /**
  * Recovery UI for the "FGAC approved, Google grant missing" state — shared
@@ -94,9 +94,12 @@ export function FileGrantRecovery({
       if (ok) {
         setStatus("verified");
       } else {
-        // The pick registered grants, just not for the file the agent asked
-        // for — most likely the agent had the wrong id. Say so.
-        setStatus(picked.length > 0 ? "picked_other" : "needs_grant");
+        // The user's pick is authoritative (product decision 2026-08-20):
+        // whatever they picked is now shared and usable — render SUCCESS,
+        // never a warning. Most likely the agent simply had the wrong id;
+        // verified_other adds one informational line about that, nothing
+        // blocking. Only an empty pick returns to needs_grant.
+        setStatus(picked.length > 0 ? "verified_other" : "needs_grant");
       }
     } finally {
       setBusy(false);
@@ -111,12 +114,21 @@ export function FileGrantRecovery({
   return (
     <div className="mx-auto mt-12 max-w-2xl px-6 pb-16">
       <div className="rounded-lg border border-border bg-card p-8">
-        {status === "verified" ? (
+        {status === "verified" || status === "verified_other" ? (
           <>
-            <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ {shortCap} access verified</h1>
+            <h1 className="mb-2 text-xl font-bold text-success-foreground">
+              {status === "verified" ? `✓ ${shortCap} access verified` : `✓ ${shortCap} access granted`}
+            </h1>
             <p className="text-sm text-muted-foreground">
-              {"Google now shares "}{resourceName ? <strong>{fileLabel}</strong> : `the selected ${short}`}{" with FGAC and your access rule is active. The agent can retry its request now."}
+              {status === "verified"
+                ? <>{"Google now shares "}{resourceName ? <strong>{fileLabel}</strong> : `the selected ${short}`}{" with FGAC and your access rule is active. The agent can retry its request now."}</>
+                : `Google now shares the ${short}(s) you picked with FGAC and their access rules are active. The agent can use them now — it will find them in its permissions.`}
             </p>
+            {status === "verified_other" && fileId && (
+              <p className="mt-3 text-xs text-subtle [overflow-wrap:anywhere]">
+                {`Heads up: the specific ${d.noun} ID the agent originally asked for (`}<code className="font-mono">{fileId}</code>{`) wasn't among your picks — most likely the agent guessed a wrong ID. Nothing to fix on your end; if the agent really needs that exact ${short}, it can request access again.`}
+              </p>
+            )}
           </>
         ) : (
           <>
@@ -132,14 +144,7 @@ export function FileGrantRecovery({
               {`Google only shares a ${short} when you pick it in Google's own file picker — that's the per-file permission FGAC runs on (nothing else in your Drive is shared). Pick the ${short} below and you're done.`}
             </p>
 
-            {status === "picked_other" && (
-              <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
-                {`The ${short}(s) you picked are now shared with FGAC — but none of them matched the exact ${d.noun} the agent asked for`}
-                {fileId ? <>{" (ID "}<code className="font-mono text-xs">{fileId}</code>{")"}</> : null}
-                {`. If the agent guessed a wrong ID, that's fine: ask it to retry using the ${short} you just picked. Otherwise, pick the exact ${short} again.`}
-              </div>
-            )}
-
+            
             <button
               onClick={() => triggerAddSheets(fileId ?? undefined)}
               disabled={pickerLoading || busy || status === "checking"}
@@ -161,7 +166,7 @@ export function FileGrantRecovery({
         )}
       </div>
 
-      {status !== "verified" && kind === "sheet" && (
+      {status !== "verified" && status !== "verified_other" && kind === "sheet" && (
         <div className="mt-6 rounded-lg border border-border bg-card p-2.5">
           <div className="px-1.5 pb-2 pt-1 text-sm font-semibold text-foreground">
             Watch how it works (2 min)

--- a/src/app/dashboard/FileGrantRecovery.tsx
+++ b/src/app/dashboard/FileGrantRecovery.tsx
@@ -35,6 +35,11 @@ export function FileGrantRecovery({
 }) {
   const [status, setStatus] = useState<GrantStatus>(fileId ? "checking" : "needs_grant");
   const [busy, setBusy] = useState(false);
+  // Access level applied to the pick. Read-only default; the user chooses
+  // before picking (they had no way to choose at all before 2026-08-20 —
+  // the page silently granted read-only).
+  const [level, setLevel] = useState<"read" | "read_write">("read");
+  const [grantedLevel, setGrantedLevel] = useState<"read" | "read_write">("read");
   const d = DRIVE_FILE_KINDS[kind];
   const short = kind === "sheet" ? "sheet" : d.noun;
   const verifyPath = kind === "sheet" ? "/api/rules/verify-sheets-access" : "/api/rules/verify-docs-access";
@@ -66,24 +71,29 @@ export function FileGrantRecovery({
   const handleFilesPicked = async (picked: PickedFile[]) => {
     setBusy(true);
     try {
-      // Upsert rules only for picked files that have none yet — re-POSTing
-      // an existing rule would silently reset its Read/Write choice.
+      // Read-only picks upsert only files that have no rule yet — re-POSTing
+      // an existing rule would silently downgrade a Read & Write choice. An
+      // explicit Read & Write selection applies to every picked file
+      // (upgrading an existing read-only rule is exactly what the user asked
+      // for by selecting it).
+      const chosenActionType = level === "read_write" ? d.actionTypes.readWrite : d.actionTypes.read;
       const existing = await fetch(grantPath)
         .then(r => r.json())
         .then(dta => new Set((dta[rulesKey] ?? []).map((r: { targetResourceId: string }) => r.targetResourceId)))
         .catch(() => new Set());
       for (const file of picked) {
-        if (existing.has(file.id)) continue;
+        if (level === "read" && existing.has(file.id)) continue;
         await fetch(grantPath, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             targetResourceId: file.id,
             resourceName: file.name,
-            actionType: d.actionTypes.read,
+            actionType: chosenActionType,
           }),
         });
       }
+      setGrantedLevel(level);
 
       if (!fileId) {
         // No specific file to verify — a pick is all setup requires.
@@ -122,7 +132,7 @@ export function FileGrantRecovery({
             <p className="text-sm text-muted-foreground">
               {status === "verified"
                 ? <>{"Google now shares "}{resourceName ? <strong>{fileLabel}</strong> : `the selected ${short}`}{" with FGAC and your access rule is active. The agent can retry its request now."}</>
-                : `Google now shares the ${short}(s) you picked with FGAC and their access rules are active. The agent can use them now — it will find them in its permissions.`}
+                : `Google now shares the ${short}(s) you picked with FGAC and their ${grantedLevel === "read_write" ? "Read & Write" : "Read Only"} access rules are active. The agent can use them now — it will find them in its permissions. You can change the access level any time from the dashboard.`}
             </p>
             {status === "verified_other" && fileId && (
               <p className="mt-3 text-xs text-subtle [overflow-wrap:anywhere]">
@@ -145,6 +155,17 @@ export function FileGrantRecovery({
             </p>
 
             
+            <fieldset className="mb-4 flex flex-col gap-2 text-sm text-foreground">
+              <label className="flex items-center gap-2">
+                <input type="radio" name="recovery-permission" value="read" checked={level === "read"} onChange={() => setLevel("read")} />
+                Read only
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="radio" name="recovery-permission" value="read_write" checked={level === "read_write"} onChange={() => setLevel("read_write")} />
+                Read &amp; write
+              </label>
+            </fieldset>
+
             <button
               onClick={() => triggerAddSheets(fileId ?? undefined)}
               disabled={pickerLoading || busy || status === "checking"}

--- a/src/app/dashboard/FileGrantRecovery.tsx
+++ b/src/app/dashboard/FileGrantRecovery.tsx
@@ -115,8 +115,7 @@ export function FileGrantRecovery({
           <>
             <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ {shortCap} access verified</h1>
             <p className="text-sm text-muted-foreground">
-              Google now shares {resourceName ? <strong>{fileLabel}</strong> : `the selected ${short}`} with
-              FGAC and your access rule is active. The agent can retry its request now.
+              {"Google now shares "}{resourceName ? <strong>{fileLabel}</strong> : `the selected ${short}`}{" with FGAC and your access rule is active. The agent can retry its request now."}
             </p>
           </>
         ) : (
@@ -126,22 +125,18 @@ export function FileGrantRecovery({
             </h1>
             <p className="mb-1 text-sm text-muted-foreground [overflow-wrap:anywhere]">
               {fromApproval
-                ? <>Your FGAC rule for <strong>{fileLabel}</strong> is saved, but Google hasn&apos;t shared the {short} itself with FGAC yet.</>
-                : <>FGAC has a rule for <strong>{fileLabel}</strong>, but Google hasn&apos;t shared the {short} itself with FGAC yet.</>}
+                ? <>{"Your FGAC rule for "}<strong>{fileLabel}</strong>{` is saved, but Google hasn't shared the ${short} itself with FGAC yet.`}</>
+                : <>{"FGAC has a rule for "}<strong>{fileLabel}</strong>{`, but Google hasn't shared the ${short} itself with FGAC yet.`}</>}
             </p>
             <p className="mb-5 text-sm text-muted-foreground">
-              Google only shares a {short} when you pick it in Google&apos;s own file
-              picker — that&apos;s the per-file permission FGAC runs on (nothing else
-              in your Drive is shared). Pick the {short} below and you&apos;re done.
+              {`Google only shares a ${short} when you pick it in Google's own file picker — that's the per-file permission FGAC runs on (nothing else in your Drive is shared). Pick the ${short} below and you're done.`}
             </p>
 
             {status === "picked_other" && (
               <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
-                The {short}(s) you picked are now shared with FGAC — but none of them
-                matched the exact {d.noun} the agent asked for
-                {fileId ? <> (ID <code className="font-mono text-xs">{fileId}</code>)</> : null}.
-                If the agent guessed a wrong ID, that&apos;s fine: ask it to retry using
-                the {short} you just picked. Otherwise, pick the exact {short} again.
+                {`The ${short}(s) you picked are now shared with FGAC — but none of them matched the exact ${d.noun} the agent asked for`}
+                {fileId ? <>{" (ID "}<code className="font-mono text-xs">{fileId}</code>{")"}</> : null}
+                {`. If the agent guessed a wrong ID, that's fine: ask it to retry using the ${short} you just picked. Otherwise, pick the exact ${short} again.`}
               </div>
             )}
 

--- a/src/app/dashboard/FileGrantRecovery.tsx
+++ b/src/app/dashboard/FileGrantRecovery.tsx
@@ -2,81 +2,91 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { useGooglePicker, PickedSheet } from "../useGooglePicker";
+import { useGooglePicker, PickedFile } from "./useGooglePicker";
 import { TrackedVideoEmbed } from "@/components/TrackedVideoEmbed";
+import { DRIVE_FILE_KINDS, type DriveFileKind } from "@/lib/driveFileKinds";
 
 const SHEETS_DEMO_EMBED = "https://share.descript.com/embed/Fv9pwXugLUa";
 
 type GrantStatus = "checking" | "needs_grant" | "verified" | "picked_other";
 
 /**
- * Recovery UI for the "FGAC approved, Google grant missing" state.
+ * Recovery UI for the "FGAC approved, Google grant missing" state — shared
+ * by /dashboard/sheets-setup and /dashboard/docs-setup.
  *
- * Approving a sheet in FGAC only creates our rule; Google shares the file
+ * Approving a file in FGAC only creates our rule; Google shares the file
  * with FGAC exclusively through a Google Picker pick (per-file drive.file
  * grant). Production showed users approving and then retrying into 404s
  * with no way out — this page IS the way out: one button that opens the
- * Picker, the demo video for anyone unsure, and a live verification check
- * so we never again say "done" without Google agreeing.
+ * Picker, the demo video for anyone unsure (sheets has one today), and a
+ * live verification check so we never again say "done" without Google
+ * agreeing.
  */
-export function SheetsGrantRecovery({
-  spreadsheetId,
+export function FileGrantRecovery({
+  kind,
+  fileId,
   resourceName,
   fromApproval,
 }: {
-  spreadsheetId: string | null;
+  kind: DriveFileKind;
+  fileId: string | null;
   resourceName: string | null;
   fromApproval: boolean;
 }) {
-  const [status, setStatus] = useState<GrantStatus>(spreadsheetId ? "checking" : "needs_grant");
+  const [status, setStatus] = useState<GrantStatus>(fileId ? "checking" : "needs_grant");
   const [busy, setBusy] = useState(false);
+  const d = DRIVE_FILE_KINDS[kind];
+  const short = kind === "sheet" ? "sheet" : d.noun;
+  const verifyPath = kind === "sheet" ? "/api/rules/verify-sheets-access" : "/api/rules/verify-docs-access";
+  const grantPath = kind === "sheet" ? "/api/rules/grant-sheets-access" : "/api/rules/grant-docs-access";
+  const rulesKey = kind === "sheet" ? "sheetsRules" : "docsRules";
 
   const verify = useCallback(async (recovery: boolean): Promise<boolean> => {
-    if (!spreadsheetId) return false;
+    if (!fileId) return false;
     try {
       const res = await fetch(
-        `/api/rules/verify-sheets-access?sid=${encodeURIComponent(spreadsheetId)}${recovery ? "&context=recovery" : ""}`,
+        `${verifyPath}?${d.setupIdParam}=${encodeURIComponent(fileId)}${recovery ? "&context=recovery" : ""}`,
       );
       const data = await res.json();
       return data.state === "ok";
     } catch {
       return false;
     }
-  }, [spreadsheetId]);
+  }, [fileId, verifyPath, d.setupIdParam]);
 
   useEffect(() => {
     let cancelled = false;
-    if (!spreadsheetId) return;
+    if (!fileId) return;
     verify(false).then(ok => {
       if (!cancelled) setStatus(ok ? "verified" : "needs_grant");
     });
     return () => { cancelled = true; };
-  }, [spreadsheetId, verify]);
+  }, [fileId, verify]);
 
-  const handleSheetsPicked = async (picked: PickedSheet[]) => {
+  const handleFilesPicked = async (picked: PickedFile[]) => {
     setBusy(true);
     try {
-      // Upsert rules only for picked sheets that have none yet — re-POSTing
+      // Upsert rules only for picked files that have none yet — re-POSTing
       // an existing rule would silently reset its Read/Write choice.
-      const existing = await fetch("/api/rules/grant-sheets-access")
+      const existing = await fetch(grantPath)
         .then(r => r.json())
-        .then(d => new Set((d.sheetsRules ?? []).map((r: { targetResourceId: string }) => r.targetResourceId)))
+        .then(dta => new Set((dta[rulesKey] ?? []).map((r: { targetResourceId: string }) => r.targetResourceId)))
         .catch(() => new Set());
-      for (const sheet of picked) {
-        if (existing.has(sheet.id)) continue;
-        await fetch("/api/rules/grant-sheets-access", {
+      for (const file of picked) {
+        if (existing.has(file.id)) continue;
+        await fetch(grantPath, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            targetResourceId: sheet.id,
-            resourceName: sheet.name,
-            actionType: "sheet_read",
+            targetResourceId: file.id,
+            resourceName: file.name,
+            actionType: d.actionTypes.read,
           }),
         });
       }
 
-      if (!spreadsheetId) {
-        // No specific sheet to verify — a pick is all setup requires.
+      if (!fileId) {
+        // No specific file to verify — a pick is all setup requires.
         setStatus(picked.length > 0 ? "verified" : "needs_grant");
         return;
       }
@@ -84,7 +94,7 @@ export function SheetsGrantRecovery({
       if (ok) {
         setStatus("verified");
       } else {
-        // The pick registered grants, just not for the sheet the agent asked
+        // The pick registered grants, just not for the file the agent asked
         // for — most likely the agent had the wrong id. Say so.
         setStatus(picked.length > 0 ? "picked_other" : "needs_grant");
       }
@@ -93,49 +103,50 @@ export function SheetsGrantRecovery({
     }
   };
 
-  const { triggerAddSheets, isLoading: pickerLoading } = useGooglePicker(handleSheetsPicked);
+  const { triggerAddSheets, isLoading: pickerLoading } = useGooglePicker(handleFilesPicked, kind);
 
-  const sheetLabel = resourceName || spreadsheetId || "your spreadsheet";
+  const fileLabel = resourceName || fileId || `your ${d.noun}`;
+  const shortCap = short.charAt(0).toUpperCase() + short.slice(1);
 
   return (
     <div className="mx-auto mt-12 max-w-2xl px-6 pb-16">
       <div className="rounded-lg border border-border bg-card p-8">
         {status === "verified" ? (
           <>
-            <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ Sheet access verified</h1>
+            <h1 className="mb-2 text-xl font-bold text-success-foreground">✓ {shortCap} access verified</h1>
             <p className="text-sm text-muted-foreground">
-              Google now shares {resourceName ? <strong>{sheetLabel}</strong> : "the selected sheet"} with
+              Google now shares {resourceName ? <strong>{fileLabel}</strong> : `the selected ${short}`} with
               FGAC and your access rule is active. The agent can retry its request now.
             </p>
           </>
         ) : (
           <>
             <h1 className="mb-2 text-xl font-bold text-foreground">
-              {fromApproval ? "Approved — one more step" : "Finish setting up sheet access"}
+              {fromApproval ? "Approved — one more step" : `Finish setting up ${short} access`}
             </h1>
             <p className="mb-1 text-sm text-muted-foreground [overflow-wrap:anywhere]">
               {fromApproval
-                ? <>Your FGAC rule for <strong>{sheetLabel}</strong> is saved, but Google hasn&apos;t shared the sheet itself with FGAC yet.</>
-                : <>FGAC has a rule for <strong>{sheetLabel}</strong>, but Google hasn&apos;t shared the sheet itself with FGAC yet.</>}
+                ? <>Your FGAC rule for <strong>{fileLabel}</strong> is saved, but Google hasn&apos;t shared the {short} itself with FGAC yet.</>
+                : <>FGAC has a rule for <strong>{fileLabel}</strong>, but Google hasn&apos;t shared the {short} itself with FGAC yet.</>}
             </p>
             <p className="mb-5 text-sm text-muted-foreground">
-              Google only shares a sheet when you pick it in Google&apos;s own file
+              Google only shares a {short} when you pick it in Google&apos;s own file
               picker — that&apos;s the per-file permission FGAC runs on (nothing else
-              in your Drive is shared). Pick the sheet below and you&apos;re done.
+              in your Drive is shared). Pick the {short} below and you&apos;re done.
             </p>
 
             {status === "picked_other" && (
               <div className="mb-5 rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
-                The sheet(s) you picked are now shared with FGAC — but none of them
-                matched the exact spreadsheet the agent asked for
-                {spreadsheetId ? <> (ID <code className="font-mono text-xs">{spreadsheetId}</code>)</> : null}.
+                The {short}(s) you picked are now shared with FGAC — but none of them
+                matched the exact {d.noun} the agent asked for
+                {fileId ? <> (ID <code className="font-mono text-xs">{fileId}</code>)</> : null}.
                 If the agent guessed a wrong ID, that&apos;s fine: ask it to retry using
-                the sheet you just picked. Otherwise, pick the exact sheet again.
+                the {short} you just picked. Otherwise, pick the exact {short} again.
               </div>
             )}
 
             <button
-              onClick={() => triggerAddSheets(spreadsheetId ?? undefined)}
+              onClick={() => triggerAddSheets(fileId ?? undefined)}
               disabled={pickerLoading || busy || status === "checking"}
               className="w-full rounded-sm bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
             >
@@ -145,7 +156,7 @@ export function SheetsGrantRecovery({
                   ? "Saving…"
                   : pickerLoading
                     ? "Opening Google Picker…"
-                    : "Pick the sheet in Google Picker"}
+                    : `Pick the ${short} in Google Picker`}
             </button>
             <p className="mt-2 text-xs text-subtle">
               First time? Google will ask you to allow FGAC&apos;s file picker
@@ -155,7 +166,7 @@ export function SheetsGrantRecovery({
         )}
       </div>
 
-      {status !== "verified" && (
+      {status !== "verified" && kind === "sheet" && (
         <div className="mt-6 rounded-lg border border-border bg-card p-2.5">
           <div className="px-1.5 pb-2 pt-1 text-sm font-semibold text-foreground">
             Watch how it works (2 min)

--- a/src/app/dashboard/accounts/page.tsx
+++ b/src/app/dashboard/accounts/page.tsx
@@ -8,7 +8,7 @@ import { db } from '@/db';
 import { Card, CardHeader, Badge, EmptyState, buttonSecondary } from '@/components/ui';
 import { DelegateAccessButton } from '../DelegateAccessButton';
 import { RevokeDelegationButton } from '../RevokeDelegationButton';
-import { ExposedSheetsManager } from '../ExposedSheetsManager';
+import { ExposedFilesManager } from '../ExposedFilesManager';
 import { AddDelegatedAccountButton } from './AddDelegatedAccountButton';
 import { ReconnectGoogleButton } from './ReconnectGoogleButton';
 import { checkGoogleAccess } from '../googleAccess';
@@ -168,7 +168,8 @@ export default async function AccountsPage() {
           {/* Renders its own card chrome and header, and its horizontal
               header layout needs the full-width column — nesting it in the
               narrow side column wrapped the heading one word per line. */}
-          <ExposedSheetsManager activeKeys={activeKeys} />
+          <ExposedFilesManager kind="sheet" activeKeys={activeKeys} />
+          <ExposedFilesManager kind="doc" activeKeys={activeKeys} />
         </div>
 
         {/* ─── Side column ────────────────────────────────────────────── */}

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -273,7 +273,7 @@ export async function createRule(formData: FormData) {
   let finalRegexPattern: string | null = null;
   let targetResourceId: string | null = null;
 
-  if (service === 'sheets') {
+  if (service === 'sheets' || service === 'docs') {
     targetResourceId = rawPattern;
   } else {
     finalRegexPattern = rawPattern;
@@ -321,7 +321,7 @@ export async function updateRule(formData: FormData) {
   let finalRegexPattern: string | null = null;
   let targetResourceId: string | null = null;
 
-  if (service === 'sheets') {
+  if (service === 'sheets' || service === 'docs') {
     targetResourceId = rawPattern;
   } else {
     finalRegexPattern = rawPattern;
@@ -342,7 +342,7 @@ export async function updateRule(formData: FormData) {
     service,
     actionType,
     regexPattern: finalRegexPattern,
-    targetResourceId: service === 'sheets' ? targetResourceId : rule.targetResourceId,
+    targetResourceId: (service === 'sheets' || service === 'docs') ? targetResourceId : rule.targetResourceId,
     targetEmail: targetEmail || null,
   }).where(eq(accessRules.id, ruleId));
 
@@ -380,16 +380,20 @@ const SHEET_ACTION_TYPES = ['sheet_read', 'sheet_read_write', 'sheet_block'] as 
  * Google Picker flow.
  */
 /**
- * Persist sheets picked in the Google Picker as access rules.
+ * Persist files picked in the Google Picker as access rules (shared by the
+ * sheets and docs exposure flows).
  *
  * With a profileId the exposure is scoped to that profile; without one it is
  * global. Existing rules are never narrowed: a global rule stays global, and a
  * profile-scoped rule gains the new assignment instead of replacing the set.
  */
-export async function exposeSheetsFromPicker(
+async function exposeFilesFromPicker(
+  kind: 'sheet' | 'doc',
   picked: { id: string; name: string }[],
   profileId?: string,
 ) {
+  const { DRIVE_FILE_KINDS } = await import("@/lib/driveFileKinds");
+  const d = DRIVE_FILE_KINDS[kind];
   const dbUser = await getDbUser();
 
   if (profileId) {
@@ -399,15 +403,16 @@ export async function exposeSheetsFromPicker(
     if (!key) throw new Error("Unauthorized or profile not found");
   }
 
-  for (const sheet of picked) {
-    if (!sheet?.id) continue;
-    const name = sheet.name || `Spreadsheet (${sheet.id.slice(0, 8)})`;
+  const fallbackNoun = d.noun.charAt(0).toUpperCase() + d.noun.slice(1);
+  for (const file of picked) {
+    if (!file?.id) continue;
+    const name = file.name || `${fallbackNoun} (${file.id.slice(0, 8)})`;
 
     const existing = await db.select().from(accessRules)
       .where(and(
         eq(accessRules.userId, dbUser.id),
-        eq(accessRules.service, 'sheets'),
-        eq(accessRules.targetResourceId, sheet.id),
+        eq(accessRules.service, d.service),
+        eq(accessRules.targetResourceId, file.id),
       ))
       .limit(1).then(res => res[0]);
 
@@ -431,9 +436,9 @@ export async function exposeSheetsFromPicker(
         .values({
           userId: dbUser.id,
           ruleName: name,
-          service: 'sheets',
-          actionType: 'sheet_read',
-          targetResourceId: sheet.id,
+          service: d.service,
+          actionType: d.actionTypes.read,
+          targetResourceId: file.id,
           resourceName: name,
         })
         .returning();
@@ -449,19 +454,39 @@ export async function exposeSheetsFromPicker(
   revalidatePath("/dashboard/accounts");
 }
 
+export async function exposeSheetsFromPicker(
+  picked: { id: string; name: string }[],
+  profileId?: string,
+) {
+  return exposeFilesFromPicker('sheet', picked, profileId);
+}
+
+export async function exposeDocsFromPicker(
+  picked: { id: string; name: string }[],
+  profileId?: string,
+) {
+  return exposeFilesFromPicker('doc', picked, profileId);
+}
+
+const DOC_ACTION_TYPES = ['doc_read', 'doc_read_write', 'doc_block'] as const;
+
 export async function setSheetRulePermission(ruleId: string, actionType: string) {
   const dbUser = await getDbUser();
 
-  if (!SHEET_ACTION_TYPES.includes(actionType as typeof SHEET_ACTION_TYPES[number])) {
-    throw new Error(`Invalid sheet permission: ${actionType}`);
+  const isSheetType = SHEET_ACTION_TYPES.includes(actionType as typeof SHEET_ACTION_TYPES[number]);
+  const isDocType = DOC_ACTION_TYPES.includes(actionType as typeof DOC_ACTION_TYPES[number]);
+  if (!isSheetType && !isDocType) {
+    throw new Error(`Invalid file permission: ${actionType}`);
   }
 
   const rule = await db.select().from(accessRules).where(eq(accessRules.id, ruleId)).limit(1).then(res => res[0]);
   if (!rule || rule.userId !== dbUser.id) {
     throw new Error("Unauthorized or Rule not found");
   }
-  if (rule.service !== 'sheets') {
-    throw new Error("Not a Google Sheets rule");
+  // The action-type family must match the rule's service — a sheets rule can
+  // never end up with doc_* permissions or vice versa.
+  if (!(rule.service === 'sheets' && isSheetType) && !(rule.service === 'docs' && isDocType)) {
+    throw new Error("Permission type does not match the rule's service");
   }
 
   await db.update(accessRules)
@@ -648,11 +673,15 @@ export type MagicApprovalResult =
        * grant for the sheet yet — the approve page must route the user into
        * the Picker recovery flow instead of claiming the agent can retry. */
       needsSheetsGrant?: { spreadsheetId: string; resourceName?: string };
+      /** Docs twin of needsSheetsGrant (routes to /dashboard/docs-setup). */
+      needsDocsGrant?: { documentId: string; resourceName?: string };
       /** Set on successful sheets approvals: the primary spreadsheet a rule
        * was created for. The approve page's success card polls the Google
        * grant for this id before telling the user "the agent can retry now"
        * (drive.file grants are eventually consistent — see sheetsGrantCheck). */
       grantedSpreadsheetId?: string;
+      /** Docs twin of grantedSpreadsheetId. */
+      grantedDocumentId?: string;
     }
   | {
       ok: false;
@@ -675,7 +704,7 @@ export type MagicApprovalResult =
  * revoked permissions is the replay attack single-use exists to prevent.
  */
 async function grantActiveForApproval(
-  p: { action: string; userId: string; recipient?: string; spreadsheetId?: string },
+  p: { action: string; userId: string; recipient?: string; spreadsheetId?: string; documentId?: string },
   keyId: string,
 ): Promise<boolean> {
   const assignedOrGlobal = async (ruleId: string): Promise<boolean> => {
@@ -714,6 +743,21 @@ async function grantActiveForApproval(
     return false;
   }
 
+  if ((p.action === "docs_expose" || p.action === "docs_write") && p.documentId) {
+    const needed = p.action === "docs_write"
+      ? ["doc_read_write"]
+      : ["doc_read", "doc_read_write"];
+    const rules = await db.select().from(accessRules).where(and(
+      eq(accessRules.userId, p.userId),
+      eq(accessRules.service, "docs"),
+    ));
+    for (const r of rules) {
+      if (r.targetResourceId !== p.documentId || !needed.includes(r.actionType)) continue;
+      if (await assignedOrGlobal(r.id)) return true;
+    }
+    return false;
+  }
+
   return false;
 }
 
@@ -735,6 +779,142 @@ export async function approvalLinkStatus(token: string): Promise<
     .where(eq(approvalConsumptions.jti, p.jti)).limit(1);
   if (used.length === 0) return "fresh";
   return (await grantActiveForApproval(p, p.proxyKeyId)) ? "already_granted" : "used_inactive";
+}
+
+/**
+ * Shared picker-first approval for per-file (sheets/docs) magic links.
+ * Extracted from the sheets branch of approveMagicLink when Docs support
+ * landed — behavior for sheets is unchanged (same events, same copy).
+ *
+ * The pick is the real authorization moment — it registers the Google-side
+ * drive.file grant AND confirms the file's identity. Rules are created only
+ * for picked ids Google confirms the owner's token can reach; the token's id
+ * gets NO rule unless it is among them (no phantom rules for ids the agent
+ * guessed wrong). drive.file grants are eventually consistent: verifying a
+ * pick in the seconds right after a first-time consent (the hottest path for
+ * new users) can see "missing" for a file Google IS sharing — same race as
+ * the MCP-side grace retries, so the pick gets the same grace instead of
+ * failing the user's first approval (observed live 2026-08-19).
+ */
+async function applyFileGrantApproval(opts: {
+  kind: "sheet" | "doc";
+  dbUser: { id: string; clerkUserId: string };
+  key: { id: string };
+  p: { jti: string; action: string; resourceName?: string };
+  fileId: string;
+  readWrite: boolean;
+  picked?: { id: string; name?: string }[];
+  consume: () => Promise<boolean>;
+  alreadyUsed: () => Promise<MagicApprovalResult>;
+  describe: () => string;
+}): Promise<MagicApprovalResult> {
+  const { kind, dbUser, key, p, fileId, readWrite, picked, consume, alreadyUsed, describe } = opts;
+  const { DRIVE_FILE_KINDS } = await import("@/lib/driveFileKinds");
+  const { verifyFileGrant, getOwnerGoogleToken } = await import("@/lib/driveFileGrantCheck");
+  const { captureServerEvent } = await import("@/lib/posthogServer");
+  const d = DRIVE_FILE_KINDS[kind];
+  // Kind-specific analytics/copy: sheets keeps its historical event and prop
+  // names; the short noun matches the pre-docs sheets copy ("sheet(s)").
+  const verificationEvent = kind === "sheet" ? "sheets_grant_verification" : "docs_grant_verification";
+  const idProp = kind === "sheet" ? "spreadsheet_id" : "document_id";
+  const short = kind === "sheet" ? "sheet" : "document";
+  const googleToken = await getOwnerGoogleToken(dbUser.clerkUserId);
+
+  const grantedResult = (grantedId: string, description: string): MagicApprovalResult =>
+    kind === "sheet"
+      ? { ok: true, description, grantedSpreadsheetId: grantedId }
+      : { ok: true, description, grantedDocumentId: grantedId };
+
+  const insertFileRule = async (id: string, name: string | null) => {
+    const [rule] = await db.insert(accessRules).values({
+      userId: dbUser.id,
+      ruleName: `${readWrite ? "Read & Write" : "Read Only"}: ${name || id}`,
+      service: d.service,
+      actionType: readWrite ? d.actionTypes.readWrite : d.actionTypes.read,
+      targetResourceId: id,
+      resourceName: name,
+    }).returning();
+    await db.insert(keyRuleAssignments).values({ proxyKeyId: key.id, accessRuleId: rule.id });
+  };
+
+  if (picked && picked.length > 0) {
+    const verifyPicks = async () => {
+      const out: { id: string; name: string | null }[] = [];
+      for (const s of picked.slice(0, 10)) {
+        if (typeof s?.id !== "string" || !s.id) continue;
+        const check = googleToken
+          ? await verifyFileGrant(kind, googleToken, s.id)
+          : { state: "missing" as const };
+        if (check.state === "ok") {
+          out.push({ id: s.id, name: (typeof s.name === "string" && s.name) || ("title" in check ? check.title : null) });
+        }
+      }
+      return out;
+    };
+    let verified = await verifyPicks();
+    for (let attempt = 0; verified.length === 0 && attempt < 2; attempt++) {
+      await new Promise(r => setTimeout(r, 3500));
+      verified = await verifyPicks();
+    }
+    if (verified.length === 0) {
+      // Read-only failure — the link was NOT consumed; the user can retry.
+      return {
+        ok: false,
+        retryable: true,
+        reason: `Google hasn't finished sharing the picked ${short}(s) with FGAC yet. Wait a few seconds and pick again — this link is still valid.`,
+      };
+    }
+    if (!(await consume())) return await alreadyUsed();
+    for (const v of verified) await insertFileRule(v.id, v.name);
+
+    const substituted = !verified.some(v => v.id === fileId);
+    captureServerEvent(dbUser.clerkUserId, verificationEvent, {
+      result: "ok", via: "magic_link", [idProp]: verified[0].id, link_id: p.jti,
+    });
+    captureServerEvent(dbUser.clerkUserId, "approval_link_approved", {
+      action: p.action, substituted, granted_count: verified.length, link_id: p.jti,
+    });
+    revalidatePath("/dashboard");
+    const names = verified.map(v => v.name || v.id).join(", ");
+    const level = readWrite ? "read & write" : "read-only";
+    return grantedResult(
+      verified[0].id,
+      substituted
+        ? `Granted ${level} access to ${names}. That's the ${short} you picked — not the ID the agent originally sent, which you don't appear to have. The agent will find the right ${short} in its permissions.`
+        : `Granted ${level} access to ${names}.`,
+    );
+  }
+
+  // Fallback path (no pick info — verification was inconclusive at page
+  // load, or a client without the picker flow). Create the rule, verify
+  // the Google half, and route to the recovery page when it's missing —
+  // never claim "retry now" for a file Google can't reach (the
+  // approve→retry→404 dead end the 2026-08 launch cohort churned on).
+  if (!(await consume())) return await alreadyUsed();
+  await insertFileRule(fileId, p.resourceName || null);
+  const grant = googleToken
+    ? await verifyFileGrant(kind, googleToken, fileId)
+    : { state: "missing" as const };
+  captureServerEvent(dbUser.clerkUserId, verificationEvent, {
+    result: grant.state,
+    via: "magic_link",
+    [idProp]: fileId,
+    link_id: p.jti,
+  });
+  if (grant.state === "missing") {
+    captureServerEvent(dbUser.clerkUserId, "approval_link_approved", { action: p.action, link_id: p.jti });
+    revalidatePath("/dashboard");
+    return {
+      ok: true,
+      description: describe(),
+      ...(kind === "sheet"
+        ? { needsSheetsGrant: { spreadsheetId: fileId, resourceName: p.resourceName || undefined } }
+        : { needsDocsGrant: { documentId: fileId, resourceName: p.resourceName || undefined } }),
+    };
+  }
+  captureServerEvent(dbUser.clerkUserId, "approval_link_approved", { action: p.action, link_id: p.jti });
+  revalidatePath("/dashboard");
+  return grantedResult(fileId, describe());
 }
 
 /**
@@ -823,112 +1003,25 @@ export async function approveMagicLink(
     // success — the agent's retry will work either way.
     await grantSendToAnyone(dbUser.id, key.id);
   } else if ((p.action === "sheets_expose" || p.action === "sheets_write") && p.spreadsheetId) {
-    const readWrite = p.action === "sheets_write" || sheetsWriteChoice === true;
-    const { verifySheetsGrant, getOwnerGoogleToken } = await import("@/lib/sheetsGrantCheck");
-    const googleToken = await getOwnerGoogleToken(dbUser.clerkUserId);
-
-    const insertSheetRule = async (id: string, name: string | null) => {
-      const [rule] = await db.insert(accessRules).values({
-        userId: dbUser.id,
-        ruleName: `${readWrite ? "Read & Write" : "Read Only"}: ${name || id}`,
-        service: "sheets",
-        actionType: readWrite ? "sheet_read_write" : "sheet_read",
-        targetResourceId: id,
-        resourceName: name,
-      }).returning();
-      await db.insert(keyRuleAssignments).values({ proxyKeyId: key.id, accessRuleId: rule.id });
-    };
-
-    if (pickedSheets && pickedSheets.length > 0) {
-      // Picker-first path. The pick is the real authorization moment — it
-      // registers the Google-side drive.file grant AND confirms the file's
-      // identity. Rules are created only for picked ids Google confirms the
-      // owner's token can reach; the token's id gets NO rule unless it is
-      // among them (no phantom rules for ids the agent guessed wrong).
-      // drive.file grants are eventually consistent: verifying a pick in the
-      // seconds right after a first-time consent (the hottest path for new
-      // users) can see "missing" for a sheet Google IS sharing. Same race as
-      // the MCP-side withSheetsGrace — give the pick the same grace instead
-      // of failing the user's first approval (observed live 2026-08-19).
-      const verifyPicks = async () => {
-        const out: { id: string; name: string | null }[] = [];
-        for (const s of pickedSheets.slice(0, 10)) {
-          if (typeof s?.id !== "string" || !s.id) continue;
-          const check = googleToken
-            ? await verifySheetsGrant(googleToken, s.id)
-            : { state: "missing" as const };
-          if (check.state === "ok") {
-            out.push({ id: s.id, name: (typeof s.name === "string" && s.name) || ("title" in check ? check.title : null) });
-          }
-        }
-        return out;
-      };
-      let verified = await verifyPicks();
-      for (let attempt = 0; verified.length === 0 && attempt < 2; attempt++) {
-        await new Promise(r => setTimeout(r, 3500));
-        verified = await verifyPicks();
-      }
-      if (verified.length === 0) {
-        // Read-only failure — the link was NOT consumed; the user can retry.
-        return {
-          ok: false,
-          retryable: true,
-          reason: "Google hasn't finished sharing the picked sheet(s) with FGAC yet. Wait a few seconds and pick again — this link is still valid.",
-        };
-      }
-      if (!(await consume())) return await alreadyUsed();
-      for (const v of verified) await insertSheetRule(v.id, v.name);
-
-      const substituted = !verified.some(v => v.id === p.spreadsheetId);
-      captureServerEvent(dbUser.clerkUserId, "sheets_grant_verification", {
-        result: "ok", via: "magic_link", spreadsheet_id: verified[0].id, link_id: p.jti,
-      });
-      captureServerEvent(dbUser.clerkUserId, "approval_link_approved", {
-        action: p.action, substituted, granted_count: verified.length, link_id: p.jti,
-      });
-      revalidatePath("/dashboard");
-      const names = verified.map(v => v.name || v.id).join(", ");
-      const level = readWrite ? "read & write" : "read-only";
-      return {
-        ok: true,
-        grantedSpreadsheetId: verified[0].id,
-        description: substituted
-          ? `Granted ${level} access to ${names}. That's the sheet you picked — not the ID the agent originally sent, which you don't appear to have. The agent will find the right sheet in its permissions.`
-          : `Granted ${level} access to ${names}.`,
-      };
-    }
-
-    // Fallback path (no pick info — verification was inconclusive at page
-    // load, or a client without the picker flow). Create the rule, verify
-    // the Google half, and route to the recovery page when it's missing —
-    // never claim "retry now" for a sheet Google can't reach (the
-    // approve→retry→404 dead end the 2026-08 launch cohort churned on).
-    if (!(await consume())) return await alreadyUsed();
-    await insertSheetRule(p.spreadsheetId, p.resourceName || null);
-    const grant = googleToken
-      ? await verifySheetsGrant(googleToken, p.spreadsheetId)
-      : { state: "missing" as const };
-    captureServerEvent(dbUser.clerkUserId, "sheets_grant_verification", {
-      result: grant.state,
-      via: "magic_link",
-      spreadsheet_id: p.spreadsheetId,
-      link_id: p.jti,
+    return applyFileGrantApproval({
+      kind: "sheet",
+      dbUser, key, p,
+      fileId: p.spreadsheetId,
+      readWrite: p.action === "sheets_write" || sheetsWriteChoice === true,
+      picked: pickedSheets,
+      consume, alreadyUsed,
+      describe: () => describeApproval(p),
     });
-    if (grant.state === "missing") {
-      captureServerEvent(dbUser.clerkUserId, "approval_link_approved", { action: p.action, link_id: p.jti });
-      revalidatePath("/dashboard");
-      return {
-        ok: true,
-        description: describeApproval(p),
-        needsSheetsGrant: {
-          spreadsheetId: p.spreadsheetId,
-          resourceName: p.resourceName || undefined,
-        },
-      };
-    }
-    captureServerEvent(dbUser.clerkUserId, "approval_link_approved", { action: p.action, link_id: p.jti });
-    revalidatePath("/dashboard");
-    return { ok: true, description: describeApproval(p), grantedSpreadsheetId: p.spreadsheetId };
+  } else if ((p.action === "docs_expose" || p.action === "docs_write") && p.documentId) {
+    return applyFileGrantApproval({
+      kind: "doc",
+      dbUser, key, p,
+      fileId: p.documentId,
+      readWrite: p.action === "docs_write" || sheetsWriteChoice === true,
+      picked: pickedSheets,
+      consume, alreadyUsed,
+      describe: () => describeApproval(p),
+    });
   } else {
     return { ok: false, reason: "This approval link is malformed." };
   }

--- a/src/app/dashboard/approve/ApprovedSettling.tsx
+++ b/src/app/dashboard/approve/ApprovedSettling.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
+import { DRIVE_FILE_KINDS, type DriveFileKind } from "@/lib/driveFileKinds";
 
 const POLL_INTERVAL_MS = 2_000;
 const POLL_TIMEOUT_MS = 15_000;
@@ -9,7 +10,8 @@ const POLL_TIMEOUT_MS = 15_000;
 type SettleState = "settling" | "verified" | "unconfirmed";
 
 /**
- * Post-approval settling check for sheets grants (grant-race fix, 2026-08).
+ * Post-approval settling check for per-file (sheets/docs) grants
+ * (grant-race fix, 2026-08).
  *
  * Approval-time verification passes with the owner's token, but Google's
  * per-file drive.file grant is eventually consistent: the agent's very next
@@ -20,9 +22,12 @@ type SettleState = "settling" | "verified" | "unconfirmed";
  * a live test read against Google passes. If Google still hasn't settled
  * after 15 s, it says so honestly and routes to the recovery page.
  */
-export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: string; message: string }) {
+export function ApprovedSettling({ kind, fileId, message }: { kind: DriveFileKind; fileId: string; message: string }) {
   const [state, setState] = useState<SettleState>("settling");
   const startedAt = useRef(Date.now());
+  const d = DRIVE_FILE_KINDS[kind];
+  const short = kind === "sheet" ? "sheet" : d.noun;
+  const verifyPath = kind === "sheet" ? "/api/rules/verify-sheets-access" : "/api/rules/verify-docs-access";
 
   useEffect(() => {
     let cancelled = false;
@@ -31,7 +36,7 @@ export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: st
     const poll = async () => {
       try {
         const r = await fetch(
-          `/api/rules/verify-sheets-access?sid=${encodeURIComponent(spreadsheetId)}&context=post_approval`,
+          `${verifyPath}?${d.setupIdParam}=${encodeURIComponent(fileId)}&context=post_approval`,
         );
         const data = await r.json();
         if (cancelled) return;
@@ -50,7 +55,7 @@ export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: st
 
     void poll();
     return () => { cancelled = true; if (timer) clearTimeout(timer); };
-  }, [spreadsheetId]);
+  }, [fileId, verifyPath, d.setupIdParam]);
 
   if (state === "settling") {
     return (
@@ -59,7 +64,7 @@ export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: st
         <p className="text-sm text-muted-foreground">{message}</p>
         <p className="mt-3 flex items-center gap-2 text-sm text-muted-foreground" role="status">
           <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-border border-t-foreground" aria-hidden="true" />
-          Confirming Google has finished sharing the sheet…
+          Confirming Google has finished sharing the {short}…
         </p>
       </div>
     );
@@ -81,14 +86,14 @@ export function ApprovedSettling({ spreadsheetId, message }: { spreadsheetId: st
     <div data-testid="approved-unconfirmed">
       <h1 className="mb-2 text-xl font-bold text-foreground">✓ Approved — one more step may be needed</h1>
       <p className="text-sm text-muted-foreground">
-        {message}{" "}However, Google hasn&apos;t confirmed the sheet is shared with
+        {message}{" "}However, Google hasn&apos;t confirmed the {short} is shared with
         FGAC yet. This usually settles within a minute — if the agent still
         gets an error, finish the share on the{" "}
         <Link
-          href={`/dashboard/sheets-setup?sid=${encodeURIComponent(spreadsheetId)}&from=approval`}
+          href={`${d.setupPath}?${d.setupIdParam}=${encodeURIComponent(fileId)}&from=approval`}
           className="underline hover:text-foreground"
         >
-          sheets setup page
+          {short}s setup page
         </Link>.
       </p>
     </div>

--- a/src/app/dashboard/approve/FileApprovalFlow.tsx
+++ b/src/app/dashboard/approve/FileApprovalFlow.tsx
@@ -108,16 +108,12 @@ export function FileApprovalFlow({
     return (
       <div className="flex flex-col gap-4" data-testid={`${testPrefix}-flow-pick-first`}>
         <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
-          Google hasn&apos;t shared <strong>{fileLabel}</strong> with FGAC yet, so
-          there&apos;s nothing to approve until you pick it. Google only shares a
-          {" "}{short} when you choose it in Google&apos;s own file picker — that per-file
-          permission is all FGAC runs on (nothing else in your Drive is shared).
+          {"Google hasn't shared "}<strong>{fileLabel}</strong>{` with FGAC yet, so there's nothing to approve until you pick it. Google only shares a ${short} when you choose it in Google's own file picker — that per-file permission is all FGAC runs on (nothing else in your Drive is shared).`}
         </div>
         {pickerErrorBox}
         {state.pickFailed && (
           <p className="text-sm text-muted-foreground">
-            No {short} was selected. Open the picker and choose the {short} the
-            agent should reach.
+            {`No ${short} was selected. Open the picker and choose the ${short} the agent should reach.`}
           </p>
         )}
         <button
@@ -158,17 +154,12 @@ export function FileApprovalFlow({
 
       {substituting && (
         <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]" data-testid={`${testPrefix}-flow-substitution`}>
-          You picked <strong>{grantTargets}</strong>, but the agent asked for a
-          different {short} ID (<code className="font-mono text-xs">{fileId}</code>)
-          that Google says you don&apos;t have. Most likely the agent had the wrong
-          ID. Approving grants access to <strong>what you picked</strong> — and
-          nothing for the ID the agent sent; the agent will find the right
-          {" "}{short} in its permissions.
+          {"You picked "}<strong>{grantTargets}</strong>{`, but the agent asked for a different ${short} ID (`}<code className="font-mono text-xs">{fileId}</code>{") that Google says you don't have. Most likely the agent had the wrong ID. Approving grants access to "}<strong>what you picked</strong>{` — and nothing for the ID the agent sent; the agent will find the right ${short} in its permissions.`}
         </div>
       )}
       {!substituting && (
         <div className="rounded-md border border-border bg-secondary/30 px-4 py-3 text-sm text-foreground [overflow-wrap:anywhere]">
-          Granting access to <strong>{grantTargets}</strong>
+          {"Granting access to "}<strong>{grantTargets}</strong>
           {state.title && resourceName === null ? " (verified with Google)" : ""}.
         </div>
       )}

--- a/src/app/dashboard/approve/FileApprovalFlow.tsx
+++ b/src/app/dashboard/approve/FileApprovalFlow.tsx
@@ -1,50 +1,57 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useGooglePicker, PickedSheet } from "../useGooglePicker";
+import { useGooglePicker, PickedFile } from "../useGooglePicker";
 import { TrackedVideoEmbed } from "@/components/TrackedVideoEmbed";
+import { DRIVE_FILE_KINDS, type DriveFileKind } from "@/lib/driveFileKinds";
 
 const SHEETS_DEMO_EMBED = "https://share.descript.com/embed/Fv9pwXugLUa";
 
 type FlowState =
   | { step: "checking" }
   // Grant verified (or verification inconclusive) — straight to confirm.
-  | { step: "confirm"; picked: PickedSheet[] | null; title: string | null }
+  | { step: "confirm"; picked: PickedFile[] | null; title: string | null }
   // No Google grant: the pick comes FIRST. The pick registers the grant and
   // confirms the file's identity; only then does approving mean anything.
   | { step: "need_pick"; pickFailed: boolean }
   // User picked file(s) that don't include the id the agent asked for.
-  | { step: "substitute"; picked: PickedSheet[] };
+  | { step: "substitute"; picked: PickedFile[] };
 
 /**
- * Picker-first approval flow for sheets magic links.
+ * Picker-first approval flow for per-file (sheets/docs) magic links.
  *
  * Sequence: verify the Google-side grant on load. If Google can already
- * reach the sheet, approving is one click (title shown, since we can now
- * resolve it). If not, the user picks the sheet in Google's Picker BEFORE
+ * reach the file, approving is one click (title shown, since we can now
+ * resolve it). If not, the user picks the file in Google's Picker BEFORE
  * any FGAC rule exists — approving blind on a raw id is how the connector
  * launch cohort ended up with rules for sheets Google couldn't serve. A
  * different-file pick becomes an explicit substitution: the grant follows
  * what the user actually picked, never the unverifiable id.
  */
-export function SheetsApprovalFlow({
+export function FileApprovalFlow({
   token,
-  spreadsheetId,
+  kind,
+  fileId,
   resourceName,
-  action,
+  level,
   approveAction,
 }: {
   token: string;
-  spreadsheetId: string;
+  kind: DriveFileKind;
+  fileId: string;
   resourceName: string | null;
-  action: "sheets_expose" | "sheets_write";
+  /** 'expose' = read grant with an upgrade choice; 'write' = read & write. */
+  level: "expose" | "write";
   approveAction: (formData: FormData) => Promise<void>;
 }) {
   const [state, setState] = useState<FlowState>({ step: "checking" });
+  const d = DRIVE_FILE_KINDS[kind];
+  const short = kind === "sheet" ? "sheet" : d.noun;
+  const verifyPath = kind === "sheet" ? "/api/rules/verify-sheets-access" : "/api/rules/verify-docs-access";
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`/api/rules/verify-sheets-access?sid=${encodeURIComponent(spreadsheetId)}&context=link_open`)
+    fetch(`${verifyPath}?${d.setupIdParam}=${encodeURIComponent(fileId)}&context=link_open`)
       .then(r => r.json())
       .then(data => {
         if (cancelled) return;
@@ -60,21 +67,21 @@ export function SheetsApprovalFlow({
       })
       .catch(() => { if (!cancelled) setState({ step: "confirm", picked: null, title: null }); });
     return () => { cancelled = true; };
-  }, [spreadsheetId]);
+  }, [fileId, verifyPath, d.setupIdParam]);
 
-  const handleSheetsPicked = (picked: PickedSheet[]) => {
+  const handleFilesPicked = (picked: PickedFile[]) => {
     if (picked.length === 0) {
       setState({ step: "need_pick", pickFailed: true });
       return;
     }
-    if (picked.some(s => s.id === spreadsheetId)) {
-      setState({ step: "confirm", picked, title: picked.find(s => s.id === spreadsheetId)?.name ?? null });
+    if (picked.some(s => s.id === fileId)) {
+      setState({ step: "confirm", picked, title: picked.find(s => s.id === fileId)?.name ?? null });
     } else {
       setState({ step: "substitute", picked });
     }
   };
 
-  const { triggerAddSheets, isLoading: pickerLoading, pickerError } = useGooglePicker(handleSheetsPicked);
+  const { triggerAddSheets, isLoading: pickerLoading, pickerError } = useGooglePicker(handleFilesPicked, kind);
 
   // A failed Google flow must be visible with a way forward — the silent
   // do-nothing button sent a real user away (2026-08-19).
@@ -85,52 +92,54 @@ export function SheetsApprovalFlow({
     </div>
   ) : null;
 
-  const sheetLabel = resourceName || spreadsheetId;
-  const levelChoice = action === "sheets_expose";
+  const fileLabel = resourceName || fileId;
+  const levelChoice = level === "expose";
 
   if (state.step === "checking") {
     return (
-      <p className="text-sm text-muted-foreground" data-testid="sheets-flow-checking">
-        Checking whether Google already shares this sheet with FGAC…
+      <p className="text-sm text-muted-foreground" data-testid="file-flow-checking">
+        Checking whether Google already shares this {short} with FGAC…
       </p>
     );
   }
 
   if (state.step === "need_pick") {
     return (
-      <div className="flex flex-col gap-4" data-testid="sheets-flow-pick-first">
+      <div className="flex flex-col gap-4" data-testid="file-flow-pick-first">
         <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
-          Google hasn&apos;t shared <strong>{sheetLabel}</strong> with FGAC yet, so
+          Google hasn&apos;t shared <strong>{fileLabel}</strong> with FGAC yet, so
           there&apos;s nothing to approve until you pick it. Google only shares a
-          sheet when you choose it in Google&apos;s own file picker — that per-file
+          {" "}{short} when you choose it in Google&apos;s own file picker — that per-file
           permission is all FGAC runs on (nothing else in your Drive is shared).
         </div>
         {pickerErrorBox}
         {state.pickFailed && (
           <p className="text-sm text-muted-foreground">
-            No sheet was selected. Open the picker and choose the sheet the
+            No {short} was selected. Open the picker and choose the {short} the
             agent should reach.
           </p>
         )}
         <button
-          onClick={() => triggerAddSheets(spreadsheetId)}
+          onClick={() => triggerAddSheets(fileId)}
           disabled={pickerLoading}
           className="rounded-sm bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-50"
         >
-          {pickerLoading ? "Opening Google Picker…" : "Step 1 — Pick the sheet in Google Picker"}
+          {pickerLoading ? "Opening Google Picker…" : `Step 1 — Pick the ${short} in Google Picker`}
         </button>
         <p className="text-xs text-subtle">
           First time? Google will ask you to allow FGAC&apos;s file picker
           (drive.file) and then bring you straight back here.
         </p>
-        <div className="rounded-lg border border-border bg-card p-2">
-          <div className="px-1.5 pb-1.5 pt-0.5 text-sm font-semibold text-foreground">
-            Watch how it works (2 min)
+        {kind === "sheet" && (
+          <div className="rounded-lg border border-border bg-card p-2">
+            <div className="px-1.5 pb-1.5 pt-0.5 text-sm font-semibold text-foreground">
+              Watch how it works (2 min)
+            </div>
+            <div className="relative aspect-video w-full overflow-hidden rounded-sm bg-surface-inverse">
+              <TrackedVideoEmbed src={SHEETS_DEMO_EMBED} title="FGAC Google Sheets demo" />
+            </div>
           </div>
-          <div className="relative aspect-video w-full overflow-hidden rounded-sm bg-surface-inverse">
-            <TrackedVideoEmbed src={SHEETS_DEMO_EMBED} title="FGAC Google Sheets demo" />
-          </div>
-        </div>
+        )}
       </div>
     );
   }
@@ -139,21 +148,21 @@ export function SheetsApprovalFlow({
   const substituting = state.step === "substitute";
   const grantTargets = state.step === "substitute"
     ? state.picked.map(s => s.name || s.id).join(", ")
-    : (state.title || sheetLabel);
+    : (state.title || fileLabel);
 
   return (
-    <form action={approveAction} className="flex flex-col gap-4" data-testid="sheets-flow-confirm">
+    <form action={approveAction} className="flex flex-col gap-4" data-testid="file-flow-confirm">
       <input type="hidden" name="token" value={token} />
       {picked && <input type="hidden" name="picked" value={JSON.stringify(picked)} />}
 
       {substituting && (
-        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]" data-testid="sheets-flow-substitution">
+        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]" data-testid="file-flow-substitution">
           You picked <strong>{grantTargets}</strong>, but the agent asked for a
-          different sheet ID (<code className="font-mono text-xs">{spreadsheetId}</code>)
+          different {short} ID (<code className="font-mono text-xs">{fileId}</code>)
           that Google says you don&apos;t have. Most likely the agent had the wrong
           ID. Approving grants access to <strong>what you picked</strong> — and
           nothing for the ID the agent sent; the agent will find the right
-          sheet in its permissions.
+          {" "}{short} in its permissions.
         </div>
       )}
       {!substituting && (
@@ -185,7 +194,7 @@ export function SheetsApprovalFlow({
       {picked && !substituting && (
         <button
           type="button"
-          onClick={() => triggerAddSheets(spreadsheetId)}
+          onClick={() => triggerAddSheets(fileId)}
           className="text-xs text-subtle underline hover:text-foreground self-start"
         >
           Pick again
@@ -194,11 +203,11 @@ export function SheetsApprovalFlow({
       {substituting && (
         <button
           type="button"
-          onClick={() => triggerAddSheets(spreadsheetId)}
+          onClick={() => triggerAddSheets(fileId)}
           disabled={pickerLoading}
           className="text-xs text-subtle underline hover:text-foreground self-start disabled:opacity-50"
         >
-          That&apos;s not right — pick a different sheet
+          That&apos;s not right — pick a different {short}
         </button>
       )}
       {pickerErrorBox}

--- a/src/app/dashboard/approve/FileApprovalFlow.tsx
+++ b/src/app/dashboard/approve/FileApprovalFlow.tsx
@@ -47,6 +47,7 @@ export function FileApprovalFlow({
   const [state, setState] = useState<FlowState>({ step: "checking" });
   const d = DRIVE_FILE_KINDS[kind];
   const short = kind === "sheet" ? "sheet" : d.noun;
+  const testPrefix = kind === "sheet" ? "sheets" : "docs";
   const verifyPath = kind === "sheet" ? "/api/rules/verify-sheets-access" : "/api/rules/verify-docs-access";
 
   useEffect(() => {
@@ -97,7 +98,7 @@ export function FileApprovalFlow({
 
   if (state.step === "checking") {
     return (
-      <p className="text-sm text-muted-foreground" data-testid="file-flow-checking">
+      <p className="text-sm text-muted-foreground" data-testid={`${testPrefix}-flow-checking`}>
         Checking whether Google already shares this {short} with FGAC…
       </p>
     );
@@ -105,7 +106,7 @@ export function FileApprovalFlow({
 
   if (state.step === "need_pick") {
     return (
-      <div className="flex flex-col gap-4" data-testid="file-flow-pick-first">
+      <div className="flex flex-col gap-4" data-testid={`${testPrefix}-flow-pick-first`}>
         <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]">
           Google hasn&apos;t shared <strong>{fileLabel}</strong> with FGAC yet, so
           there&apos;s nothing to approve until you pick it. Google only shares a
@@ -151,12 +152,12 @@ export function FileApprovalFlow({
     : (state.title || fileLabel);
 
   return (
-    <form action={approveAction} className="flex flex-col gap-4" data-testid="file-flow-confirm">
+    <form action={approveAction} className="flex flex-col gap-4" data-testid={`${testPrefix}-flow-confirm`}>
       <input type="hidden" name="token" value={token} />
       {picked && <input type="hidden" name="picked" value={JSON.stringify(picked)} />}
 
       {substituting && (
-        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]" data-testid="file-flow-substitution">
+        <div className="rounded-md border border-warning-foreground/30 bg-warning px-4 py-3 text-sm text-warning-foreground [overflow-wrap:anywhere]" data-testid={`${testPrefix}-flow-substitution`}>
           You picked <strong>{grantTargets}</strong>, but the agent asked for a
           different {short} ID (<code className="font-mono text-xs">{fileId}</code>)
           that Google says you don&apos;t have. Most likely the agent had the wrong

--- a/src/app/dashboard/approve/page.tsx
+++ b/src/app/dashboard/approve/page.tsx
@@ -5,7 +5,7 @@ import { verifyApprovalToken, describeApproval, approvalLinkMinutes, peekApprova
 import { captureServerEvent } from "@/lib/posthogServer";
 import { approveMagicLink, approvalLinkStatus } from "../actions";
 import { ApproveSubmitButton } from "./ApproveSubmitButton";
-import { SheetsApprovalFlow } from "./SheetsApprovalFlow";
+import { FileApprovalFlow } from "./FileApprovalFlow";
 import { ApprovedSettling } from "./ApprovedSettling";
 
 /* ─── Magic-link approval page (connector-growth Phase C) ────────────────
@@ -37,18 +37,20 @@ function Card({ children }: { children: React.ReactNode }) {
 export default async function ApprovePage({
   searchParams,
 }: {
-  searchParams: Promise<{ token?: string; result?: string; message?: string; sid?: string; notice?: string }>;
+  searchParams: Promise<{ token?: string; result?: string; message?: string; sid?: string; did?: string; notice?: string }>;
 }) {
   const params = await searchParams;
 
   if (params.result === "ok") {
-    // Sheets approvals settle asynchronously on Google's side — verify the
-    // grant is live before claiming the agent can retry (grant-race fix).
-    if (params.sid) {
+    // Per-file (sheets/docs) approvals settle asynchronously on Google's
+    // side — verify the grant is live before claiming the agent can retry
+    // (grant-race fix).
+    if (params.sid || params.did) {
       return (
         <Card>
           <ApprovedSettling
-            spreadsheetId={params.sid}
+            kind={params.sid ? "sheet" : "doc"}
+            fileId={(params.sid || params.did)!}
             message={params.message || "The permission has been granted."}
           />
         </Card>
@@ -174,9 +176,16 @@ export default async function ApprovePage({
         if (result.needsSheetsGrant.resourceName) q.set("name", result.needsSheetsGrant.resourceName);
         redirect(`/dashboard/sheets-setup?${q.toString()}`);
       }
+      if (result.needsDocsGrant) {
+        const q = new URLSearchParams({ did: result.needsDocsGrant.documentId, from: "approval" });
+        if (result.needsDocsGrant.resourceName) q.set("name", result.needsDocsGrant.resourceName);
+        redirect(`/dashboard/docs-setup?${q.toString()}`);
+      }
       const settle = result.grantedSpreadsheetId
         ? `&sid=${encodeURIComponent(result.grantedSpreadsheetId)}`
-        : "";
+        : result.grantedDocumentId
+          ? `&did=${encodeURIComponent(result.grantedDocumentId)}`
+          : "";
       redirect(`/dashboard/approve?result=ok&message=${encodeURIComponent(result.description)}${settle}`);
     }
     if (result.retryable) {
@@ -191,6 +200,7 @@ export default async function ApprovePage({
   }
 
   const isSheets = (p.action === "sheets_expose" || p.action === "sheets_write") && p.spreadsheetId;
+  const isDocs = (p.action === "docs_expose" || p.action === "docs_write") && p.documentId;
 
   return (
     <Card>
@@ -206,12 +216,13 @@ export default async function ApprovePage({
           {params.notice}
         </div>
       )}
-      {isSheets ? (
-        <SheetsApprovalFlow
+      {isSheets || isDocs ? (
+        <FileApprovalFlow
           token={token}
-          spreadsheetId={p.spreadsheetId!}
+          kind={isSheets ? "sheet" : "doc"}
+          fileId={(isSheets ? p.spreadsheetId : p.documentId)!}
           resourceName={p.resourceName || null}
-          action={p.action as "sheets_expose" | "sheets_write"}
+          level={p.action.endsWith("_write") ? "write" : "expose"}
           approveAction={approve}
         />
       ) : (

--- a/src/app/dashboard/docs-setup/page.tsx
+++ b/src/app/dashboard/docs-setup/page.tsx
@@ -1,0 +1,31 @@
+import { FileGrantRecovery } from "../FileGrantRecovery";
+
+/* ─── Docs setup / grant recovery ────────────────────────────────────────
+   Docs twin of /dashboard/sheets-setup: the landing spot whenever a docs
+   FGAC rule exists (or was just approved via magic link) but Google has no
+   drive.file grant for the document. Walks the user through the ONE action
+   that registers the grant (picking the doc in the Google Picker).
+
+   Reached from: the magic-link approve flow (`from=approval`), the
+   dashboard's "needs Google access" chip, and the MCP stranded-doc error.
+
+   The first-time drive.file consent redirect returns to this pathname with
+   `autoOpenPicker=true&pickerKind=doc&pickerContext=<did>` (and nothing
+   else), so the did is restored from pickerContext on that leg. */
+
+export default async function DocsSetupPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ did?: string; name?: string; from?: string; pickerContext?: string }>;
+}) {
+  const params = await searchParams;
+  const did = params.did || params.pickerContext || null;
+  return (
+    <FileGrantRecovery
+      kind="doc"
+      fileId={did}
+      resourceName={params.name || null}
+      fromApproval={params.from === "approval"}
+    />
+  );
+}

--- a/src/app/dashboard/sheets-setup/page.tsx
+++ b/src/app/dashboard/sheets-setup/page.tsx
@@ -1,4 +1,4 @@
-import { SheetsGrantRecovery } from "./SheetsGrantRecovery";
+import { FileGrantRecovery } from "../FileGrantRecovery";
 
 /* ─── Sheets setup / grant recovery ──────────────────────────────────────
    The landing spot whenever a sheets FGAC rule exists (or was just approved
@@ -11,8 +11,8 @@ import { SheetsGrantRecovery } from "./SheetsGrantRecovery";
    dashboard's "needs Google access" chip, and the MCP stranded-sheet error.
 
    The first-time drive.file consent redirect returns to this pathname with
-   `autoOpenPicker=true&pickerContext=<sid>` (and nothing else), so the sid
-   is restored from pickerContext on that leg. */
+   `autoOpenPicker=true&pickerKind=sheet&pickerContext=<sid>` (and nothing
+   else), so the sid is restored from pickerContext on that leg. */
 
 export default async function SheetsSetupPage({
   searchParams,
@@ -22,8 +22,9 @@ export default async function SheetsSetupPage({
   const params = await searchParams;
   const sid = params.sid || params.pickerContext || null;
   return (
-    <SheetsGrantRecovery
-      spreadsheetId={sid}
+    <FileGrantRecovery
+      kind="sheet"
+      fileId={sid}
       resourceName={params.name || null}
       fromApproval={params.from === "approval"}
     />

--- a/src/app/dashboard/useGooglePicker.ts
+++ b/src/app/dashboard/useGooglePicker.ts
@@ -5,6 +5,7 @@ import { useUser, useReverification } from '@clerk/nextjs';
 import { isReverificationCancelledError } from '@clerk/nextjs/errors';
 import { usePostHog } from 'posthog-js/react';
 import { startGoogleReconnect, type ClerkUserLike } from './googleReconnect';
+import { DRIVE_FILE_KINDS, type DriveFileKind } from '@/lib/driveFileKinds';
 
 declare global {
   interface Window {
@@ -18,8 +19,12 @@ export interface PickedSheet {
   name: string;
 }
 
+/** Kind-neutral alias — a picked file of any DriveFileKind. */
+export type PickedFile = PickedSheet;
+
 /**
- * Google Picker flow for exposing sheets.
+ * Google Picker flow for exposing per-file grants (sheets by default; pass a
+ * `kind` for docs — the view, dialog title, and copy follow the kind).
  *
  * `context` is an opaque string (e.g. a profile id) carried through the whole
  * flow — including the OAuth consent redirect — and handed back to
@@ -28,9 +33,15 @@ export interface PickedSheet {
  * First-time-grant round trip: the consent redirect returns to the SAME page
  * (`location.pathname`), and the auto-open effect re-launches the picker there.
  * On that return leg we retry the token fetch while Clerk propagates the new
- * scope, and never redirect to consent a second time (no loops).
+ * scope, and never redirect to consent a second time (no loops). The kind
+ * rides the round trip in `pickerKind`, so the auto-reopened picker shows the
+ * same view the user started from.
  */
-export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?: string) => void) {
+export function useGooglePicker(
+  onSheetsPicked: (sheets: PickedFile[], context?: string) => void,
+  kind: DriveFileKind = 'sheet',
+) {
+  const kindDesc = DRIVE_FILE_KINDS[kind];
   const { user } = useUser();
   const posthog = usePostHog();
   const [isLoading, setIsLoading] = useState(false);
@@ -117,7 +128,7 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?
       if (!tokenData.hasDriveFileScope) {
         if (fromOAuthReturn) {
           failFlow('oauth_return_scope_missing', 'drive.file still missing after consent',
-            'Google did not grant Sheets access on that pass — this usually means the consent screen was closed early, or a second authorization round is needed. Click the pick button again to retry; if it keeps happening, reconnect Google from Dashboard → Accounts.');
+            `Google did not grant ${kind === 'sheet' ? 'Sheets' : 'Docs'} access on that pass — this usually means the consent screen was closed early, or a second authorization round is needed. Click the pick button again to retry; if it keeps happening, reconnect Google from Dashboard → Accounts.`);
           return;
         }
 
@@ -126,6 +137,7 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?
         // must survive the consent round-trip or the flow dead-ends.
         const params = new URLSearchParams(window.location.search);
         params.set('autoOpenPicker', 'true');
+        params.set('pickerKind', kind);
         if (context) params.set('pickerContext', context);
         const autoRedirectUrl = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
 
@@ -146,23 +158,24 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?
         return;
       }
 
+      const fallbackNoun = kindDesc.noun.charAt(0).toUpperCase() + kindDesc.noun.slice(1);
       const pickerCallback = (data: any) => {
         if (data.action === window.google.picker.Action.PICKED) {
           const docs = data.docs.map((doc: any) => ({
             id: doc.id,
-            name: doc.name || `Spreadsheet (${doc.id.slice(0, 6)})`
+            name: doc.name || `${fallbackNoun} (${doc.id.slice(0, 6)})`
           }));
           onSheetsPicked(docs, context);
         }
         setIsLoading(false);
       };
 
-      const view = new window.google.picker.View(window.google.picker.ViewId.SPREADSHEETS);
+      const view = new window.google.picker.View(window.google.picker.ViewId[kindDesc.pickerViewId]);
       const builder = new window.google.picker.PickerBuilder()
         .addView(view)
         .setOAuthToken(tokenData.accessToken)
         .setCallback(pickerCallback)
-        .setTitle('Select Google Sheets to Expose in FGAC')
+        .setTitle(kindDesc.pickerTitle)
         .enableFeature(window.google.picker.Feature.MULTISELECT_ENABLED);
 
       // Without the Cloud project number, a drive.file pick is cosmetic:
@@ -181,7 +194,7 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?
       failFlow('open_picker', err,
         'Something went wrong opening the Google Picker. Retry the pick button; if it keeps failing, reconnect Google from Dashboard → Accounts and then return to this link.');
     }
-  }, [user, onSheetsPicked, failFlow]);
+  }, [user, onSheetsPicked, failFlow, kind, kindDesc]);
 
   // Automatically launch Google Picker if returning from OAuth reauthorization
   // redirect. The component consuming this hook must live on the page the
@@ -191,18 +204,24 @@ export function useGooglePicker(onSheetsPicked: (sheets: PickedSheet[], context?
     if (typeof window === 'undefined' || !user || !gapiLoaded) return;
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get('autoOpenPicker') === 'true') {
+      // Kind-scoped: a page can host pickers for several kinds; only the
+      // instance the consent round-trip started from re-opens. Absent param
+      // = pre-docs link → sheet (the only kind that existed).
+      const returnKind = (urlParams.get('pickerKind') ?? 'sheet') as DriveFileKind;
+      if (returnKind !== kind) return;
       const context = urlParams.get('pickerContext') ?? undefined;
       // Consume only our params; anything else (e.g. the approve page's
       // token) must survive the cleanup.
       urlParams.delete('autoOpenPicker');
       urlParams.delete('pickerContext');
+      urlParams.delete('pickerKind');
       const rest = urlParams.toString();
       const newUrl = `${window.location.pathname}${rest ? `?${rest}` : ''}`;
       window.history.replaceState({}, document.title, newUrl);
       // Auto-launch picker; fromOAuthReturn tolerates scope-propagation lag
       openPickerFlow(context, true);
     }
-  }, [user, gapiLoaded, openPickerFlow]);
+  }, [user, gapiLoaded, openPickerFlow, kind]);
 
   const enhancedOpenPicker = useReverification(openPickerFlow);
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -68,6 +68,9 @@
   --sheets: #059669;
   --sheets-bg: #ECFDF5;
   --sheets-border: #A7F3D0;
+  --docs: #4285F4;
+  --docs-bg: #F0F5FF;
+  --docs-border: #C6DAFC;
 }
 
 .dark {
@@ -116,6 +119,9 @@
   --sheets: #34D399;
   --sheets-bg: #0B1F17;
   --sheets-border: #14432F;
+  --docs: #669DF6;
+  --docs-bg: #0D1B33;
+  --docs-border: #1E3A6F;
 }
 
 @theme inline {
@@ -162,6 +168,9 @@
   --color-sheets: var(--sheets);
   --color-sheets-bg: var(--sheets-bg);
   --color-sheets-border: var(--sheets-border);
+  --color-docs: var(--docs);
+  --color-docs-bg: var(--docs-bg);
+  --color-docs-border: var(--docs-border);
 
   /* Logo palette. Fixed values — these belong to the mark, not the UI, and
      are not used for interface surfaces. */

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -13,12 +13,13 @@ export function Card({
 }: {
   children: ReactNode;
   className?: string;
-  tone?: 'default' | 'gmail' | 'sheets' | 'primary';
+  tone?: 'default' | 'gmail' | 'sheets' | 'docs' | 'primary';
 }) {
   const tones = {
     default: 'bg-card border-border',
     gmail: 'bg-gmail-bg border-gmail-border',
     sheets: 'bg-sheets-bg border-sheets-border',
+    docs: 'bg-docs-bg border-docs-border',
     primary: 'bg-primary-muted border-border',
   };
 

--- a/src/db/defaultProfile.ts
+++ b/src/db/defaultProfile.ts
@@ -7,7 +7,8 @@
  * approved) so a first tool call succeeds with no dashboard visit. The posture
  * is read-only by construction:
  *   - no send_whitelist rule exists → sending is denied by default
- *   - no sheets rules exist → every spreadsheet is denied by default
+ *   - no sheets/docs rules exist → every spreadsheet and document is denied
+ *     by default
  *   - the sensitive-mail shield is OFF by default (decision log 2026-08-06,
  *     connector-growth_v1.md) — the dashboard offers one-click enable
  *

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -83,10 +83,10 @@ export const accessRules = pgTable('access_rules', {
   userId: uuid('user_id').references(() => users.id, { onDelete: 'cascade' }).notNull(),
   targetEmail: text('target_email'), // NULL = applies to all emails, or specific email address
   ruleName: text('rule_name').notNull(), // e.g., "Block Project X" or "Q3 Financials Read Only"
-  service: text('service').notNull(), // 'gmail', 'sheets'
-  actionType: text('action_type').notNull(), // Gmail: 'read_blacklist', 'send_whitelist', etc. | Sheets: 'sheet_read', 'sheet_read_write', 'sheet_block'
+  service: text('service').notNull(), // 'gmail', 'sheets', 'docs'
+  actionType: text('action_type').notNull(), // Gmail: 'read_blacklist', 'send_whitelist', etc. | Sheets: 'sheet_read', 'sheet_read_write', 'sheet_block' | Docs: 'doc_read', 'doc_read_write', 'doc_block'
   regexPattern: text('regex_pattern'), // Optional: Gmail regex pattern or label ID
-  targetResourceId: text('target_resource_id'), // e.g. spreadsheetId for Google Sheets
+  targetResourceId: text('target_resource_id'), // e.g. spreadsheetId (sheets) or documentId (docs)
   resourceName: text('resource_name'), // e.g. human-readable document title "Q3 Financials"
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),

--- a/src/lib/approvalLinks.ts
+++ b/src/lib/approvalLinks.ts
@@ -23,18 +23,28 @@
 import * as jose from 'jose';
 
 export const APPROVAL_LINK_TTL_SECONDS = 15 * 60;
+// Per-file (sheets/docs) grants get the longer TTL: approving one can include
+// a Google Picker pick plus a first-time drive.file consent round-trip, which
+// real users don't finish in 15 minutes.
 export const SHEETS_APPROVAL_LINK_TTL_SECONDS = 30 * 60;
+
+/** Actions whose approval includes a Picker leg (longer TTL, picker-first UX). */
+function isFileGrantAction(action: ApprovalAction['action']): boolean {
+  return action.startsWith('sheets') || action.startsWith('docs');
+}
 
 /** Link lifetime in minutes for user-facing copy — keep messages honest. */
 export function approvalLinkMinutes(action: ApprovalAction['action']): number {
-  return action.startsWith('sheets') ? SHEETS_APPROVAL_LINK_TTL_SECONDS / 60 : APPROVAL_LINK_TTL_SECONDS / 60;
+  return isFileGrantAction(action) ? SHEETS_APPROVAL_LINK_TTL_SECONDS / 60 : APPROVAL_LINK_TTL_SECONDS / 60;
 }
 
 export type ApprovalAction =
   | { action: 'send_whitelist'; recipient: string }
   | { action: 'send_all' }
   | { action: 'sheets_expose'; spreadsheetId: string; resourceName?: string }
-  | { action: 'sheets_write'; spreadsheetId: string; resourceName?: string };
+  | { action: 'sheets_write'; spreadsheetId: string; resourceName?: string }
+  | { action: 'docs_expose'; documentId: string; resourceName?: string }
+  | { action: 'docs_write'; documentId: string; resourceName?: string };
 
 export interface ApprovalPayload {
   jti: string;
@@ -43,6 +53,7 @@ export interface ApprovalPayload {
   action: ApprovalAction['action'];
   recipient?: string;
   spreadsheetId?: string;
+  documentId?: string;
   resourceName?: string;
 }
 
@@ -64,7 +75,7 @@ export async function mintApprovalToken(
   jti: string = crypto.randomUUID(),
 ): Promise<string> {
   const ttlSeconds = ttlSecondsOverride
-    ?? (action.action.startsWith('sheets') ? SHEETS_APPROVAL_LINK_TTL_SECONDS : APPROVAL_LINK_TTL_SECONDS);
+    ?? (approvalLinkMinutes(action.action) * 60);
   const key = await signingKey();
   return new jose.SignJWT({ userId, proxyKeyId, ...action })
     .setProtectedHeader({ alg: 'HS256' })
@@ -112,12 +123,12 @@ export async function verifyApprovalToken(token: string): Promise<VerifyResult> 
   try {
     const key = await signingKey();
     const { payload } = await jose.jwtVerify(token, key, { algorithms: ['HS256'] });
-    const { jti, userId, proxyKeyId, action, recipient, spreadsheetId, resourceName } =
+    const { jti, userId, proxyKeyId, action, recipient, spreadsheetId, documentId, resourceName } =
       payload as Record<string, unknown>;
     if (
       typeof jti !== 'string' || typeof userId !== 'string' ||
       typeof proxyKeyId !== 'string' || typeof action !== 'string' ||
-      !['send_whitelist', 'send_all', 'sheets_expose', 'sheets_write'].includes(action)
+      !['send_whitelist', 'send_all', 'sheets_expose', 'sheets_write', 'docs_expose', 'docs_write'].includes(action)
     ) {
       return { ok: false, reason: 'invalid' };
     }
@@ -128,6 +139,7 @@ export async function verifyApprovalToken(token: string): Promise<VerifyResult> 
         action: action as ApprovalPayload['action'],
         recipient: typeof recipient === 'string' ? recipient : undefined,
         spreadsheetId: typeof spreadsheetId === 'string' ? spreadsheetId : undefined,
+        documentId: typeof documentId === 'string' ? documentId : undefined,
         resourceName: typeof resourceName === 'string' ? resourceName : undefined,
       },
     };
@@ -167,5 +179,9 @@ export function describeApproval(p: ApprovalPayload): string {
       return `Give this agent read-only access to spreadsheet ${p.resourceName || p.spreadsheetId}`;
     case 'sheets_write':
       return `Give this agent read & write access to spreadsheet ${p.resourceName || p.spreadsheetId}`;
+    case 'docs_expose':
+      return `Give this agent read-only access to document ${p.resourceName || p.documentId}`;
+    case 'docs_write':
+      return `Give this agent read & write access to document ${p.resourceName || p.documentId}`;
   }
 }

--- a/src/lib/driveFileGrantCheck.ts
+++ b/src/lib/driveFileGrantCheck.ts
@@ -1,0 +1,76 @@
+import { clerkClient } from '@clerk/nextjs/server';
+import { DRIVE_FILE_KINDS, type DriveFileKind } from '@/lib/driveFileKinds';
+
+/**
+ * Per-file access has two halves: the FGAC rule (our database) and the
+ * Google-side grant. The app never requests a Sheets/Docs OAuth scope — API
+ * access rides on per-file `drive.file` grants, which Google registers ONLY
+ * when the user picks the file in the Google Picker with our appId. An FGAC
+ * rule whose file was never picked passes policy but 403/404s at Google,
+ * which is exactly the trap the 2026-08 connector-launch cohort fell into
+ * (approve → retry → generic error → churn). This module is the single
+ * source of truth for "does Google actually let us reach this file right
+ * now?" — for every drive-file kind (sheets, docs, slides later).
+ */
+export type FileGrantState =
+  | { state: 'ok'; title: string | null }
+  // 403/404 from Google: no drive.file grant for this file (or the id is
+  // wrong — indistinguishable from outside, and the Picker fixes both).
+  | { state: 'missing' }
+  // Network error / 5xx / 429: verification could not run. Callers must
+  // degrade to "no warning", never alarm the user on Google's bad day.
+  | { state: 'unknown'; status?: number };
+
+/** Back-compat alias (pre-docs name). */
+export type SheetsGrantState = FileGrantState;
+
+export async function verifyFileGrant(
+  kind: DriveFileKind,
+  token: string,
+  fileId: string,
+): Promise<FileGrantState> {
+  let res: Response;
+  try {
+    res = await fetch(DRIVE_FILE_KINDS[kind].verifyUrl(fileId), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    return { state: 'unknown' };
+  }
+
+  if (res.ok) {
+    const data = await res.json().catch(() => null) as
+      | { properties?: { title?: string }; title?: string }
+      | null;
+    // Sheets nests the title under properties; Docs/Slides return it top-level.
+    return { state: 'ok', title: data?.properties?.title ?? data?.title ?? null };
+  }
+  if (res.status === 403 || res.status === 404) return { state: 'missing' };
+  return { state: 'unknown', status: res.status };
+}
+
+export async function verifySheetsGrant(token: string, spreadsheetId: string): Promise<FileGrantState> {
+  return verifyFileGrant('sheet', token, spreadsheetId);
+}
+
+export async function verifyDocsGrant(token: string, documentId: string): Promise<FileGrantState> {
+  return verifyFileGrant('doc', token, documentId);
+}
+
+/**
+ * The signed-in owner's Google access token (same token the MCP path uses for
+ * the owner's own mailbox). Null when Google is not connected — for grant
+ * verification purposes that reads as `missing`, since the Picker flow is
+ * also the fix for a not-yet-connected account (it triggers consent first).
+ */
+export async function getOwnerGoogleToken(clerkUserId: string): Promise<string | null> {
+  try {
+    const client = await clerkClient();
+    // Un-prefixed provider id — the `oauth_` form is deprecated (see
+    // googleAccess.ts).
+    const tokens = await client.users.getUserOauthAccessToken(clerkUserId, 'google');
+    return tokens.data?.[0]?.token || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/driveFileGrantCheck.ts
+++ b/src/lib/driveFileGrantCheck.ts
@@ -70,7 +70,16 @@ export async function getOwnerGoogleToken(clerkUserId: string): Promise<string |
     // googleAccess.ts).
     const tokens = await client.users.getUserOauthAccessToken(clerkUserId, 'google');
     return tokens.data?.[0]?.token || null;
-  } catch {
+  } catch (err) {
+    // Same observability as the MCP path: a Clerk "cannot refresh" here means
+    // grant verification will read as `missing` for a user whose real problem
+    // is a dead token, not a missing pick. Make that measurable.
+    const message = err instanceof Error ? err.message : String(err);
+    const { captureServerEvent } = await import('@/lib/posthogServer');
+    captureServerEvent(clerkUserId, 'google_token_fetch_failed', {
+      reason: /refresh/i.test(message) ? 'refresh_failed' : 'clerk_error',
+      via: 'grant_check',
+    });
     return null;
   }
 }

--- a/src/lib/driveFileKinds.ts
+++ b/src/lib/driveFileKinds.ts
@@ -1,0 +1,95 @@
+/**
+ * Drive-file kind descriptor — the one place that knows what makes a
+ * spreadsheet a spreadsheet and a document a document.
+ *
+ * Everything FGAC does per-file (per-file rules, Google Picker exposure,
+ * drive.file grant verification, grant-recovery pages, approval links)
+ * is file-type-agnostic EXCEPT for the values in this table. Adding a new
+ * Google file type (Slides is expected next) means adding a descriptor
+ * entry plus its MCP tool definitions/registrations and QA docs — shared
+ * code must key off this descriptor, never off `if (kind === 'doc')`
+ * branches.
+ *
+ * Pure module (no db/env imports) so policy unit tests can import it.
+ */
+
+export type DriveFileKind = 'sheet' | 'doc' | 'slide'; // 'slide' stubbed until Slides ships
+
+export interface DriveFileKindDescriptor {
+  /** access_rules.service value for this kind's rules. */
+  service: 'sheets' | 'docs' | 'slides';
+  /** Rule actionType values: [read, readWrite, block]. */
+  actionTypes: { read: string; readWrite: string; block: string };
+  /** Approval-link action names: exposing (read) and write-upgrading. */
+  approvalActions: { expose: string; write: string };
+  /** google.picker.ViewId key for exposing this kind. */
+  pickerViewId: 'SPREADSHEETS' | 'DOCUMENTS' | 'PRESENTATIONS';
+  /** API host+path prefix for this kind's endpoint family. */
+  apiBase: string;
+  /** Cheap authenticated probe that verifies a drive.file grant exists. */
+  verifyUrl: (id: string) => string;
+  /** Dashboard grant-recovery page (Picker walkthrough) for this kind. */
+  setupPath: string;
+  /** Query param carrying the file id on the setup page (sheets shipped as `sid`). */
+  setupIdParam: string;
+  /** Human noun for copy: "spreadsheet" / "document" / "presentation". */
+  noun: string;
+  /** Title shown on the Google Picker dialog when exposing this kind. */
+  pickerTitle: string;
+}
+
+export const DRIVE_FILE_KINDS: Record<DriveFileKind, DriveFileKindDescriptor> = {
+  sheet: {
+    service: 'sheets',
+    actionTypes: { read: 'sheet_read', readWrite: 'sheet_read_write', block: 'sheet_block' },
+    approvalActions: { expose: 'sheets_expose', write: 'sheets_write' },
+    pickerViewId: 'SPREADSHEETS',
+    apiBase: 'https://sheets.googleapis.com/v4/spreadsheets',
+    verifyUrl: (id: string) =>
+      `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(id)}?fields=properties.title`,
+    setupPath: '/dashboard/sheets-setup',
+    setupIdParam: 'sid',
+    noun: 'spreadsheet',
+    pickerTitle: 'Select Google Sheets to Expose in FGAC',
+  },
+  doc: {
+    service: 'docs',
+    actionTypes: { read: 'doc_read', readWrite: 'doc_read_write', block: 'doc_block' },
+    approvalActions: { expose: 'docs_expose', write: 'docs_write' },
+    pickerViewId: 'DOCUMENTS',
+    apiBase: 'https://docs.googleapis.com/v1/documents',
+    verifyUrl: (id: string) =>
+      `https://docs.googleapis.com/v1/documents/${encodeURIComponent(id)}?fields=title`,
+    setupPath: '/dashboard/docs-setup',
+    setupIdParam: 'did',
+    noun: 'document',
+    pickerTitle: 'Select Google Docs to Expose in FGAC',
+  },
+  // Stub: not reachable anywhere yet (no tools, no rules, no picker entry).
+  // Present so the type system and shared plumbing are three-kind-shaped
+  // from day one; wiring it up is the Slides feature, not this table.
+  slide: {
+    service: 'slides',
+    actionTypes: { read: 'slide_read', readWrite: 'slide_read_write', block: 'slide_block' },
+    approvalActions: { expose: 'slides_expose', write: 'slides_write' },
+    pickerViewId: 'PRESENTATIONS',
+    apiBase: 'https://slides.googleapis.com/v1/presentations',
+    verifyUrl: (id: string) =>
+      `https://slides.googleapis.com/v1/presentations/${encodeURIComponent(id)}?fields=title`,
+    setupPath: '/dashboard/slides-setup',
+    setupIdParam: 'pid',
+    noun: 'presentation',
+    pickerTitle: 'Select Google Slides to Expose in FGAC',
+  },
+};
+
+/** Kinds a user can actually expose today (excludes stubs). */
+export const ACTIVE_DRIVE_FILE_KINDS: DriveFileKind[] = ['sheet', 'doc'];
+
+/** Look up the kind that owns an access_rules.service value. */
+export function kindForService(service: string): DriveFileKind | null {
+  for (const kind of ACTIVE_DRIVE_FILE_KINDS) {
+    if (DRIVE_FILE_KINDS[kind].service === service) return kind;
+  }
+  return null;
+}

--- a/src/lib/sheetsGrantCheck.ts
+++ b/src/lib/sheetsGrantCheck.ts
@@ -1,60 +1,10 @@
-import { clerkClient } from '@clerk/nextjs/server';
-
 /**
- * Sheets access has two halves: the FGAC rule (our database) and the
- * Google-side grant. The app never requests a Sheets OAuth scope — API access
- * rides on per-file `drive.file` grants, which Google registers ONLY when the
- * user picks the file in the Google Picker with our appId. An FGAC rule whose
- * sheet was never picked passes policy but 403/404s at Google, which is
- * exactly the trap the 2026-08 connector-launch cohort fell into (approve →
- * retry → generic error → churn). This module is the single source of truth
- * for "does Google actually let us reach this spreadsheet right now?".
+ * Back-compat shim: the sheets-specific grant check generalized into
+ * driveFileGrantCheck when Google Docs support landed. Import from
+ * '@/lib/driveFileGrantCheck' in new code.
  */
-export type SheetsGrantState =
-  | { state: 'ok'; title: string | null }
-  // 403/404 from Google: no drive.file grant for this file (or the id is
-  // wrong — indistinguishable from outside, and the Picker fixes both).
-  | { state: 'missing' }
-  // Network error / 5xx / 429: verification could not run. Callers must
-  // degrade to "no warning", never alarm the user on Google's bad day.
-  | { state: 'unknown'; status?: number };
-
-export async function verifySheetsGrant(
-  token: string,
-  spreadsheetId: string,
-): Promise<SheetsGrantState> {
-  let res: Response;
-  try {
-    res = await fetch(
-      `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(spreadsheetId)}?fields=properties.title`,
-      { headers: { Authorization: `Bearer ${token}` } },
-    );
-  } catch {
-    return { state: 'unknown' };
-  }
-
-  if (res.ok) {
-    const data = await res.json().catch(() => null) as { properties?: { title?: string } } | null;
-    return { state: 'ok', title: data?.properties?.title ?? null };
-  }
-  if (res.status === 403 || res.status === 404) return { state: 'missing' };
-  return { state: 'unknown', status: res.status };
-}
-
-/**
- * The signed-in owner's Google access token (same token the MCP path uses for
- * the owner's own mailbox). Null when Google is not connected — for grant
- * verification purposes that reads as `missing`, since the Picker flow is
- * also the fix for a not-yet-connected account (it triggers consent first).
- */
-export async function getOwnerGoogleToken(clerkUserId: string): Promise<string | null> {
-  try {
-    const client = await clerkClient();
-    // Un-prefixed provider id — the `oauth_` form is deprecated (see
-    // googleAccess.ts).
-    const tokens = await client.users.getUserOauthAccessToken(clerkUserId, 'google');
-    return tokens.data?.[0]?.token || null;
-  } catch {
-    return null;
-  }
-}
+export {
+  verifySheetsGrant,
+  getOwnerGoogleToken,
+  type SheetsGrantState,
+} from '@/lib/driveFileGrantCheck';


### PR DESCRIPTION
## Google Docs support — per-document access control on the sheets pattern

Implements plan `docs/implementation_plans/google-docs-support-plan-b36c1c_v5.md` (Phases 0–5).

### What's new
- **Docs MCP tools**: `docs_read_document` (raw Docs API resource; optional `fields` mask for large docs), `docs_append_text` (non-destructive), `docs_replace_text` — all behind per-document deny-by-default rules (`doc_read` / `doc_read_write` / `doc_block`).
- **Raw API**: the `documents` family graduates from unenforced passthrough to per-doc enforcement; `POST v1/documents` auto-grants agent-created docs (mirrors `sheets_create`). Proxy route gets the docs twin; the Drive per-file guard honors docs rules.
- **Approval funnel**: `docs_expose`/`docs_write` magic links (30-min TTL), picker-first approval, `/dashboard/docs-setup` grant recovery, `request_access` docs types.
- **Dashboard**: Google Docs Rules card per profile, accounts-page docs manager, rule editor support.
- **D7 monitoring (plan v5)**: every MCP tool result stamps `response_chars`/`response_kb` — monitoring only, no size caps anywhere new.

### Generalization, sheets-safe
Per-file machinery is kind-parameterized via `src/lib/driveFileKinds.ts` (Slides stubbed): permission check, grace retries, grant-error recovery, picker hook, approval flow, recovery page, rule routes. Sheets strings, endpoints, testids, denial codes, and analytics props are unchanged — capability 17's assertions double as the regression suite.

### Zero DDL
`access_rules.service`/`action_type` are text columns; docs adds VALUES only. `drizzle-kit generate`: "No schema changes, nothing to migrate."

### Verification
- Unit: policy classification, approval links, `mcp-tool-lint` (17 tools) — green.
- Spike (`docs/spike_results/google-docs-drive-file-spike.md`): Docs API works on `drive.file` tokens; per-file isolation confirmed; **Docs API had to be enabled on the dev Cloud project — production project needs the same check at launch.**
- Local QA: targeted run of capabilities 09/10/14/15/16/17 (sheets regression) + new 19 (docs) — results in `docs/QA_Acceptance_Test/qa-results.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
