### PR TITLE
feat(analytics): raw Google API product/action classification + attachment size port + client_name

### DIFF
--- a/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
+++ b/docs/QA_Acceptance_Test/capabilities/10_raw_google_api.md
@@ -34,6 +34,10 @@
   the backstop). With the standard grant, drive.file limits results to
   picked/app-created files. The `$mcp_tool_call` event carries
   `raw_api_passthrough: true` and `raw_api_family: 'drive/v3'`.
+- **Analytics note**: since the raw-api-classification change, EVERY raw call
+  (not just passthroughs) stamps `raw_api_kind` / `raw_api_family` /
+  `raw_api_endpoint` / `raw_api_mutating` — the event-side assertions live in
+  capability 16 A9.
 - **No longer passthrough**: the `documents` family graduated to enforced
   per-document rules when Google Docs support landed — a raw
   `v1/documents/<id>` call must be FGAC-classified (capability 19 A6), never

--- a/docs/QA_Acceptance_Test/capabilities/16_analytics_events.md
+++ b/docs/QA_Acceptance_Test/capabilities/16_analytics_events.md
@@ -37,8 +37,24 @@ attributable to it.
 - **Expected**: Every event carries `response_chars` and `response_kb`
   (monitoring-only — plan google-docs-support v5, D7: no size caps are
   enforced; the props exist so PostHog can measure how often responses exceed
-  MCP clients' tool-result budgets). `gmail_get_attachment` additionally keeps
-  its historical `attachment_chars`/`attachment_kb`.
+  MCP clients' tool-result budgets). `gmail_get_attachment` additionally
+  carries `attachment_chars`/`attachment_kb` on every outcome, including the
+  over-cap ⚠️ failure (first shipped with the raw-api-classification change —
+  earlier docs described these props ahead of the code).
+
+### A9: Raw Google API calls carry product/action classification
+- Inspect `$mcp_tool_call` events where `$mcp_tool_name` is `google_api_get`
+  or `google_api_modify` from this run (capability 10 generates them: a raw
+  Gmail read, a raw Sheets call, and an unknown-family passthrough).
+- **Expected**: every such event carries `raw_api_kind` (one of `sheets`,
+  `sheets_create`, `docs`, `docs_create`, `gmail_read`, `gmail_send`,
+  `passthrough`, `denied`), `raw_api_mutating`, and `raw_api_endpoint` whose
+  value is the HTTP method plus an **id-stripped** path template — it must
+  contain `{id}`/`{range}` placeholders where the call used real identifiers
+  and must NOT contain any actual spreadsheet/message/document id.
+  `raw_api_family` is present on every non-denied event (`gmail`,
+  `spreadsheets`, `documents`, or the passthrough family); denied events
+  carry `denial_code` instead.
 
 ### A1: Canonical tool-call events arrive with tool names
 - Run: `npx tsx scripts/qa-posthog-events.ts --event '$mcp_tool_call' --since <run window> --environment <tier>`

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -29,7 +29,7 @@ keep internal/QA traffic out of the numbers.
 | `sign_up_started` | client (`SignUpCta.tsx`, all sign-up CTAs) | `cta_location`: nav / hero / bottom_cta |
 | `sign_up_completed` | server (Clerk webhook, `user.created`) | `$set.email` |
 | `video_played` | client (`TrackedVideoEmbed.tsx`, all Descript demo embeds) | `video_id`, `video_title`, `page` |
-| `$mcp_tool_call` | server (`/api/mcp`, every tool) | `$mcp_tool_name`, `$mcp_duration_ms`, `$mcp_is_error`, `client_id`, `outcome`, `account_email`, `account_delegated` |
+| `$mcp_tool_call` | server (`/api/mcp`, every tool) | `$mcp_tool_name`, `$mcp_duration_ms`, `$mcp_is_error`, `client_id`, `client_name`, `outcome`, `account_email`, `account_delegated`; raw tools add `raw_api_kind`, `raw_api_family`, `raw_api_endpoint`, `raw_api_mutating` |
 | `proxy_request` | server (`/api/proxy/[...path]`) | `service` (gmail/sheets/drive), `method`, `status`, `outcome`, `duration_ms`, `proxy_key_id`, `account_email`, `account_delegated` |
 | `mcp_connection_created` | server (`/api/mcp` auth layer) | `connection_id`, `client_id`, `auto_attached`, `account_age_seconds` |
 | `delegation_created` | server (dashboard action) | `delegate_email`, `reactivated` |
@@ -90,9 +90,35 @@ fraction of successful reads exceed ~25k tokens' worth of chars for
 `client_name`-identified Claude Code connections, and do those calls
 correlate with abandoned tool sequences? If material, per-kind caps with
 recovery guidance get built (Phase 6 of the plan) with thresholds calibrated
-from this distribution. `gmail_get_attachment` keeps its historical
-`attachment_chars`/`attachment_kb` alongside the generic props; its
-pre-existing 200k-char cap is unchanged.
+from this distribution. `gmail_get_attachment` additionally carries
+`attachment_chars`/`attachment_kb` on EVERY outcome — including the over-cap
+⚠️ failure, where the generic props only see the short refusal message, so
+these are the only record of the actual size that triggered the cap. (These
+two props were documented ahead of the code: the original commit `5aa23bd`
+was stranded on an unmerged branch and the props first ship with the
+raw-api-classification change, 2026-08-21.) The pre-existing 200k-char cap
+is unchanged.
+
+**Raw Google API classification (raw-api-classification plan):** every
+`google_api_get` / `google_api_modify` call stamps four props at
+classification time, denials included — `raw_api_kind` (the
+`classifyGoogleApiCall` result: `sheets`, `sheets_create`, `docs`,
+`docs_create`, `gmail_read`, `gmail_send`, `passthrough`, `denied`),
+`raw_api_family` (Google product: `gmail`, `spreadsheets`, `documents`, or
+the classifier's first-two-segments family for passthroughs; omitted on
+denials, which carry `denial_code`), `raw_api_endpoint` (the HTTP method plus
+the **id-stripped** path template from `templateGoogleApiPath`, e.g.
+`GET gmail/v1/users/me/messages/{id}` — identifiers are customer data and
+high-cardinality, so they never land on events), and `raw_api_mutating`.
+Passthrough calls additionally keep `raw_api_passthrough: true`. Raw paths
+were never captured before this change, so there is no backfill — coverage
+starts at the deploy.
+
+**`client_name` caveat:** the MCP auto-attach path stores
+`client_name = client_id` (opaque), so meaningful values currently arrive
+only from `cli-token` registrations. Capturing the DCR `client_name`
+metadata at OAuth registration is the follow-up that makes the
+per-product split (Cowork / Claude Code / Claude.ai) real.
 
 **`connector_install_started` is a rate metric, not an identity metric.** It
 fires anonymously (distinct_id `anonymous-mcp`) from the only FGAC-owned

--- a/docs/implementation_plans/raw-api-classification_v1.md
+++ b/docs/implementation_plans/raw-api-classification_v1.md
@@ -1,0 +1,104 @@
+# Raw Google API Classification + Attachment Instrumentation Port — v1
+
+Branch: `claude/raw-api-classification` (off main `0cb5c58`)
+
+## Motivation (from 2026-08-20 analytics review)
+
+1. **Raw API is the highest-volume tool surface (933 calls/7d) and 99.9% of it is
+   unclassifiable in analytics.** `classifyGoogleApiCall` already computes the product
+   (`sheets`/`docs`/`gmail_read`/`gmail_send`/`passthrough`/…) on every call, but
+   `executeRawGoogleCall` only stamps analytics props on the `passthrough` (unknown
+   family) and `denied` branches. The recognized branches — nearly all real traffic —
+   stamp nothing, so "what Google product is being used and what action" is unanswerable.
+2. **The attachment-size instrumentation never shipped.** Commit `5aa23bd`
+   (`attachment_chars`/`attachment_kb` on every `gmail_get_attachment` outcome) lives
+   only on the dangling branch `claude/fgac-mcp-attachment-debug-3f9974` and was never
+   merged. Meanwhile the docs-branch merge generalized the idea into universal
+   `response_chars`/`response_kb` — but `docs/analytics.md` and QA capability 16 already
+   document the attachment props as live, so docs assert props the code doesn't emit.
+   The universal props also do NOT cover the size-cap failure path: the ⚠️ over-cap
+   return is a ~120-char message, losing the actual attachment size that triggered it.
+3. **`client_name` is stored on `agent_connections` but never reaches events**, so the
+   per-product split (Cowork / Claude Code / Claude.ai) stays unmeasurable.
+
+## Changes
+
+### A. Raw API product/action classification (route.ts + googleApiPolicy.ts)
+
+- **`googleApiPolicy.ts`**: add pure `templateGoogleApiPath(rawPath: string): string` —
+  returns the path with identifier segments replaced by placeholders, safe to stamp as a
+  low-cardinality, PII-free analytics property. Rules:
+  - strip leading slashes, query string, and fragment (same normalization as
+    `classifyGoogleApiCall`);
+  - a segment directly following one of the ID-parent resources
+    (`spreadsheets`, `documents`, `messages`, `threads`, `drafts`, `labels`,
+    `attachments`, `files`, `calendars`, `events`, `tasklists`, `tasks`, `contacts`)
+    becomes `{id}`; following `values` it becomes `{range}`;
+  - a `:verb` suffix on a replaced segment is preserved (`values/Sheet1:append` →
+    `values/{range}:append`);
+  - fallback heuristic for unknown families: any segment ≥ 25 chars, or ≥ 10 chars
+    containing a digit, becomes `{id}` (versions like `v4` and words like `me` survive).
+- **`route.ts` `executeRawGoogleCall`**: immediately after classification, stamp on
+  EVERY raw call (including denied):
+  - `raw_api_kind`: `cls.kind`
+  - `raw_api_family`: `'spreadsheets'` for sheets kinds, `'documents'` for docs kinds,
+    `'gmail'` for gmail kinds, `cls.family` for passthrough, omitted for denied
+    (`denial_code` already identifies those)
+  - `raw_api_endpoint`: `` `${method} ${templateGoogleApiPath(path)}` ``
+  - `raw_api_mutating`: `method !== 'GET'`
+  - the passthrough branch keeps `raw_api_passthrough: true` and drops its now-redundant
+    `raw_api_family` stamp.
+- No backfill is possible (raw paths were never captured — correct, they can contain
+  ids); coverage starts at deploy.
+
+### B. Port `5aa23bd` — attachment size on every outcome
+
+In the `gmail_get_attachment` handler: compute `attachmentChars`/`approxKb` once,
+`addToolCallProps({ attachment_chars, attachment_kb })` BEFORE the size-cap check, so
+the props ride on success, over-cap ⚠️ failures, and (via the shared props context)
+any later outcome. This matches what `docs/analytics.md:94` and QA capability 16
+already claim exists. After merge, delete the stranded
+`claude/fgac-mcp-attachment-debug-3f9974` branch.
+
+### C. `client_name` on `$mcp_tool_call`
+
+`ConnectionApproved` gains `clientName: string | null` (from
+`agent_connections.client_name`); `requireApproval` stamps
+`addToolCallProps({ client_name })` on success. Known limitation, documented rather than
+solved here: the MCP auto-attach path stores `clientName = clientId` (opaque), so
+meaningful names currently arrive only via `cli-token` registrations. Capturing the DCR
+`client_name` metadata at OAuth registration is a separate follow-up; this change makes
+the pipe exist so events light up as soon as storage improves.
+
+## Tests
+
+Extend `scripts/test-google-api-policy.ts` with `templateGoogleApiPath` cases: gmail
+message/attachment ids, sheets values range with `:append` verb, docs, drive files,
+calendar events, id-less list paths, query strings, %-encoded segments, and a
+no-placeholder identity case (`gmail/v1/users/me/labels` — `me` follows `users`, which
+is not an ID parent... note: `users` IS followed by `me`; keep `me` literal via
+explicit allowlist `me` before parent-rule placeholder).
+
+## Docs
+
+- `docs/analytics.md`: document `raw_api_kind` / `raw_api_family` / `raw_api_endpoint` /
+  `raw_api_mutating` / `client_name`; correct the attachment-props paragraph to note the
+  props ship with THIS change (they were documented ahead of code).
+- QA capability 16 (`16_analytics_events.md`): add an assertion that raw
+  `google_api_get`/`google_api_modify` calls carry the four `raw_api_*` props with an
+  id-stripped endpoint.
+- QA capability 10 (`10_raw_google_api.md`): prose note pointing at capability 16 for
+  the analytics expectations (no new assertion here to keep runbook scope stable).
+
+## Validation
+
+1. `npx tsx scripts/test-google-api-policy.ts` (all existing + new cases green).
+2. `npm run lint` + production build type-check.
+3. `/deploy-pr-preview` → preview URL.
+4. Scoped QA: `qa-env-runner` limited to raw Google API (capability 10) + analytics
+   events (capability 16) against the preview deployment — exercise `google_api_get`
+   (gmail + sheets + unknown-family path), `google_api_modify`, and
+   `gmail_get_attachment`, then verify via `scripts/qa-posthog-events.ts` that the new
+   props (`raw_api_*`, `attachment_chars`/`attachment_kb`, `client_name`) arrive on
+   `$mcp_tool_call` events in the preview environment tier.
+5. `npx tsx scripts/qa-coverage-check.ts` for the touched capabilities.

--- a/scripts/test-google-api-policy.ts
+++ b/scripts/test-google-api-policy.ts
@@ -5,6 +5,7 @@
 import {
   classifyGoogleApiCall, extractSendRecipients, collectLabelIds,
   sheetsApprovalAction, docsApprovalAction, extractDocsDocumentId,
+  templateGoogleApiPath, rawApiFamily,
 } from '../src/app/api/mcp/googleApiPolicy';
 
 let failures = 0;
@@ -154,6 +155,64 @@ expect('blocked mints nothing (write)',
 expect('documentId carried through',
   docsApprovalAction('not_exposed', 'doc-42', true),
   (a: { documentId?: string } | null) => a?.documentId === 'doc-42');
+
+console.log('templateGoogleApiPath:');
+expect('gmail message id → {id}',
+  templateGoogleApiPath('gmail/v1/users/me/messages/18c8f2ab91d004a7'),
+  (t: string) => t === 'gmail/v1/users/me/messages/{id}');
+expect('gmail list (no id) unchanged, query stripped',
+  templateGoogleApiPath('gmail/v1/users/me/messages?maxResults=5&q=foo'),
+  (t: string) => t === 'gmail/v1/users/me/messages');
+expect('gmail attachment id → {id} (both parents)',
+  templateGoogleApiPath('/gmail/v1/users/me/messages/18c8f2ab91/attachments/ANGjdJ8w9TfWQzvvMbwFxyz'),
+  (t: string) => t === 'gmail/v1/users/me/messages/{id}/attachments/{id}');
+expect('gmail user email → {id} (email heuristic)',
+  templateGoogleApiPath('gmail/v1/users/someone@example.com/labels'),
+  (t: string) => t === 'gmail/v1/users/{id}/labels');
+expect('sheets values range with verb → {range}:append',
+  templateGoogleApiPath('v4/spreadsheets/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms/values/Sheet1!A1:B2:append'),
+  (t: string) => t === 'v4/spreadsheets/{id}/values/{range}:append');
+expect('sheets column-only range (A:B) fully replaced',
+  templateGoogleApiPath('v4/spreadsheets/1BxiM/values/A:B'),
+  (t: string) => t === 'v4/spreadsheets/{id}/values/{range}');
+expect('sheets %-encoded range → {range}',
+  templateGoogleApiPath('v4/spreadsheets/1BxiM/values/Sheet1%21A1%3AB5'),
+  (t: string) => t === 'v4/spreadsheets/{id}/values/{range}');
+expect('docs batchUpdate keeps verb',
+  templateGoogleApiPath('v1/documents/1a2B3c4D5e6F:batchUpdate'),
+  (t: string) => t === 'v1/documents/{id}:batchUpdate');
+expect('drive file id → {id}',
+  templateGoogleApiPath('drive/v3/files/1a2B3c4D5e6F7g8H'),
+  (t: string) => t === 'drive/v3/files/{id}');
+expect('calendar event under named calendar → {id}s',
+  templateGoogleApiPath('calendar/v3/calendars/primary/events/abc123def456'),
+  (t: string) => t === 'calendar/v3/calendars/{id}/events/{id}');
+expect('short literal segments survive (me, v4, about)',
+  templateGoogleApiPath('drive/v3/about'),
+  (t: string) => t === 'drive/v3/about');
+
+console.log('rawApiFamily:');
+expect('sheets kind → spreadsheets',
+  rawApiFamily(classifyGoogleApiCall('v4/spreadsheets/1BxiM/values/A1', 'GET')),
+  (f: string | null) => f === 'spreadsheets');
+expect('sheets_create → spreadsheets',
+  rawApiFamily(classifyGoogleApiCall('v4/spreadsheets', 'POST')),
+  (f: string | null) => f === 'spreadsheets');
+expect('docs kind → documents',
+  rawApiFamily(classifyGoogleApiCall('v1/documents/d1', 'GET')),
+  (f: string | null) => f === 'documents');
+expect('gmail read → gmail',
+  rawApiFamily(classifyGoogleApiCall('gmail/v1/users/me/messages', 'GET')),
+  (f: string | null) => f === 'gmail');
+expect('gmail send → gmail',
+  rawApiFamily(classifyGoogleApiCall('gmail/v1/users/me/messages/send', 'POST')),
+  (f: string | null) => f === 'gmail');
+expect('passthrough carries classifier family',
+  rawApiFamily(classifyGoogleApiCall('calendar/v3/calendars/primary/events', 'GET')),
+  (f: string | null) => f === 'calendar/v3');
+expect('denied → null',
+  rawApiFamily(classifyGoogleApiCall('batch/gmail/v1', 'POST')),
+  (f: string | null) => f === null);
 
 if (failures > 0) {
   console.error(`\n${failures} test(s) FAILED`);

--- a/src/app/api/mcp/googleApiPolicy.ts
+++ b/src/app/api/mcp/googleApiPolicy.ts
@@ -95,6 +95,71 @@ export function classifyGoogleApiCall(rawPath: string, method: string): RawCallC
   return { kind: 'passthrough', family: segments.slice(0, 2).join('/') || 'unknown', isMutating };
 }
 
+// Resource collections whose next path segment is a caller-supplied
+// identifier (message id, spreadsheet id, file id, …).
+const ID_PARENT_SEGMENTS = new Set([
+  'spreadsheets', 'documents', 'messages', 'threads', 'drafts', 'labels',
+  'attachments', 'files', 'calendars', 'events', 'tasklists', 'tasks', 'contacts',
+]);
+
+/**
+ * Id-strip a raw Google API path into a low-cardinality endpoint template for
+ * analytics (`raw_api_endpoint`), e.g.
+ * `gmail/v1/users/me/messages/18c8f2ab91` → `gmail/v1/users/me/messages/{id}`,
+ * `v4/spreadsheets/1BxiM…/values/Sheet1!A1:B2:append` →
+ * `v4/spreadsheets/{id}/values/{range}:append`.
+ * Identifiers can be customer data (and explode GROUP BY cardinality), so they
+ * must never land on events; API-surface verbs (`:append`, `:batchUpdate`)
+ * are kept because they carry the action semantics.
+ */
+export function templateGoogleApiPath(rawPath: string): string {
+  const path = rawPath.replace(/^\/+/, '').split(/[?#]/)[0];
+  const segments = path.split('/').filter(Boolean);
+  return segments.map((seg, i) => {
+    // A trailing `:verb` (letters only, ≥4 chars) is API surface, not data —
+    // the length floor keeps range colons like `A:B` from parsing as verbs.
+    const verbMatch = seg.match(/^(.*?):([A-Za-z]{4,})$/);
+    const base = verbMatch ? verbMatch[1] : seg;
+    const verb = verbMatch ? `:${verbMatch[2]}` : '';
+    const prev = i > 0 ? segments[i - 1].toLowerCase().replace(/:.*$/, '') : '';
+    let decoded = base;
+    try { decoded = decodeURIComponent(base); } catch { /* keep raw */ }
+
+    if (prev === 'values') return `{range}${verb}`;
+    if (ID_PARENT_SEGMENTS.has(prev)) return `{id}${verb}`;
+    // Fallback for families without a known parent: long or digit-bearing
+    // segments and anything email-shaped are identifiers.
+    if (decoded.length >= 25 || (decoded.length >= 10 && /\d/.test(decoded)) || decoded.includes('@')) {
+      return `{id}${verb}`;
+    }
+    return seg;
+  }).join('/');
+}
+
+/**
+ * The Google product family a classified raw call belongs to, stamped as
+ * `raw_api_family`. Known kinds map to their product; passthrough keeps the
+ * family the classifier derived from the path; denials return null (their
+ * `denial_code` already identifies them).
+ */
+export function rawApiFamily(cls: RawCallClass): string | null {
+  switch (cls.kind) {
+    case 'sheets':
+    case 'sheets_create':
+      return 'spreadsheets';
+    case 'docs':
+    case 'docs_create':
+      return 'documents';
+    case 'gmail_read':
+    case 'gmail_send':
+      return 'gmail';
+    case 'passthrough':
+      return cls.family;
+    case 'denied':
+      return null;
+  }
+}
+
 /**
  * Extract all recipient addresses (To/Cc/Bcc) from a Gmail messages/send
  * request body ({ raw: <base64url RFC 2822 message> }).

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -34,6 +34,7 @@ import { mintApprovalLink, approvalLinkMinutes, type ApprovalAction } from '@/li
 import { TOOL_DEFS, toolAnnotations, type FgacToolDef } from './toolDefs';
 import {
   classifyGoogleApiCall, extractSendRecipients, sheetsApprovalAction, docsApprovalAction,
+  templateGoogleApiPath, rawApiFamily,
 } from './googleApiPolicy';
 import { DRIVE_FILE_KINDS, type DriveFileKind } from '@/lib/driveFileKinds';
 
@@ -58,6 +59,7 @@ interface ConnectionApproved {
   connectionId: string;
   proxyKeyId: string | null;
   nickname: string | null;
+  clientName: string | null;
   user: { id: string; email: string; clerkUserId: string };
 }
 
@@ -188,6 +190,7 @@ async function resolveConnection(userId: string, clientId: string | undefined): 
     connectionId: connection.id,
     proxyKeyId: connection.proxyKeyId,
     nickname: connection.nickname,
+    clientName: connection.clientName,
     user: { id: user.id, email: user.email, clerkUserId: user.clerkUserId },
   };
 }
@@ -724,6 +727,10 @@ async function requireApproval(authInfo: AuthInfo | undefined): Promise<Connecti
   if (!result.authorized) {
     return textResult(pendingMessage(result));
   }
+  // Client-product attribution: today clientName is usually the opaque DCR
+  // client_id (only cli-token registrations send a real name), but stamping
+  // it means events light up as soon as DCR name capture improves.
+  if (result.clientName) addToolCallProps({ client_name: result.clientName });
   return result;
 }
 
@@ -853,6 +860,17 @@ async function executeRawGoogleCall(
   body?: string | Record<string, unknown>,
 ) {
   const cls = classifyGoogleApiCall(path, method);
+  // Product/action observability: raw calls are the highest-volume tool
+  // surface, and the classifier already knows the product — stamp it on
+  // every call (denials included) so analytics can break raw usage down by
+  // Google product and id-stripped endpoint, not just "google_api_get".
+  const family = rawApiFamily(cls);
+  addToolCallProps({
+    raw_api_kind: cls.kind,
+    raw_api_endpoint: `${method} ${templateGoogleApiPath(path)}`,
+    raw_api_mutating: method !== 'GET',
+    ...(family ? { raw_api_family: family } : {}),
+  });
   if (cls.kind === 'denied') {
     addToolCallProps({ denial_code: cls.code });
     return textResult(cls.reason);
@@ -944,8 +962,9 @@ async function executeRawGoogleCall(
   if (cls.kind === 'passthrough') {
     // Classify-don't-block: unknown Google API families are forwarded with
     // the account's token (Google's scopes are the enforcement backstop) and
-    // tagged so demand is visible in analytics before we build rules for it.
-    addToolCallProps({ raw_api_family: cls.family, raw_api_passthrough: true });
+    // flagged so demand is visible in analytics before we build rules for it
+    // (family/kind/endpoint were already stamped at classification above).
+    addToolCallProps({ raw_api_passthrough: true });
     const result = await googleFetch(rawUrl(cleanPath), resolved.token, method, serializeBody(body), resolved.targetEmail);
     if (!result.ok) return errorResult(result.error);
     return jsonResult(result.data);
@@ -1142,8 +1161,14 @@ const handler = createMcpHandler(
         if (!attachmentResult.ok) return errorResult(attachmentResult.error);
 
         const attachment = attachmentResult.data as { size?: number; data?: string };
-        if (attachment.data && attachment.data.length > MAX_ATTACHMENT_CHARS) {
-          const approxKb = Math.round((attachment.data.length * 3) / 4 / 1024);
+        // Size on EVERY outcome (port of 5aa23bd): the generic response_chars
+        // only sees the short ⚠️ message on over-cap failures, so the true
+        // attachment size must be stamped before the cap check or analytics
+        // can't tell a 200 KB refusal from a 2 MB one.
+        const attachmentChars = attachment.data?.length ?? 0;
+        const approxKb = Math.round((attachmentChars * 3) / 4 / 1024);
+        addToolCallProps({ attachment_chars: attachmentChars, attachment_kb: approxKb });
+        if (attachmentChars > MAX_ATTACHMENT_CHARS) {
           return textResult(`⚠️ Attachment is ~${approxKb} KB, which exceeds the ~150 KB limit for MCP responses. Ask the user to retrieve it directly from Gmail.`);
         }
         return jsonResult(attachment);


### PR DESCRIPTION
## Summary

- **Raw API classification**: every `google_api_get`/`google_api_modify` call now stamps `raw_api_kind`, `raw_api_family`, `raw_api_endpoint` (id-stripped template via new pure `templateGoogleApiPath`), and `raw_api_mutating` on `$mcp_tool_call` — previously only unknown-family passthroughs were tagged, leaving ~99.9% of the highest-volume tool surface unclassifiable by product/action.
- **Port of stranded 5aa23bd**: `attachment_chars`/`attachment_kb` on every `gmail_get_attachment` outcome (the original commit never merged; docs/QA already described these props as live). Stamped before the over-cap check so the ⚠️ path records the true size.
- **`client_name` on tool calls**: stamped from `agent_connections.client_name` (mostly opaque client_id today; pipe exists for when DCR name capture lands).
- Docs: `docs/analytics.md` updated; QA capability 16 gains **A9** (raw-call classification props, id-stripped endpoint), capability 10 cross-references it.
- Tests: 18 new cases in `scripts/test-google-api-policy.ts` (runs in `npm run mcp:lint`).

No schema, env, or behavioral changes — analytics stamping only. No backfill possible (raw paths were never captured; ids stay off events by design).

## Validation
- Unit tests green (33 policy cases), eslint clean on touched files, `tsc --noEmit` clean.
- Preview: scoped QA on capabilities 10 + 16 (analytics events) to verify the new props arrive in PostHog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)