### PR TITLE
docs(site): Google Docs across public surfaces + serverInfo 1.3.0

### DIFF
--- a/scripts/branch-db.ts
+++ b/scripts/branch-db.ts
@@ -16,6 +16,17 @@ function runNeonCmd(cmd: string) {
   }
 }
 
+/** Like runNeonCmd, but returns the failure instead of exiting — for callers
+ * that can recover (e.g. branch-limit → cleanup → retry). */
+function tryNeonCmd(cmd: string): { result?: any; error?: string } {
+  try {
+    return { result: JSON.parse(execSync(`npx --yes neonctl ${cmd} -o json`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })) };
+  } catch (error: any) {
+    const stderr = error?.stderr?.toString?.() ?? '';
+    return { error: (stderr || error?.message || 'unknown neonctl error').trim() };
+  }
+}
+
 async function getGitBranch() {
   if (process.env.VERCEL_GIT_COMMIT_REF) {
     return process.env.VERCEL_GIT_COMMIT_REF;
@@ -99,9 +110,28 @@ async function main() {
 
   if (!branch) {
     console.log(`🌿 Branch '${branchName}' not found. Creating from 'main'...`);
-    const created = runNeonCmd(`branches create --project-id ${projectId} --name ${branchName} --compute`);
-    if (created && created.connection_uris && created.connection_uris.length > 0) {
-      const uri = created.connection_uris[0].connection_uri;
+    // Neon caps the project at 10 branches; stale branches of merged work
+    // accumulate until creation fails. Self-heal: on a limit error, prune
+    // stale branches (scripts/cleanup-neon-branches.ts — safe rules: never
+    // the current branch, never an open PR's preview) and retry once.
+    let created = tryNeonCmd(`branches create --project-id ${projectId} --name ${branchName} --compute`);
+    if (created.error) {
+      if (!/limit/i.test(created.error)) {
+        console.error(`❌ Neon CLI error: ${created.error}`);
+        process.exit(1);
+      }
+      console.log('⚠️ Neon branch limit reached — running stale-branch cleanup and retrying...');
+      execSync('npx tsx scripts/cleanup-neon-branches.ts', { stdio: 'inherit' });
+      created = tryNeonCmd(`branches create --project-id ${projectId} --name ${branchName} --compute`);
+      if (created.error) {
+        console.error(`❌ Branch creation still failing after cleanup: ${created.error}`);
+        console.error('   Every remaining Neon branch maps to active work — free one manually.');
+        process.exit(1);
+      }
+    }
+    const createdBranch = created.result;
+    if (createdBranch && createdBranch.connection_uris && createdBranch.connection_uris.length > 0) {
+      const uri = createdBranch.connection_uris[0].connection_uri;
       console.log(`✅ Created branch '${branchName}'!`);
       await updateEnvLocal(uri);
       console.log(`🎉 Ready! Local environment connected to branch: ${branchName}`);

--- a/scripts/cleanup-neon-branches.ts
+++ b/scripts/cleanup-neon-branches.ts
@@ -5,6 +5,29 @@ import { execSync } from 'child_process'
 // Load environment variables from .env.local
 config({ path: '.env.local' })
 
+/**
+ * Prune stale Neon database branches — safe enough to run AUTOMATICALLY
+ * (scripts/branch-db.ts invokes it when branch creation hits Neon's
+ * 10-branch limit, and it can be run by hand any time).
+ *
+ * A Neon branch is STALE when the git branch it serves is finished:
+ *   - `preview/<git-branch>` (Vercel preview integration): the git branch no
+ *     longer exists on origin, or is merged into origin/main. A preview
+ *     branch backing an OPEN PR is never touched — deleting it breaks that
+ *     PR's live preview deployment (the old version of this script did
+ *     exactly that: it deleted every preview/* branch unconditionally).
+ *   - `<sanitized-git-branch>` (local dev via db:branch): same rule, with
+ *     one extra protection — the CURRENT local git branch's Neon branch is
+ *     never deleted even if merged, so an active dev server doesn't lose its
+ *     database mid-session.
+ *   - Anything that maps to no known git branch, current or historical,
+ *     is left alone (unknown ≠ stale).
+ *
+ * `--dry-run` prints what would be deleted without deleting.
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
 function runNeonCmd(cmd: string) {
   try {
     const output = execSync(`npx --yes neonctl ${cmd} -o json`, { encoding: 'utf-8' });
@@ -16,8 +39,10 @@ function runNeonCmd(cmd: string) {
   }
 }
 
+const sanitize = (name: string) => name.replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase();
+
 async function main() {
-  console.log('🧹 Scanning for stale Neon database branches...');
+  console.log(`🧹 Scanning for stale Neon database branches...${DRY_RUN ? ' (dry run)' : ''}`);
 
   let projectId = process.env.NEON_PROJECT_ID;
   if (!projectId) {
@@ -31,52 +56,84 @@ async function main() {
 
   console.log(`Using project ID: ${projectId}`);
 
-  // Get all branches
   const branches = runNeonCmd(`branches list --project-id ${projectId}`);
-  
-  // Also get git branches from remote to know what is actually stale
-  let remoteGitBranches: string[] = [];
+
+  // Remote git branches (raw names) and their merge state vs origin/main.
+  let remoteBranches: string[];
   try {
-    const gitOutput = execSync('git ls-remote --heads origin', { encoding: 'utf-8' });
-    remoteGitBranches = gitOutput.split('\n')
-      .filter(line => line.trim().length > 0)
-      .map(line => {
-        const parts = line.split('refs/heads/');
-        if (parts.length > 1) {
-           // match the sanitization logic used in branch-db.ts
-           return parts[1].trim().replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase();
-        }
-        return '';
-      }).filter(b => b !== '');
+    execSync('git fetch origin --quiet', { encoding: 'utf-8' });
+    remoteBranches = execSync('git ls-remote --heads origin', { encoding: 'utf-8' })
+      .split('\n')
+      .map(line => line.split('refs/heads/')[1]?.trim())
+      .filter((b): b is string => !!b);
   } catch (error) {
-    console.error('⚠️ Could not fetch remote git branches. Proceeding with caution.');
+    // No remote view = no way to prove staleness. Refuse to guess.
+    console.error('❌ Could not fetch remote git branches — aborting without deleting anything.');
+    process.exit(1);
   }
+
+  const mergedIntoMain = (gitBranch: string): boolean => {
+    try {
+      execSync(`git merge-base --is-ancestor "origin/${gitBranch}" origin/main`, { encoding: 'utf-8' });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const sanitizedToRaw = new Map<string, string>();
+  for (const b of remoteBranches) sanitizedToRaw.set(sanitize(b), b);
+
+  let currentBranchSanitized = '';
+  try {
+    currentBranchSanitized = sanitize(execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim());
+  } catch { /* detached HEAD etc. — no extra protection possible */ }
 
   let deletedCount = 0;
   for (const branch of branches) {
     // Never delete the primary/main branch
-    if (branch.primary || branch.name === 'main' || branch.name.includes('main')) {
+    if (branch.primary || branch.default || branch.name === 'main' || branch.name.includes('main')) {
       continue;
     }
 
-    // Check if branch name corresponds to an active git branch
-    const isActive = remoteGitBranches.includes(branch.name);
-    
-    // Check age (e.g. older than 7 days if we wanted, but for now just if it has no active PR/Git branch)
-    // Note: If you don't have remoteGitBranches, we might not want to delete.
-    if (remoteGitBranches.length > 0 && !isActive) {
-      console.log(`🗑️  Deleting stale Neon branch: ${branch.name} (${branch.id})`);
-      runNeonCmd(`branches delete ${branch.id} --project-id ${projectId}`);
-      deletedCount++;
-    } else if (remoteGitBranches.length === 0) {
-        console.log(`⏭️  Skipping ${branch.name} because remote git branches could not be fetched.`);
+    let gitRef: string | undefined;   // the git branch this Neon branch serves
+    let protectedReason: string | null = null;
+
+    if (branch.name.startsWith('preview/')) {
+      gitRef = branch.name.slice('preview/'.length);
+      if (gitRef && remoteBranches.includes(gitRef) && !mergedIntoMain(gitRef)) {
+        protectedReason = 'backs an open (unmerged) preview';
+      }
+    } else {
+      gitRef = sanitizedToRaw.get(branch.name);
+      if (branch.name === currentBranchSanitized) {
+        protectedReason = 'current local git branch';
+      } else if (gitRef && !mergedIntoMain(gitRef)) {
+        protectedReason = 'git branch still active (unmerged)';
+      } else if (!gitRef) {
+        // Doesn't map to any remote git branch. For preview/* that means the
+        // branch is gone (stale); for plain names it could be anything a
+        // human made by hand — leave those alone.
+        protectedReason = 'no matching git branch — not created by this tooling?';
+      }
     }
+
+    if (protectedReason) {
+      console.log(`⏭️  Keeping ${branch.name} (${protectedReason})`);
+      continue;
+    }
+
+    console.log(`🗑️  ${DRY_RUN ? 'Would delete' : 'Deleting'} stale Neon branch: ${branch.name} (${branch.id})${gitRef ? ` — git branch '${gitRef}' is ${remoteBranches.includes(gitRef) ? 'merged' : 'gone'}` : ''}`);
+    if (!DRY_RUN) {
+      runNeonCmd(`branches delete ${branch.id} --project-id ${projectId}`);
+    }
+    deletedCount++;
   }
 
   if (deletedCount === 0) {
     console.log('✨ No stale branches found to clean up.');
   } else {
-    console.log(`✅ Successfully cleaned up ${deletedCount} stale branches.`);
+    console.log(`✅ ${DRY_RUN ? 'Would clean up' : 'Successfully cleaned up'} ${deletedCount} stale branch(es).`);
   }
 }
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1542,7 +1542,7 @@ const handler = createMcpHandler(
   {
     serverInfo: {
       name: 'fgac',
-      version: '1.1.0',
+      version: '1.3.0',
     },
   },
   {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -21,8 +21,9 @@ const READ_TOOLS: Array<[string, string]> = [
   ["gmail_labels", "Lists the account's Gmail labels"],
   ["sheets_get_spreadsheet", "Spreadsheet metadata and sheet tabs"],
   ["sheets_read_range", "Reads cell values from a range"],
+  ["docs_read_document", "Reads a Google Doc (optionally trimmed by a field mask)"],
   ["get_my_permissions", "Shows the rules that govern this connection"],
-  ["google_api_get", "Any Gmail/Sheets read endpoint, rule-checked"],
+  ["google_api_get", "Any Gmail/Sheets/Docs read endpoint, rule-checked"],
   ["request_access", "Asks you to approve a specific permission upgrade"],
 ];
 
@@ -30,7 +31,9 @@ const WRITE_TOOLS: Array<[string, string]> = [
   ["gmail_send", "Sends mail — recipients must be on your send whitelist"],
   ["sheets_update_range", "Overwrites cells — needs Read & Write on the sheet"],
   ["sheets_append_rows", "Appends rows — needs Read & Write on the sheet"],
-  ["google_api_modify", "Supported Gmail/Sheets write endpoints, rule-checked"],
+  ["docs_append_text", "Appends text to a doc — needs Read & Write on the doc"],
+  ["docs_replace_text", "Replaces text in a doc — needs Read & Write on the doc"],
+  ["google_api_modify", "Supported Gmail/Sheets/Docs write endpoints, rule-checked"],
 ];
 
 const EXAMPLES: Array<{
@@ -63,6 +66,11 @@ const EXAMPLES: Array<{
     prompt: "Log today's totals as a new row in the tracking sheet.",
     outcome:
       "With Read & Write enabled on that spreadsheet, Claude appends the row and confirms the updated range. If the sheet is read-only, the write is refused with a clear read-only message and no data changes.",
+  },
+  {
+    prompt: "Append today's meeting notes to my running notes doc.",
+    outcome:
+      "Google Docs work like Sheets: expose a document in the picker, and with Read & Write enabled Claude appends the notes and confirms. Documents you haven't exposed are denied by default, and a denial includes a one-click approval link so granting access takes seconds.",
   },
 ];
 
@@ -118,9 +126,9 @@ export default function DocsPage() {
           </h1>
           <p className="mx-auto max-w-[620px] text-[17px] leading-relaxed text-muted-foreground">
             FGAC.ai is a permission layer between AI agents and your Google
-            account. Agents connect once over MCP; every Gmail and Sheets
-            request they make is checked against rules you control — deny by
-            default, allow on your terms.
+            account. Agents connect once over MCP; every Gmail, Sheets, and
+            Docs request they make is checked against rules you control — deny
+            by default, allow on your terms.
           </p>
           <p className="mt-5 text-sm text-muted-foreground">
             Not connected yet?{" "}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -253,10 +253,10 @@ export default function DocsPage() {
 
           <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
             {[
-              ["Gmail and Google Sheets only.", "Other Google services (Drive, Calendar, Docs) are denied — support arrives service by service, each behind its own rules."],
+              ["Gmail, Google Sheets, and Google Docs only.", "Other Google services (Calendar, Slides, full Drive browsing) are denied — support arrives service by service, each behind its own rules."],
               ["Agents can never delete.", "No tool exposes DELETE. Trash, empty-trash, and destructive Gmail settings are refused regardless of your rules."],
               ["Sending requires a whitelist.", "With no send-whitelist rule configured, all outbound mail is refused. That's the default. When a send is denied, you get a one-click, single-use link to approve exactly that recipient — or the agent can ask via request_access."],
-              ["New connections start read-only.", "Connecting attaches the agent to your Default Profile: it can read this account's mail — plus any inbox its owner has delegated to you — and nothing else: no sending, no Sheets, no undelegated inboxes. You can review, re-scope, or block it from the dashboard at any time."],
+              ["New connections start read-only.", "Connecting attaches the agent to your Default Profile: it can read this account's mail — plus any inbox its owner has delegated to you — and nothing else: no sending, no Sheets or Docs, no undelegated inboxes. You can review, re-scope, or block it from the dashboard at any time."],
               ["Attachments cap at ~150 KB", "through MCP responses. Larger files must be fetched from Gmail directly."],
               ["Delegated inboxes need an explicit delegation", "created by the inbox owner from their own FGAC account, revocable any time. Once granted, the inbox attaches to your Default Profile automatically."],
             ].map(([lead, rest]) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -229,9 +229,10 @@ export default async function LandingPage() {
               How we use Google Data
             </h2>
             <p className="mx-auto max-w-[720px] text-[15px] leading-[1.65] text-muted-foreground">
-              FGAC.ai requests Gmail and Sheets scopes to act as a secure proxy
-              between Google and your AI agents. Every request is checked against
-              your rules before it is forwarded — verbatim — to Google.
+              FGAC.ai requests Gmail and per-file Drive scopes — covering Sheets
+              and Docs — to act as a secure proxy between Google and your AI
+              agents. Every request is checked against your rules before it is
+              forwarded — verbatim — to Google.
             </p>
           </div>
           <div className="grid gap-5 md:grid-cols-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,20 +24,25 @@ export default async function LandingPage() {
             </span>
             <span className="inline-flex items-center gap-1.5 rounded-full border border-sheets-border bg-sheets-bg px-3 py-1 text-[13px] font-semibold text-sheets">
               <span className="h-[7px] w-[7px] rounded-full bg-sheets" />
-              Google Sheets — new
+              Google Sheets
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-docs-border bg-docs-bg px-3 py-1 text-[13px] font-semibold text-docs">
+              <span className="h-[7px] w-[7px] rounded-full bg-docs" />
+              Google Docs — new
             </span>
           </div>
 
           <h1 className="text-[40px] font-extrabold leading-[1.05] tracking-[-0.03em] text-foreground sm:text-[60px]">
             Your agents can work your{' '}
-            <span className="text-primary">Sheets and Gmail.</span>
+            <span className="text-primary">Docs, Sheets and Gmail.</span>
             <br />
             You hold the keys.
           </h1>
 
           <p className="mx-auto max-w-[640px] text-[17px] leading-[1.55] text-muted-foreground sm:text-[19px]">
-            Read and write Google Sheets. Send email from Gmail — even across
-            multiple accounts. Every request passes through your rules first.
+            Read and write Google Sheets and Docs. Send email from Gmail — even
+            across multiple accounts. Every request passes through your rules
+            first.
           </p>
 
           <div className="flex flex-col gap-3 pt-1 sm:flex-row sm:justify-center">

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -234,11 +234,11 @@ export default function SetupPage() {
           <div className="overflow-hidden rounded-lg border border-border bg-card">
             <div className="flex items-start gap-3.5 border-b border-border px-6 py-5">
               <span className="mt-px shrink-0 rounded-full border border-sheets-border bg-sheets-bg px-2.5 py-0.5 text-xs font-bold text-sheets">
-                Sheets
+                Sheets &amp; Docs
               </span>
               <div>
                 <strong className="text-sm text-foreground">
-                  Expose spreadsheets with the Google Picker
+                  Expose spreadsheets and documents with the Google Picker
                 </strong>
                 <p className="mt-0.5 text-[13px] leading-relaxed text-muted-foreground">
                   Click <strong>+ Expose a sheet</strong> on a profile and pick

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -57,6 +57,10 @@ export default function SetupPage() {
               <span className="h-[7px] w-[7px] rounded-full bg-sheets" />
               Google Sheets
             </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-docs-border bg-docs-bg px-3 py-1 text-[13px] font-semibold text-docs">
+              <span className="h-[7px] w-[7px] rounded-full bg-docs" />
+              Google Docs
+            </span>
           </div>
 
           <h1 className="mb-3.5 text-[34px] font-extrabold leading-[1.1] tracking-[-0.03em] text-foreground sm:text-[44px]">


### PR DESCRIPTION
Follow-up to #76: the Google Docs feature is live in production, but the public site still described a Gmail+Sheets-only surface. This updates every listing/directory-adjacent surface in the codebase:

- **`/docs`** — docs tools in the tool reference (read + write tables), raw-tool descriptions name the Docs API, intro prose, and a new example prompt showing docs grant semantics.
- **Landing page** — "Google Docs — new" badge (docs brand tone), headline "Docs, Sheets and Gmail.", subhead updated.
- **Setup page** — picker step covers spreadsheets and documents.
- **MCP `serverInfo` version** 1.1.0 → 1.3.0, matching `mcp-registry-server.json`.

Checked and needing no code change: `public/skills` bundle (no tool enumeration). Outside this repo: the Anthropic portal listing text (pending owner sign-off on `listing_copy.md`) and the optional reviewer-runbook refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
